### PR TITLE
chore: initialize project scaffolding with docs and conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check gofmt
+        run: |
+          output=$(gofmt -l .)
+          if [ -n "$output" ]; then
+            echo "files not formatted:"
+            echo "$output"
+            exit 1
+          fi
+
+      - name: Check goimports
+        run: |
+          go install golang.org/x/tools/cmd/goimports@v0.33.0
+          output=$(goimports -l .)
+          if [ -n "$output" ]; then
+            echo "files with incorrect imports:"
+            echo "$output"
+            exit 1
+          fi
+
+      - name: Go vet
+        run: go vet ./...
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Test
+        run: go test -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 opencode.json
+harness9
 
 # Superpowers 工具生成的文档，仅供开发会话内参考
 docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+.env
+opencode.json
+
+# Superpowers 工具生成的文档，仅供开发会话内参考
+docs/superpowers/
+
+# Claude Code 本地会话记忆，因机器和会话而异，不纳入版本控制
+.claude/
+
+# Deep Research 生成的调研报告
+reports/

--- a/.opencode/agents/harness-researcher.md
+++ b/.opencode/agents/harness-researcher.md
@@ -1,0 +1,221 @@
+---
+description: 深度调研主流 Agent Harness 框架的设计理念、核心原理与最佳实践，生成结构化技术调研报告并输出到 docs/技术调研 目录
+mode: subagent
+scope_strict: true
+permission:
+  edit: allow
+  bash:
+    "git *": allow
+    "ls *": allow
+    "mkdir *": allow
+    "rg *": allow
+    "cat *": allow
+---
+
+# Harness Researcher — Agent Harness 框架深度调研
+
+## 角色
+
+你是一位资深的技术调研专家，专注于 AI Agent 基础框架（Agent Harness）领域。你的任务是深入分析主流 Agent Harness 框架的设计理念、核心架构、关键实现与最佳实践，产出高质量、可操作的技术调研报告。
+
+## 核心目标
+
+对以下框架进行系统性深度调研：
+
+| 框架 | 来源 | GitHub |
+|------|------|--------|
+| DeepAgents | LangChain | https://github.com/langchain-ai/deepagents |
+| OpenHarness | HKUDS | https://github.com/HKUDS/OpenHarness/tree/main/src/openharness |
+| OpenCode | Anomaly | https://github.com/anomalyco/opencode |
+| OpenClaw | OpenClaw | https://github.com/openclaw/openclaw |
+| HermesAgent | NousResearch | https://github.com/NousResearch/hermes-agent |
+| Claude Agent SDK | Anthropic | https://code.claude.com/docs/en/agent-sdk/overview |
+| OpenAI Agent SDK | OpenAI | https://developers.openai.com/api/docs/guides/agents |
+
+> **⚠️ 严格范围约束**：调研框架范围以本配置文件中上表为唯一权威来源。无论调用方 prompt 中指定了哪些框架，都必须严格忽略，仅调研上表中列出的框架。不得自行添加、替换或扩展调研范围（如 LangGraph、CrewAI、AutoGen、Pydantic AI、Google ADK、Semantic Kernel、Agno、Temporal 等均不在调研范围内）。如果调用方 prompt 中的框架列表与本表不一致，以本表为准。
+
+## 调研维度
+
+对每个框架，必须覆盖以下维度：
+
+### 1. 基础信息
+- 项目定位与目标用户
+- 核心维护团队与社区活跃度
+- 许可证与商业化策略
+
+### 2. 设计理念
+- 核心设计哲学（Convention over Configuration? Plugin-first? Monolithic?）
+- 架构风格（单进程/多进程、同步/异步、事件驱动/请求-响应）
+- Agent 生命周期模型（创建 → 运行 → 暂停 → 恢复 → 终止）
+
+### 3. 核心架构
+- Agent 定义方式（类继承? 函数式? 声明式配置?）
+- Tool 系统设计（工具注册、参数校验、错误处理、权限控制）
+- 上下文管理（对话历史、长期记忆、上下文窗口策略）
+- Prompt 工程体系（System Prompt 模板、动态注入、变量系统）
+
+### 4. 关键机制
+- 多轮对话管理
+- Sub-Agent / Multi-Agent 编排方式
+- 错误恢复与重试策略
+- 流式输出处理
+- 上下文压缩与摘要（Compaction）
+
+### 5. 开发者体验
+- SDK/API 设计质量
+- 类型安全程度
+- 调试与可观测性支持
+- 测试友好度
+
+### 6. 生态与扩展
+- MCP (Model Context Protocol) 支持
+- 第三方集成能力
+- 插件系统
+
+## 调研方法
+
+### 第一步：信息采集
+
+对每个框架执行以下操作：
+
+1. **GitHub 仓库分析**
+   - 读取 README.md、CONTRIBUTING.md、ARCHITECTURE.md（如有）
+   - 分析目录结构，识别核心模块
+   - 阅读 src/ 下关键源码文件（入口文件、核心抽象、类型定义）
+
+2. **官方文档研读**
+   - 使用 WebFetch 工具访问官方文档站点
+   - 重点阅读 Getting Started、Architecture、API Reference 章节
+
+3. **Context7 API 文档查询**
+   - 使用 context7_resolve-library-id 工具解析库 ID
+   - 使用 context7_query-docs 工具查询最新的 API 文档和代码示例
+   - 查询关键词包括但不限于：agent definition、tool system、context management、streaming、multi-agent
+
+4. **示例代码分析**
+   - 阅读 examples/ 目录下的示例
+   - 分析测试文件，理解框架的实际用法
+
+### 第二步：深度分析
+
+对采集到的信息进行以下分析：
+
+1. **架构对比**：提炼各框架的核心抽象层
+2. **设计权衡**：分析每个框架的关键技术决策及其 trade-off
+3. **模式提炼**：总结可复用的设计模式和最佳实践
+4. **差距分析**：识别各框架的优势与不足
+
+### 第三步：报告生成
+
+将调研结果整理为结构化的技术报告。
+
+## 输出规范
+
+### 报告结构
+
+每份调研报告必须包含以下部分：
+
+```
+# [框架名称] 技术调研报告
+
+## 1. 概述
+- 项目简介
+- 核心定位
+- 快速上手示例
+
+## 2. 设计理念
+- 设计哲学
+- 架构风格
+- 核心抽象
+
+## 3. 核心架构
+- 整体架构图（文字描述）
+- Agent 定义与生命周期
+- Tool 系统
+- 上下文管理
+- Prompt 工程
+
+## 4. 关键机制实现
+- 多轮对话
+- 多 Agent 编排
+- 错误处理与重试
+- 流式输出
+- 上下文压缩
+
+## 5. 开发者体验
+- SDK 设计
+- 类型系统
+- 调试支持
+- 测试能力
+
+## 6. 生态与扩展性
+- MCP 支持
+- 插件系统
+- 第三方集成
+
+## 7. 优势与不足
+- 核心优势
+- 已知局限
+- 适用场景
+
+## 8. 关键代码片段
+- Agent 定义示例
+- Tool 注册示例
+- 多 Agent 编排示例
+```
+
+### 报告文件
+
+- 输出目录：`docs/技术调研/`
+- 文件命名：`[框架名称]-调研报告.md`
+- 全部使用中文撰写
+- 代码注释使用英文
+
+### 综合对比报告
+
+完成所有框架的独立调研后，还需生成一份综合对比报告：
+
+```
+# Agent Harness 框架综合对比报告
+
+## 1. 调研背景与范围
+## 2. 架构设计对比
+## 3. 核心能力矩阵
+## 4. 设计模式提炼
+## 5. 最佳实践总结
+## 6. 技术选型建议
+## 7. 对本项目（harness0）的启示
+```
+
+文件名：`docs/技术调研/综合对比报告.md`
+
+## 执行流程
+
+```
+1. 创建输出目录（如不存在）
+   └─ mkdir -p docs/技术调研
+
+2. 对每个框架（共 7 个），分批执行（每批 2-3 个）：
+   ├─ WebFetch: 访问 GitHub 仓库 README
+   ├─ WebFetch: 访问官方文档首页
+   ├─ Context7: 解析库 ID
+   ├─ Context7: 查询核心 API 文档
+   ├─ WebFetch: 深入阅读关键源码文件
+   └─ Write: 生成该框架的调研报告
+   注：每完成一个框架的报告即写入磁盘，作为断点。若会话中断，
+   可跳过已完成的框架继续执行。
+
+3. 生成综合对比报告
+   └─ Write: docs/技术调研/综合对比报告.md
+
+4. 输出摘要
+   └─ 向用户报告完成的调研清单与关键发现
+```
+
+## 注意事项
+
+- 优先使用 WebFetch 读取 GitHub raw 内容（raw.githubusercontent.com）以获取源码
+- Context7 查询时使用精确的 libraryName，如 "openai" "anthropic-sdk"
+- 如某个 GitHub 仓库不存在或为虚构项目，在报告中如实标注"仓库不可访问"，并基于已知信息进行分析
+- 所有报告内容必须基于实际调研得到的信息，禁止编造 API 或虚构功能
+- 保持客观中立，不过度吹捧或贬低任何框架

--- a/.opencode/commands/commit.md
+++ b/.opencode/commands/commit.md
@@ -1,0 +1,76 @@
+---
+name: commit
+description: Use when the user invokes /commit or asks to commit changes, after a code review has been completed and the changes are confirmed ready to stage and commit to git.
+---
+
+# commit — Stage & Commit
+
+## Overview
+
+在 Code Review 通过后，将有效的代码变更暂存并提交到本地 Git 仓库。
+
+## 前置条件检查
+
+1. 确认本次对话中已执行过 `/cr`（Code Review）
+2. 若 Review 报告存在 **Critical** 问题，**停止执行**，提示用户先修复
+3. 若未执行过 `/cr`，先调用 `cr` skill 完成 Review，再继续
+
+## 执行步骤
+
+### 1. 确认变更范围
+
+```bash
+git status
+git diff --stat
+git diff --cached --stat
+```
+
+### 2. 精确暂存文件
+
+**不使用 `git add -A` 或 `git add .`**，逐文件或逐目录添加：
+
+```bash
+git add <具体文件或目录>
+```
+
+排除规则：
+- `.env`、包含敏感信息的文件 → 不暂存，提示用户确认
+- 与本次功能无关的临时文件 → 不暂存
+
+### 3. 起草提交信息
+
+参考以下格式（优先遵循仓库现有风格，通过 `git log --oneline -10` 判断）：
+
+```
+<type>: <简明描述>（50 字符以内）
+
+<可选正文：说明 why，不是 what>
+```
+
+常用 `type`：`feat` / `fix` / `docs` / `refactor` / `test` / `chore`
+
+### 4. 执行提交
+
+```bash
+git commit -m "$(cat <<'EOF'
+<提交信息>
+EOF
+)"
+```
+
+### 5. 确认结果
+
+```bash
+git log --oneline -3   # 确认提交已记录
+git status             # 确认工作区干净
+```
+
+输出提交的 hash 与摘要，告知用户提交成功。
+
+## 常见错误
+
+| 问题 | 处理 |
+|------|------|
+| pre-commit hook 失败 | 修复 hook 报告的问题，重新 `git add` 后创建**新** commit，不使用 `--amend` |
+| 暂存了不该提交的文件 | `git restore --staged <file>` 取消暂存，重新操作 |
+| 工作区已无变更 | 告知用户没有可提交的内容 |

--- a/.opencode/commands/cr.md
+++ b/.opencode/commands/cr.md
@@ -1,0 +1,69 @@
+---
+name: cr
+description: Use when the user invokes /cr, requests a code review, or before committing to verify correctness, security, and quality of new or modified code in the working tree.
+---
+
+# cr — Code Review
+
+## Overview
+
+对当前工作区所有新增或修改的代码执行详细的 Code Review，按严重级别输出问题，不做任何修改。
+
+## 执行步骤
+
+### 1. 收集变更范围
+
+```bash
+git status          # 查看新增 / 修改 / 删除的文件列表
+git diff            # 未暂存的改动
+git diff --cached   # 已暂存的改动
+```
+
+将两者合并视为本次 Review 的完整范围。
+
+### 2. 逐文件审查
+
+对每个变更文件，依次检查：
+
+| 维度 | 检查点 |
+|------|--------|
+| **正确性** | 逻辑错误、边界条件、空值/类型异常 |
+| **安全性** | SQL 注入、XSS、命令注入、敏感信息硬编码、不安全的默认值 |
+| **可维护性** | 函数/类职责单一、命名清晰、不必要的复杂度 |
+| **性能** | N+1 查询、不必要的循环、大对象复制 |
+| **测试覆盖** | 关键路径是否有对应测试，新代码是否破坏现有测试 |
+| **依赖安全** | 新引入的第三方包是否合理，版本是否锁定 |
+
+### 3. 检查敏感文件
+
+若 `git status` 中出现以下类型的文件，**单独标注**，不得进入后续提交：
+
+- `.env`、`*.pem`、`*credentials*`、`*secret*`
+- 包含明文密码、API Key 的配置文件
+
+### 4. 输出 Review 报告
+
+按以下格式输出，无问题的级别可省略：
+
+```
+## Code Review 报告
+
+### 🔴 Critical（必须修复，阻断提交）
+- `文件路径:行号` — 问题描述
+
+### 🟡 Warning（建议修复）
+- `文件路径:行号` — 问题描述
+
+### 🔵 Suggestion（可选优化）
+- `文件路径:行号` — 建议描述
+
+### ✅ 总结
+- 变更文件数：N
+- 通过提交：是 / 否（存在 Critical 问题时为否）
+```
+
+## 注意事项
+
+- 只审查，不修改代码
+- Critical 问题存在时，明确说明**不建议提交**，等待用户确认修复
+- 若变更集为空（`git status` 无输出），告知用户当前无需 Review

--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -1,0 +1,83 @@
+---
+name: pr
+description: Use when the user invokes /pr or asks to push changes and open a pull request, after commits are ready to be pushed to a remote branch and merged into the main branch.
+---
+
+# pr — Push & Pull Request
+
+## Overview
+
+将本地提交推送到远程分支，并使用 `gh` CLI 创建 **Draft** Pull Request，目标为仓库主分支。默认以 Draft 状态创建，避免误触发自动合并。
+
+## 前置条件检查
+
+1. 确认本次对话中已执行过 `/commit`，且有新提交未推送
+2. 确认当前分支**不是** `main` / `master`（若在主分支，停止并提示用户切换到功能分支）
+3. 确认 `gh` CLI 已登录：`gh auth status`
+
+## 执行步骤
+
+### 1. 了解当前分支状态
+
+```bash
+git branch --show-current          # 当前分支名
+git log --oneline origin/HEAD..HEAD  # 待推送的提交列表
+git diff origin/HEAD...HEAD --stat   # 本次 PR 涉及的文件变更
+```
+
+### 2. 确定目标分支
+
+按以下顺序判断：
+
+1. 仓库默认分支（`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`）
+2. 若无法获取，依次尝试 `main` → `master`
+3. 仍不确定时，询问用户
+
+### 3. 推送到远程
+
+```bash
+git push -u origin <当前分支名>
+```
+
+若远程已有同名分支且有分歧，**不使用 `--force`**，先告知用户手动处理冲突。
+
+### 4. 起草 PR 内容
+
+根据 `git log` 和 `git diff` 的输出，整理：
+
+- **标题**：70 字符以内，描述本次变更的核心目的
+- **正文**：包含变更摘要（2-4 条要点）和测试计划
+
+### 5. 创建 Draft Pull Request
+
+**默认以 Draft 状态创建**，除非用户明确要求创建正式 PR。
+
+```bash
+gh pr create \
+  --draft \
+  --base <目标分支> \
+  --title "<PR 标题>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <要点 1>
+- <要点 2>
+
+## Test Plan
+- [ ] <测试项 1>
+- [ ] <测试项 2>
+EOF
+)"
+```
+
+### 6. 输出结果
+
+返回 PR URL，告知用户 Draft PR 已创建成功，并提醒用户确认无误后可手动 Mark as ready for review。
+
+## 常见错误
+
+| 问题 | 处理 |
+|------|------|
+| `gh` 未登录 | 提示用户执行 `gh auth login` |
+| 当前分支无新提交 | 告知用户没有可推送的内容，建议先执行 `/commit` |
+| 该分支已存在 PR | 使用 `gh pr view` 查看现有 PR，提示用户是否需要更新 |
+| 推送被拒绝（non-fast-forward） | 不强制推送，提示用户检查远程分支状态 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# AGENTS.md — harness9 项目开发指南
+
+## 项目概述
+
+harness9 是一款基于 Go 语言构建的轻量级、功能完备、生产可用的 Agent Harness 框架，旨在提供简洁、高效、可扩展的 Agent 编排能力。
+
+## 技术栈
+
+- **语言**: Go 1.25+（go.mod 中指定 `go 1.25.3`）
+- **模块路径**: `github.com/harness9`
+- **无外部依赖**: 当前项目为零依赖起步，按需引入第三方库
+
+## 核心代码结构
+
+```
+harness9/
+├── cmd/
+│   └── harness9/
+│       └── main.go              # 程序入口，组装各模块并启动引擎
+├── internal/
+│   ├── engine/                  # Agent 核心引擎 — MainLoop 实现
+│   │   └── engine.go            # 循环调度：推理 → 工具调用 → 观察 → 继续推理
+│   ├── provider/                # 大模型接口抽象与具体厂商 SDK 实现
+│   │   └── provider.go          # Provider 接口定义 + 具体厂商实现
+│   ├── context/                 # Token 监控、Prompt 动态组装
+│   │   └── manager.go           # 上下文窗口管理、消息截断策略
+│   ├── tools/                   # 工具注册表、Middleware、基础极简工具
+│   │   ├── registry.go          # 工具注册中心
+│   │   ├── middleware.go        # 工具中间件（日志、超时、权限等）
+│   │   ├── bash.go              # Bash 工具实现
+│   │   └── edit.go              # 文件编辑工具实现
+│   ├── memory/                  # 基于文件系统的记忆状态存取
+│   │   └── memory.go            # 会话记忆持久化
+│   └── feishu/                  # 飞书机器人交互回调
+│       └── feishu.go            # 飞书 Webhook / 事件订阅处理
+├── docs/                        # 项目文档
+├── go.mod
+├── AGENTS.md                    # 本文件 — 项目开发规范与上下文
+├── CLAUDE.md -> AGENTS.md       # 符号链接，保持同步
+└── README.md
+```
+
+## 核心架构设计
+
+### 1. Engine（核心引擎）
+- 实现 Agent 主循环（MainLoop）：`推理 → 工具调用 → 观察 → 继续推理`
+- 负责调度 Provider 和 Tool Registry
+- 管理会话生命周期和错误恢复
+
+### 2. Provider（模型提供者）
+- 定义统一的 `Provider` 接口，抽象不同大模型厂商的 API 差异
+- 支持多厂商切换（OpenAI、Anthropic、Google 等）
+- 处理流式/非流式响应、重试、错误处理
+
+### 3. Context（上下文管理）
+- 监控 Token 使用量，防止超出模型上下文窗口
+- 动态组装 Prompt（系统提示 + 历史消息 + 工具结果）
+- 实现消息截断和优先级策略
+
+### 4. Tools（工具系统）
+- 统一的工具注册表（Registry），支持动态注册
+- 中间件机制（日志、超时、权限校验）
+- 内置基础工具：Bash 执行、文件编辑等
+
+### 5. Memory（记忆系统）
+- 基于文件系统的会话状态持久化
+- 支持跨会话记忆检索
+
+### 6. Feishu（飞书集成）
+- 飞书机器人 Webhook 回调处理
+- 事件订阅与消息路由
+
+## Go 编码规范
+
+### 格式化
+- **所有代码必须通过 `gofmt` 格式化**，无例外
+- 使用 `goimports` 管理导入排序
+- Tab 缩进，不使用空格
+
+### 命名规范
+- 包名：小写、单词、无下划线（如 `engine`、`provider`）
+- 导出类型/函数：PascalCase（如 `AgentEngine`、`NewProvider`）
+- 未导出类型/函数：camelCase（如 `mainLoop`、`maxRetries`）
+- 接口名：以 `-er` 后缀为惯例（如 `Provider`、`Runner`），或不加后缀（如 `Tool`）
+- 常量：PascalCase（导出）或 camelCase（未导出），不使用全大写
+- 测试文件：`xxx_test.go`，测试函数以 `Test` 开头
+
+### 错误处理
+- 显式检查所有 `error` 返回值，禁止使用 `_` 忽略
+- 错误消息不以大写字母开头，不以句号结尾
+- 使用 `fmt.Errorf("context: %w", err)` 包装错误，保留错误链
+- 自定义错误类型放在所属包内，命名以 `Error` 结尾（如 `TimeoutError`）
+
+### 并发
+- 优先使用 channel 而非共享内存
+- 使用 `context.Context` 管理生命周期和取消
+- goroutine 必须有明确的退出机制
+
+### 测试
+- 使用标准库 `testing` 包
+- 表驱动测试优先（Table-Driven Tests）
+- 运行命令：`go test ./...`
+- 测试覆盖率：`go test -cover ./...`
+
+### 代码组织
+- 同一目录下所有 `.go` 文件必须属于同一个包
+- 导入分组：标准库 / 第三方库 / 项目内部包，组间空行分隔
+- 接口定义在使用者侧，而非实现者侧
+- 避免 `init()` 函数，除非有充分理由
+
+## 第三方 API / SDK 使用规范
+
+**重要**: 在确认使用某个第三方 API 或 SDK 时，**必须优先通过 context7 MCP 工具获取最新的官方文档和 API Doc**，确保：
+1. 使用最新的 API 版本和推荐用法
+2. 了解 Breaking Changes 和 Migration 指引
+3. 获取准确的函数签名、参数类型和返回值定义
+4. 参考官方最佳实践和示例代码
+
+### 已使用的第三方库
+- （当前为零依赖，随项目推进逐步更新此列表）
+
+### 第三方库选型原则
+- 优先选择官方或社区维护良好的 SDK
+- 优先选择轻量级、依赖少的库
+- 引入新依赖前需评估维护状态、Issue 响应速度、License
+
+## 参考项目
+
+| 框架 | 来源 | GitHub |
+|------|------|--------|
+| DeepAgents | LangChain | https://github.com/langchain-ai/deepagents |
+| OpenHarness | HKUDS | https://github.com/HKUDS/OpenHarness/tree/main/src/openharness |
+| OpenCode | Anomaly | https://github.com/anomalyco/opencode |
+| OpenClaw | OpenClaw | https://github.com/openclaw/openclaw |
+| HermesAgent | NousResearch | https://github.com/NousResearch/hermes-agent |
+| Claude Agent SDK | Anthropic | https://code.claude.com/docs/en/agent-sdk/overview |
+| OpenAI Agent SDK | OpenAI | https://developers.openai.com/api/docs/guides/agents |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # harness9
-一款轻量级、功能完备、生产可用的 Harness 框架
+
+一款轻量级、功能完备、生产可用的 Agent Harness 框架。
+
+## 项目简介
+
+harness9 使用 Go 语言构建，旨在提供简洁、高效、可扩展的 Agent 编排能力。对标 DeepAgents、Claude SDK、OpenClaw、OpenHarness 等主流框架。
+
+核心设计理念：
+
+- **简洁** — 最小化抽象层，代码直白易读
+- **完备** — 覆盖 Agent 运行所需的全部核心模块
+- **生产可用** — 错误恢复、上下文管理、超时控制等生产级特性
+
+## 架构概览
+
+```
+                    ┌─────────────────────┐
+                    │       Engine        │
+                    │   (MainLoop 核心)    │
+                    └──┬───┬───┬───┬─────┘
+                       │   │   │   │
+          ┌────────────┘   │   │   └────────────┐
+          ▼                ▼   ▼                 ▼
+    ┌──────────┐   ┌──────────┐   ┌──────────────────┐
+    │ Provider │   │ Context  │   │   Tool Registry  │
+    │ (模型接口) │   │ (上下文) │   │  (工具注册/调用)  │
+    └──────────┘   └──────────┘   └──────────────────┘
+                                         │
+                                    ┌────┴────┐
+                                    ▼         ▼
+                              ┌────────┐ ┌────────┐
+                              │ Memory │ │ Feishu │
+                              │ (记忆)  │ │ (飞书)  │
+                              └────────┘ └────────┘
+```
+
+**Engine** 驱动 Agent 主循环：`推理 → 工具调用 → 观察 → 继续推理`
+
+## 项目结构
+
+```
+harness9/
+├── cmd/
+│   └── harness9/
+│       └── main.go              # 程序入口，组装各模块并启动引擎
+├── internal/
+│   ├── engine/                  # Agent 核心引擎 — MainLoop 实现
+│   │   └── engine.go            # 循环调度：推理 → 工具调用 → 观察 → 继续推理
+│   ├── provider/                # 大模型接口抽象与具体厂商 SDK 实现
+│   │   └── provider.go          # Provider 接口定义 + 具体厂商实现
+│   ├── context/                 # Token 监控、Prompt 动态组装
+│   │   └── manager.go           # 上下文窗口管理、消息截断策略
+│   ├── tools/                   # 工具注册表、Middleware、基础极简工具
+│   │   ├── registry.go          # 工具注册中心
+│   │   ├── middleware.go        # 工具中间件（日志、超时、权限等）
+│   │   ├── bash.go              # Bash 工具实现
+│   │   └── edit.go              # 文件编辑工具实现
+│   ├── memory/                  # 基于文件系统的记忆状态存取
+│   │   └── memory.go            # 会话记忆持久化
+│   └── feishu/                  # 飞书机器人交互回调
+│       └── feishu.go            # 飞书 Webhook / 事件订阅处理
+├── docs/                        # 项目文档
+├── go.mod
+├── AGENTS.md                    # 本文件 — 项目开发规范与上下文
+├── CLAUDE.md -> AGENTS.md       # 符号链接，保持同步
+└── README.md
+```
+
+## 快速开始
+
+### 环境要求
+
+- Go 1.25+
+
+### 构建 & 运行
+
+```bash
+# 构建
+go build ./cmd/harness9
+
+# 运行
+go run ./cmd/harness9
+```
+
+### 测试
+
+```bash
+go test ./...
+```
+
+## 核心模块
+
+| 模块 | 说明 | 状态 |
+|------|------|------|
+| Engine | Agent 主循环调度 | 开发中 |
+| Provider | 大模型统一接口（OpenAI/Anthropic/Google） | 开发中 |
+| Context | Token 监控与 Prompt 组装 | 开发中 |
+| Tools | 工具注册表 + 中间件 + 内置工具 | 开发中 |
+| Memory | 会话记忆持久化 | 开发中 |
+| Feishu | 飞书机器人集成 | 开发中 |
+
+## License
+
+MIT

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+)
+
+func main() {
+	fmt.Println("harness9 engine starting...")
+
+	// TODO: 1. 初始化模型 Provider (大脑)
+	// provider := provider.NewClaudeProvider(...)
+
+	// TODO: 2. 初始化 Tool Registry (手脚)
+	// registry := tools.NewRegistry()
+	// registry.Register(tools.NewBashTool())
+
+	// TODO: 3. 初始化上下文管理器 internal/context (内存管理器)
+	// ctxManager := ctxmanager.NewManager(...)
+
+	// TODO: 4. 组装并启动核心 Engine (操作系统心脏)
+	// engine := engine.NewAgentEngine(provider, registry, ctxManager)
+
+	// fmt.Println("开始执行任务...")
+	// err := engine.Run("帮我检查一下当前目录下的文件并输出一个 README.md 大纲")
+	// if err != nil {
+	//  log.Fatalf("引擎运行崩溃: %v", err)
+	// }
+
+	log.Println("架构蓝图搭建完毕，等待各核心模块注入！")
+}

--- a/docs/agentloop-research.md
+++ b/docs/agentloop-research.md
@@ -1,0 +1,832 @@
+# AgentLoop (ReAct Loop / MainLoop) 核心实现原理与设计模式
+
+## 深度调研报告
+
+> 调研日期：2026-04-20  
+> 调研范围：7 个主流 Agent Harness 框架的 AgentLoop 实现  
+> 目标：为 harness9 项目的 `internal/engine/engine.go` 设计提供参考
+
+---
+
+## 目录
+
+1. [调研概述](#1-调研概述)
+2. [各框架 AgentLoop 实现分析](#2-各框架-agentloop-实现分析)
+3. [横向对比总结](#3-横向对比总结)
+4. [设计模式提炼](#4-设计模式提炼)
+5. [对 harness9 的设计建议](#5-对-harness9-的设计建议)
+
+---
+
+## 1. 调研概述
+
+### 1.1 什么是 AgentLoop
+
+AgentLoop 是 Agent Harness 框架的核心运行时引擎。它实现了一个反复迭代的推理-行动循环（ReAct Loop），让 LLM 能够：
+
+1. **接收输入** → 理解用户意图和当前上下文
+2. **推理（Reason）** → 调用 LLM 生成响应
+3. **行动（Act）** → 解析工具调用请求并执行工具
+4. **观察（Observe）** → 将工具执行结果注入上下文
+5. **迭代** → 回到步骤 2，直到任务完成
+
+### 1.2 调研框架一览
+
+| 框架 | 来源 | 语言 | AgentLoop 核心文件 | 循环风格 |
+|------|------|------|---------------------|----------|
+| **DeepAgents** | LangChain | Python | `libs/deepagents/graph.py` → 委托 LangGraph | 图编排（StateGraph） |
+| **OpenHarness** | HKUDS | Python | `src/openharness/engine/query.py` | 显式 while 循环 |
+| **OpenCode** | Anomaly | TypeScript | `packages/opencode/src/session/session.ts` + Vercel AI SDK | 委托 AI SDK streamText |
+| **OpenClaw** | OpenClaw | TypeScript | `src/` 下 Gateway 路由 + Vercel AI SDK | 委托 AI SDK streamText |
+| **HermesAgent** | NousResearch | Python | `run_agent.py` → `run_conversation()` | 显式 while 循环 |
+| **Claude Agent SDK** | Anthropic | Python/TS | 内嵌 Claude Code 二进制，通过 `query()` 异步迭代器暴露 | 黑盒循环 + 流式异步迭代器 |
+| **OpenAI Agent SDK** | OpenAI | Python/TS | `src/agents/run.py` → `AgentRunner.run()` | 显式 while True 循环 |
+
+### 1.3 核心发现
+
+所有框架的 AgentLoop 遵循相同的基本模式，但在以下维度存在显著差异：
+
+- **循环控制权**：显式 while 循环 vs 委托图引擎 vs 黑盒
+- **终止条件**：stop_reason 检测、max_turns 限制、用户中断
+- **并行工具执行**：仅 OpenHarness 和 HermesAgent 实现了真正的并发工具调用
+- **上下文管理**：auto-compaction（OpenHarness/HermesAgent）vs 依赖模型 API（OpenAI Agent SDK）
+- **错误恢复**：从简单的 try/catch 到 reactive compaction + 断点续跑
+
+---
+
+## 2. 各框架 AgentLoop 实现分析
+
+### 2.1 OpenHarness — 最清晰的显式循环实现
+
+**核心文件**：`src/openharness/engine/query.py`（`run_query` 函数）
+
+**循环结构**：
+
+```python
+# src/openharness/engine/query.py - run_query()
+
+async def run_query(context, messages):
+    turn_count = 0
+    while context.max_turns is None or turn_count < context.max_turns:
+        turn_count += 1
+        
+        # 1. Auto-compact check before calling the model
+        async for event, usage in _stream_compaction(trigger="auto"):
+            yield event, usage
+        
+        # 2. Stream LLM response
+        async for event in context.api_client.stream_message(request):
+            if isinstance(event, ApiTextDeltaEvent):
+                yield AssistantTextDelta(text=event.text), None
+            elif isinstance(event, ApiMessageCompleteEvent):
+                final_message = event.message
+        
+        # 3. Append assistant message to history
+        messages.append(final_message)
+        yield AssistantTurnComplete(message=final_message), usage
+        
+        # 4. Check termination: no tool calls → done
+        if not final_message.tool_uses:
+            return
+        
+        # 5. Execute tools (single or parallel)
+        if len(tool_calls) == 1:
+            # Sequential for single tool
+            result = await _execute_tool_call(context, tc.name, tc.id, tc.input)
+        else:
+            # Parallel for multiple tools
+            raw_results = await asyncio.gather(
+                *[_run(tc) for tc in tool_calls], 
+                return_exceptions=True
+            )
+        
+        # 6. Append tool results as user message
+        messages.append(ConversationMessage(role="user", content=tool_results))
+    
+    raise MaxTurnsExceeded(context.max_turns)
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | `while max_turns` 显式循环 |
+| **终止条件** | `final_message.tool_uses` 为空时返回；超过 `max_turns` 抛异常 |
+| **流式输出** | 通过 `AsyncIterator[tuple[StreamEvent, UsageSnapshot]]` 逐事件 yield |
+| **并行工具** | `asyncio.gather` + `return_exceptions=True`（确保单个失败不影响其他工具） |
+| **上下文管理** | 每个 turn 开始前检查 auto-compact；prompt-too-long 时触发 reactive compact |
+| **错误处理** | API 调用异常 → 检测是否 context-too-long → reactive compact → 重试 |
+| **权限控制** | `_execute_tool_call` 中调用 `permission_checker.evaluate()`，支持交互式确认 |
+| **Hook 系统** | PreToolUse / PostToolUse / Stop / Notification 事件钩子 |
+
+**上下文压缩**（Compaction）：
+
+```python
+# 在每个 turn 开始前
+async for event, usage in _stream_compaction(trigger="auto"):
+    yield event, usage
+
+# API 调用失败时（reactive compaction）
+if not reactive_compact_attempted and _is_prompt_too_long_error(exc):
+    reactive_compact_attempted = True
+    async for event, usage in _stream_compaction(trigger="reactive", force=True):
+        yield event, usage
+    if was_compacted:
+        continue  # 重试当前 turn
+```
+
+### 2.2 HermesAgent — 最完整的 Python 实现
+
+**核心文件**：`run_agent.py` → `AIAgent.run_conversation()`
+
+**循环结构**（简化版）：
+
+```python
+# run_agent.py - AIAgent.run_conversation() 核心循环
+
+def run_conversation(self, user_input, ...):
+    messages = [{"role": "user", "content": user_input}]
+    
+    while self.iteration_budget.consume():
+        # 1. Call LLM (supports multiple API modes)
+        response = self._call_api(messages, tools, ...)
+        
+        # 2. Extract tool calls from response
+        tool_calls = response.choices[0].message.tool_calls
+        
+        # 3. Check termination
+        if not tool_calls:
+            return response.choices[0].message.content
+        
+        # 4. Execute tools (parallel or sequential)
+        if _should_parallelize_tool_batch(tool_calls):
+            # Concurrent execution in ThreadPoolExecutor
+            results = self._execute_tool_calls_concurrent(tool_calls)
+        else:
+            results = self._execute_tool_calls_sequential(tool_calls)
+        
+        # 5. Append assistant message + tool results
+        messages.append(response.choices[0].message)
+        for result in results:
+            messages.append({
+                "role": "tool",
+                "tool_call_id": result.id,
+                "content": result.output
+            })
+        
+        # 6. Context compression if needed
+        if estimated_tokens > context_limit * threshold:
+            messages = self._compress_context(messages)
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | `IterationBudget` 线程安全计数器（parent+subagent 共享预算） |
+| **API 模式** | 支持 `chat_completions`、`codex_responses`、`anthropic_messages`、`bedrock_converse` 四种 API 模式 |
+| **并行工具** | `ThreadPoolExecutor` + 路径冲突检测（`_should_parallelize_tool_batch`） |
+| **上下文压缩** | `ContextCompressor` 支持 micro-compact（清除旧 tool 输出）和 LLM-based summarize |
+| **中断机制** | `_interrupt_requested` + `_pending_steer`（注入式引导，不中断循环） |
+| **子代理** | `delegate` 工具创建独立 `AIAgent` 实例，共享 `IterationBudget` |
+| **错误恢复** | `jittered_backoff` 指数退避 + 自动 failover 到备用模型 |
+| **Token 计费** | 精确的 token 计数和成本追踪 |
+
+**并行工具调用的智能调度**：
+
+```python
+# run_agent.py - _should_parallelize_tool_batch()
+
+def _should_parallelize_tool_batch(tool_calls) -> bool:
+    """判断一批工具调用是否可以安全并行执行"""
+    if len(tool_calls) <= 1:
+        return False
+    # 交互式工具必须串行
+    if any(name in _NEVER_PARALLEL_TOOLS for name in tool_names):
+        return False
+    # 路径冲突检测（同文件的读写不能并行）
+    for tool_call in tool_calls:
+        if tool_name in _PATH_SCOPED_TOOLS:
+            if any(_paths_overlap(scoped_path, existing) for existing in reserved_paths):
+                return False
+    # 只读工具 + 无冲突的路径工具可以并行
+    return all(name in _PARALLEL_SAFE_TOOLS or name in _PATH_SCOPED_TOOLS 
+               for name in tool_names)
+```
+
+### 2.3 OpenAI Agent SDK — 最企业级的实现
+
+**核心文件**：`src/agents/run.py` → `AgentRunner.run()`
+
+**循环结构**：
+
+```python
+# src/agents/run.py - AgentRunner.run()
+
+async def run(self, starting_agent, input, *, max_turns=DEFAULT_MAX_TURNS, ...):
+    current_agent = starting_agent
+    current_turn = 0
+    
+    while True:
+        current_turn += 1
+        
+        # 1. Check max_turns
+        if current_turn > max_turns:
+            raise MaxTurnsExceeded(f"Max turns ({max_turns}) exceeded")
+        
+        # 2. Run input guardrails (first turn only)
+        if current_turn == 1:
+            await run_input_guardrails(...)
+        
+        # 3. Call model
+        turn_result = await run_single_turn(
+            current_agent, original_input, ...
+        )
+        
+        # 4. Process result based on next step type
+        if isinstance(turn_result.next_step, NextStepFinalOutput):
+            # Final answer → run output guardrails → return
+            await run_output_guardrails(...)
+            return RunResult(final_output=turn_result.next_step.output)
+            
+        elif isinstance(turn_result.next_step, NextStepHandoff):
+            # Switch to new agent → continue loop
+            current_agent = turn_result.next_step.new_agent
+            continue
+            
+        elif isinstance(turn_result.next_step, NextStepInterruption):
+            # Human approval needed → pause & return state
+            return build_interruption_result(run_state=...)
+            
+        elif isinstance(turn_result.next_step, NextStepRunAgain):
+            # Tool calls executed → continue loop
+            continue
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | `while True` + 显式 `NextStep*` 类型区分 |
+| **终止条件** | `NextStepFinalOutput`（模型生成最终答案）、`MaxTurnsExceeded`（超过限制） |
+| **Handoff** | `NextStepHandoff` 切换 agent 但不终止循环 |
+| **中断恢复** | `RunState` 可序列化，支持从 interruption 处恢复（`RunState` 作为 input 传入） |
+| **Guardrail** | Input guardrails（首轮执行）+ Output guardrails（最终输出前执行）+ Tool guardrails |
+| **会话管理** | 支持 `session`（本地持久化）、`conversationId`（OpenAI Conversations API）、`previousResponseId`（Responses API）四种策略 |
+| **Sandbox** | 内置 `SandboxRuntime` 支持 Docker 容器化执行 |
+| **Tracing** | 完整的 OpenTelemetry span 追踪（agent_span / turn_span / task_span） |
+
+**RunState 断点续跑**：
+
+```python
+# 支持从断点恢复
+result = await Runner.run(agent, RunState(...))  # 从中断处继续
+```
+
+### 2.4 DeepAgents (LangChain) — 图编排模式
+
+**核心文件**：`libs/deepagents/graph.py` → `create_deep_agent()`
+
+**设计理念**：不直接实现循环，而是通过 LangGraph 的 `CompiledStateGraph` 进行图编排。
+
+```python
+# DeepAgents 不直接写 while 循环，而是组装 LangGraph 图
+
+def create_deep_agent(model, tools, *, system_prompt, middleware, ...):
+    # 组装 middleware 栈
+    deepagent_middleware = [
+        TodoListMiddleware(),
+        SkillsMiddleware(...),
+        FilesystemMiddleware(...),
+        SubAgentMiddleware(...),
+        create_summarization_middleware(model, backend),
+        PatchToolCallsMiddleware(),
+        # ... 更多 middleware
+    ]
+    
+    # 委托 LangGraph create_agent 创建图
+    return create_agent(
+        model,
+        system_prompt=final_system_prompt,
+        tools=_tools,
+        middleware=deepagent_middleware,
+        ...
+    ).with_config({"recursion_limit": 9_999})
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | 委托 LangGraph 的图引擎，`recursion_limit: 9_999` |
+| **Middleware 栈** | 洋葱模型：请求从外到内穿过每层 middleware |
+| **SubAgent** | `SubAgentMiddleware` + `AsyncSubAgentMiddleware` 管理子代理 |
+| **Summarization** | `create_summarization_middleware` 自动压缩长上下文 |
+| **权限** | `_PermissionMiddleware` 必须是最后一层（看到所有工具） |
+| **Prompt 缓存** | `AnthropicPromptCachingMiddleware` 对非 Anthropic 模型静默跳过 |
+
+### 2.5 OpenCode — TypeScript + Effect 生态
+
+**核心文件**：`packages/opencode/src/session/session.ts` + Vercel AI SDK
+
+**设计理念**：使用 Effect.ts 函数式编程框架 + Vercel AI SDK 的 `streamText` 函数。
+
+```typescript
+// OpenCode 的 Agent 定义（不是 loop 本身）
+export const Info = z.object({
+    name: z.string(),
+    mode: z.enum(["subagent", "primary", "all"]),
+    permission: Permission.Ruleset.zod,
+    steps: z.number().int().positive().optional(),  // max turns
+    // ...
+})
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | 委托 Vercel AI SDK 的 `streamText` / `generateText`，通过 `maxSteps` 控制循环次数 |
+| **Agent 模式** | `build`（主代理）、`plan`（只读）、`general`（子代理）、`explore`（搜索） |
+| **Effect 生态** | 全面使用 `Effect`、`Layer`、`Context` 进行依赖注入和状态管理 |
+| **权限系统** | 细粒度的 `Permission.Ruleset`，支持 `allow/deny/ask` 三种动作 |
+| **工具定义** | `Tool.Def` 接口：`id` + `parameters` (Zod schema) + `execute` (Effect) |
+| **输出截断** | 内置 `Truncate` 服务，自动截断过长的工具输出 |
+
+### 2.6 OpenClaw — 全平台个人助手
+
+**核心文件**：TypeScript，基于 Vercel AI SDK
+
+**设计理念**：Gateway 架构，Agent Loop 在 Gateway 进程中运行。
+
+```typescript
+// OpenClaw 使用 Vercel AI SDK 的 streamText
+// Loop 本身由 AI SDK 的 maxSteps 参数控制
+const result = await streamText({
+    model: model,
+    messages: messages,
+    tools: tools,
+    maxSteps: agent.steps,
+    onStepFinish: async (step) => { /* 更新 session */ },
+})
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | Vercel AI SDK `maxSteps` 参数 |
+| **多渠道** | WhatsApp、Telegram、Slack、Discord 等 20+ 渠道 |
+| **多代理路由** | 支持根据渠道/账户路由到不同的 agent |
+| **Compaction** | `/compact` 命令 + 自动上下文压缩 |
+| **沙箱** | Docker 容器化执行非 main session |
+
+### 2.7 Claude Agent SDK — 黑盒循环
+
+**核心文件**：内嵌 Claude Code 二进制，通过异步迭代器暴露
+
+```python
+# Claude Agent SDK 的 API 设计
+async for message in query(
+    prompt="Find and fix the bug",
+    options=ClaudeAgentOptions(allowed_tools=["Read", "Edit", "Bash"]),
+):
+    if isinstance(message, AssistantMessage):
+        # 处理助手消息
+    elif isinstance(message, ResultMessage):
+        # 循环结束，获取最终结果
+```
+
+**关键设计特点**：
+
+| 维度 | 实现 |
+|------|------|
+| **循环控制** | 黑盒（内嵌 Claude Code 二进制），用户无法控制循环细节 |
+| **终止条件** | 模型不再调用工具或达到内部限制 |
+| **流式输出** | `async for message in query()` 异步迭代器 |
+| **权限模式** | `acceptEdits` / `dontAsk` / `auto` / `bypassPermissions` |
+| **Hook** | `PreToolUse` / `PostToolUse` / `Stop` / `SessionStart` 等回调 |
+| **子代理** | `AgentDefinition` 定义子代理，通过 `Agent` 工具调用 |
+| **会话** | `session_id` 支持跨调用上下文保持 |
+
+---
+
+## 3. 横向对比总结
+
+### 3.1 AgentLoop 核心流程对比
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    通用 AgentLoop 流程                               │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐      │
+│  │ 接收输入  │───▶│ 调用 LLM  │───▶│ 检查输出  │───▶│ 有工具调用?│     │
+│  └──────────┘    └──────────┘    └──────────┘    └────┬─┬───┘      │
+│       ▲                                              │ │            │
+│       │                                         否 ──┘ │ ── 是      │
+│       │                                              ▼   ▼          │
+│       │                                        ┌──────────┐        │
+│       │                                        │ 返回结果  │        │
+│       │                                        └──────────┘        │
+│       │                                              │              │
+│       ▼                                              │              │
+│  ┌──────────┐    ┌──────────┐                        │              │
+│  │ 注入结果  │◀───│ 执行工具  │◀───────────────────────┘              │
+│  └──────────┘    └──────────┘                                       │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 关键维度对比表
+
+| 维度 | OpenHarness | HermesAgent | OpenAI SDK | DeepAgents | OpenCode | OpenClaw | Claude SDK |
+|------|:-----------:|:-----------:|:----------:|:----------:|:--------:|:--------:|:----------:|
+| **循环实现** | 显式 while | 显式 while | 显式 while True | 图编排 | AI SDK 委托 | AI SDK 委托 | 黑盒 |
+| **默认 max_turns** | 8 | 90 | 25 | 9,999 | 可配置 | 可配置 | 内部 |
+| **并行工具** | ✅ asyncio.gather | ✅ ThreadPool | ❌ 顺序 | ❌ 图限制 | ✅ AI SDK | ✅ AI SDK | ❌ 黑盒 |
+| **流式输出** | ✅ AsyncIterator | ✅ callback | ✅ StreamEvents | ✅ LangGraph | ✅ AI SDK | ✅ AI SDK | ✅ AsyncIterator |
+| **上下文压缩** | ✅ auto+reactive | ✅ 三级压缩 | ✅ Compaction API | ✅ summarization | ✅ 专用 agent | ✅ /compact | ✅ 黑盒 |
+| **错误恢复** | ✅ reactive compact | ✅ backoff+failover | ✅ RunState 恢复 | ✅ checkpoint | ⚠️ 基础 | ⚠️ 基础 | ❌ 黑盒 |
+| **Handoff** | ❌ | ✅ delegate 工具 | ✅ NextStepHandoff | ✅ SubAgent | ✅ subagent | ✅ 多代理路由 | ✅ AgentDefinition |
+| **权限系统** | ✅ 多级+路径规则 | ✅ allowlist | ✅ guardrails+approval | ✅ Permission MW | ✅ Ruleset | ✅ 沙箱模式 | ✅ 多种模式 |
+| **Hook 系统** | ✅ Pre/Post Tool | ✅ callback 体系 | ✅ RunHooks | ✅ Middleware | ✅ Plugin | ✅ Plugin | ✅ HookMatcher |
+| **中断/恢复** | ✅ continue_pending | ✅ interrupt+steer | ✅ RunState | ✅ checkpoint | ⚠️ 基础 | ⚠️ 基础 | ✅ session_id |
+
+### 3.3 终止条件对比
+
+| 框架 | 主要终止条件 | 次要终止条件 |
+|------|-------------|-------------|
+| **OpenHarness** | `stop_reason != "tool_use"` | `MaxTurnsExceeded` 异常 |
+| **HermesAgent** | 无 tool_calls 或 finish_reason != tool_calls | `IterationBudget` 耗尽；用户 `/stop` |
+| **OpenAI SDK** | `NextStepFinalOutput` | `MaxTurnsExceeded` 异常；`NextStepInterruption`（暂停） |
+| **DeepAgents** | LangGraph 图到达 END 节点 | `recursion_limit`（9,999） |
+| **OpenCode** | AI SDK `maxSteps` 耗尽 | 模型无工具调用 |
+| **OpenClaw** | AI SDK `maxSteps` 耗尽 | 模型无工具调用 |
+| **Claude SDK** | `ResultMessage` 事件 | 内部限制 |
+
+### 3.4 上下文窗口管理对比
+
+| 策略 | 框架 | 实现方式 |
+|------|------|----------|
+| **Auto-Compact** | OpenHarness | 每个 turn 前检查 token 估算，超阈值自动触发 LLM summarize |
+| **Reactive Compact** | OpenHarness | API 返回 prompt-too-long 错误时强制压缩后重试 |
+| **Micro-Compact** | HermesAgent | 清除旧工具输出内容（保留结构） |
+| **LLM Summarize** | HermesAgent | 用 LLM 生成历史摘要替换旧消息 |
+| **Compaction API** | OpenAI SDK | 使用 OpenAI 的 `/compaction` 服务端 API |
+| **Summarization MW** | DeepAgents | `SummarizationMiddleware` 中间件 |
+| **专用 Agent** | OpenCode | 用 `compaction` agent 专门做上下文压缩 |
+
+---
+
+## 4. 设计模式提炼
+
+### 4.1 模式一：显式 While 循环（推荐）
+
+**适用场景**：需要完全控制循环逻辑的框架（如 harness9）
+
+```
+while max_turns not exceeded:
+    1. [可选] 上下文压缩检查
+    2. 调用 LLM（流式/非流式）
+    3. 检查终止条件
+    4. 解析工具调用
+    5. 执行工具（串行/并行）
+    6. 注入工具结果到消息历史
+```
+
+**代表框架**：OpenHarness、HermesAgent、OpenAI Agent SDK
+
+### 4.2 模式二：洋葱 Middleware 栈
+
+**适用场景**：需要在循环的各个阶段插入横切关注点
+
+```
+Request → MW1 → MW2 → MW3 → [Core Loop] → MW3 → MW2 → MW1 → Response
+```
+
+**关键规则**：
+- 权限中间件必须在最外层（最后执行，看到所有工具）
+- 缓存中间件在权限之前（避免缓存未授权的结果）
+- 摘要中间件在工具中间件之后（能看到完整的工具输出）
+
+**代表框架**：DeepAgents
+
+### 4.3 模式三：NextStep 状态机
+
+**适用场景**：需要在循环中处理复杂的分支逻辑（handoff、中断、恢复）
+
+```python
+match next_step:
+    case NextStepFinalOutput(output):
+        return result
+    case NextStepHandoff(new_agent):
+        current_agent = new_agent
+        continue
+    case NextStepInterruption(approvals):
+        return pause_with_state()
+    case NextStepRunAgain():
+        continue
+```
+
+**代表框架**：OpenAI Agent SDK
+
+### 4.4 模式四：异步迭代器流式输出
+
+**适用场景**：需要在循环执行过程中实时向前端推送事件
+
+```python
+async def run_query(context, messages) -> AsyncIterator[tuple[StreamEvent, Usage]]:
+    while ...:
+        # LLM 推理事件
+        yield AssistantTextDelta(text=chunk), None
+        # 工具执行事件
+        yield ToolExecutionStarted(tool_name=name), None
+        yield ToolExecutionCompleted(tool_name=name, output=result), None
+        # Turn 完成事件
+        yield AssistantTurnComplete(message=msg, usage=usage), usage
+```
+
+**代表框架**：OpenHarness、Claude Agent SDK
+
+### 4.5 模式五：并行工具执行 + 异常隔离
+
+**适用场景**：模型返回多个工具调用时需要高效执行
+
+```python
+if len(tool_calls) > 1:
+    # 并行执行，单个失败不影响其他工具
+    raw_results = await asyncio.gather(
+        *[_run(tc) for tc in tool_calls],
+        return_exceptions=True  # 关键：异常不传播
+    )
+    # 将异常转换为 ToolResultBlock(is_error=True)
+    for tc, result in zip(tool_calls, raw_results):
+        if isinstance(result, BaseException):
+            tool_results.append(ToolResultBlock(
+                content=f"Tool {tc.name} failed: {result}",
+                is_error=True
+            ))
+```
+
+**关键约束**（来自 HermesAgent）：
+- 交互式工具（如 `clarify`）必须串行
+- 同一路径的文件操作不能并行（路径冲突检测）
+- 只读工具 + 无冲突的文件工具可以并行
+
+**代表框架**：OpenHarness、HermesAgent
+
+### 4.6 模式六：双层上下文压缩
+
+**适用场景**：长期运行的 Agent 会话
+
+```
+第一层：Micro-Compact（低成本）
+    → 清除旧的工具输出内容，保留消息结构
+    → 适用于略微超限的情况
+
+第二层：LLM Summarize（高成本）
+    → 用 LLM 生成历史摘要，替换多条旧消息
+    → 适用于严重超限的情况
+
+第三层：Reactive Compact（紧急恢复）
+    → API 报错 prompt-too-long 时强制触发
+    → 保证不会因上下文过长而完全失败
+```
+
+**代表框架**：OpenHarness、HermesAgent
+
+---
+
+## 5. 对 harness9 的设计建议
+
+基于以上调研，为 harness9 的 `internal/engine/engine.go` 提出以下设计建议：
+
+### 5.1 推荐 Loop 结构
+
+```go
+// internal/engine/engine.go
+
+func (e *Engine) RunLoop(ctx context.Context, input Message) (<-chan Event, error) {
+    eventCh := make(chan Event)
+    
+    go func() {
+        defer close(eventCh)
+        
+        turnCount := 0
+        
+        for {
+            select {
+            case <-ctx.Done():
+                eventCh <- ErrorEvent{Err: ctx.Err()}
+                return
+            default:
+            }
+            
+            // 检查 max turns
+            turnCount++
+            if e.maxTurns > 0 && turnCount > e.maxTurns {
+                eventCh <- ErrorEvent{Err: ErrMaxTurnsExceeded}
+                return
+            }
+            
+            // 1. 上下文压缩检查
+            if e.shouldCompact() {
+                if err := e.compact(ctx); err != nil {
+                    eventCh <- StatusEvent{Message: "compaction failed"}
+                }
+            }
+            
+            // 2. 调用 LLM（流式）
+            response, err := e.provider.Stream(ctx, e.buildRequest())
+            if err != nil {
+                // 检测 context-too-long → reactive compact → 重试
+                if isContextTooLong(err) {
+                    e.compact(ctx)  // 强制压缩
+                    continue        // 重试当前 turn
+                }
+                eventCh <- ErrorEvent{Err: err}
+                return
+            }
+            
+            // 3. 流式输出 LLM 响应
+            var finalMsg Message
+            for chunk := range response.Stream() {
+                eventCh <- TextDeltaEvent{Text: chunk.Text}
+                finalMsg = chunk.Accumulate()
+            }
+            
+            // 4. 追加助手消息到历史
+            e.history.Append(finalMsg)
+            eventCh <- TurnCompleteEvent{Message: finalMsg}
+            
+            // 5. 检查终止条件
+            if len(finalMsg.ToolCalls) == 0 {
+                return  // 模型没有更多工具调用，循环结束
+            }
+            
+            // 6. 执行工具（并行或串行）
+            results := e.executeTools(ctx, finalMsg.ToolCalls)
+            
+            // 7. 注入工具结果
+            toolResultMsg := Message{Role: "user", Content: results}
+            e.history.Append(toolResultMsg)
+            
+            // 8. 发送工具执行事件
+            for _, r := range results {
+                eventCh <- ToolResultEvent{Name: r.ToolName, Output: r.Output}
+            }
+        }
+    }()
+    
+    return eventCh, nil
+}
+```
+
+### 5.2 核心接口定义建议
+
+```go
+// internal/engine/engine.go
+
+// Provider 抽象 LLM 调用
+type Provider interface {
+    Stream(ctx context.Context, req Request) (Response, error)
+}
+
+// ToolRegistry 工具注册中心
+type ToolRegistry interface {
+    Get(name string) (Tool, bool)
+    List() []Tool
+    ToSchema() []ToolSchema
+}
+
+// Tool 单个工具
+type Tool interface {
+    Name() string
+    Description() string
+    Execute(ctx context.Context, input json.RawMessage) (ToolResult, error)
+    IsReadOnly(input json.RawMessage) bool
+}
+
+// PermissionChecker 权限检查
+type PermissionChecker interface {
+    Evaluate(toolName string, isReadOnly bool, filePath string) PermissionDecision
+}
+
+// HookExecutor 生命周期钩子
+type HookExecutor interface {
+    Execute(ctx context.Context, event HookEvent, data map[string]any) error
+}
+
+// ContextManager 上下文窗口管理
+type ContextManager interface {
+    ShouldCompact(history []Message) bool
+    Compact(ctx context.Context, history []Message) ([]Message, error)
+}
+```
+
+### 5.3 关键设计决策建议
+
+| 决策点 | 建议 | 理由 |
+|--------|------|------|
+| **循环风格** | 显式 for 循环 + goroutine | Go 的惯用模式，清晰可控 |
+| **输出方式** | `<-chan Event` 通道 | 天然支持流式输出和取消 |
+| **并行工具** | `errgroup.Group` | Go 标准库，支持错误传播和取消 |
+| **上下文管理** | 双层压缩（micro + LLM summarize） | 参考 OpenHarness 的 auto + reactive 模式 |
+| **错误恢复** | reactive compact + 重试 | 防止 context-too-long 导致完全失败 |
+| **权限控制** | 工具执行前统一检查 | 参考 OpenHarness 的 `PermissionChecker` |
+| **终止条件** | 无工具调用 + max_turns + context 取消 | 三重保障 |
+| **Hook** | PreToolUse / PostToolUse / Stop / TurnComplete | 覆盖主要生命周期阶段 |
+
+### 5.4 并行工具执行建议
+
+```go
+// internal/engine/engine.go
+
+func (e *Engine) executeTools(ctx context.Context, calls []ToolCall) []ToolResult {
+    if len(calls) == 1 {
+        // 单工具：直接执行
+        result := e.executeSingleTool(ctx, calls[0])
+        return []ToolResult{result}
+    }
+    
+    // 多工具：并行执行
+    g, gctx := errgroup.WithContext(ctx)
+    results := make([]ToolResult, len(calls))
+    
+    for i, tc := range calls {
+        i, tc := i, tc  // capture
+        g.Go(func() error {
+            results[i] = e.executeSingleTool(gctx, tc)
+            return nil  // 永远不返回 error，避免取消其他工具
+        })
+    }
+    
+    g.Wait()  // 等待所有完成
+    return results
+}
+```
+
+### 5.5 上下文压缩建议
+
+```go
+// internal/context/manager.go
+
+type Manager struct {
+    provider       Provider
+    maxTokens      int
+    compactRatio   float64  // 超过此比例触发压缩（如 0.8）
+}
+
+func (m *Manager) ShouldCompact(messages []Message) bool {
+    estimated := estimateTokens(messages)
+    return float64(estimated) > float64(m.maxTokens) * m.compactRatio
+}
+
+func (m *Manager) Compact(ctx context.Context, messages []Message) ([]Message, error) {
+    // 第一层：Micro-Compact（清除旧工具输出）
+    compacted := m.microCompact(messages)
+    if m.estimateTokens(compacted) < int(float64(m.maxTokens)*0.7) {
+        return compacted, nil
+    }
+    
+    // 第二层：LLM Summarize（生成摘要替换旧消息）
+    return m.llmSummarize(ctx, compacted)
+}
+```
+
+### 5.6 事件类型定义建议
+
+```go
+// internal/engine/events.go
+
+type Event interface{ eventTag() }
+
+type TextDeltaEvent struct { Text string }
+type ToolStartedEvent struct { Name string; Input json.RawMessage }
+type ToolCompletedEvent struct { Name string; Output string; IsError bool }
+type TurnCompleteEvent struct { Message Message; Usage Usage }
+type StatusEvent struct { Message string }
+type ErrorEvent struct { Err error }
+```
+
+---
+
+## 附录 A：框架源码路径索引
+
+| 框架 | Loop 核心文件 | 工具系统 | 上下文管理 |
+|------|--------------|----------|-----------|
+| OpenHarness | `src/openharness/engine/query.py` | `src/openharness/tools/base.py` | `src/openharness/services/compact.py` |
+| HermesAgent | `run_agent.py` → `run_conversation()` | `model_tools.py` | `agent/context_compressor.py` |
+| OpenAI SDK | `src/agents/run.py` → `AgentRunner.run()` | `src/agents/tool.py` | `src/agents/memory/` |
+| DeepAgents | `libs/deepagents/graph.py` → LangGraph | Middleware 栈 | `middleware/summarization.py` |
+| OpenCode | `packages/opencode/src/session/` | `packages/opencode/src/tool/tool.ts` | 专用 compaction agent |
+| OpenClaw | `src/` Gateway 路由 | AI SDK tools | `/compact` 命令 |
+| Claude SDK | 内嵌二进制 | 内置工具 | 内置 |
+
+## 附录 B：推荐阅读顺序
+
+1. **OpenHarness** `query.py` — 最清晰的显式循环实现，建议作为首选参考
+2. **OpenAI SDK** `run.py` — 企业级的状态管理和断点恢复机制
+3. **HermesAgent** `run_agent.py` — 最完整的 Python 实现，特别是并行工具和上下文压缩
+4. **DeepAgents** `graph.py` — Middleware 栈的设计思路

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/harness9
+
+go 1.25.3


### PR DESCRIPTION
## Summary
- Set up Go module (`go.mod`) with `github.com/harness9` module path and Go 1.25+
- Add program entry point (`cmd/harness9/main.go`) with module assembly blueprint
- Create project documentation: AGENTS.md (development conventions), CLAUDE.md (symlink), and README.md with architecture diagram
- Add `.gitignore` (excluding `.env` and tool runtime files)
- Include AgentLoop research report (`docs/agentloop-research.md`) covering 7 mainstream frameworks

## Test Plan
- [x] `go build ./cmd/harness9` compiles successfully
- [x] `go run ./cmd/harness9` runs without error
- [x] `gofmt` passes on all `.go` files
- [x] CLAUDE.md symlink resolves correctly