### PR TITLE
docs: 完善全项目中文注释并添加中英文术语对照

### DIFF
--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -4,11 +4,11 @@
 //
 // 启动流程：
 //
-//	1. 确定物理工作路径（WorkDir）
-//	2. 从 .env 文件加载环境变量（API Key、Base URL 等）
-//	3. 创建 LLM Provider（模型后端适配器）
-//	4. 创建 Tool Registry 并注册内置工具
-//	5. 组装 Agent Engine 并启动主循环
+//  1. 确定物理工作路径（WorkDir）
+//  2. 从 .env 文件加载环境变量（API Key、Base URL 等）
+//  3. 创建 LLM Provider（模型后端适配器）
+//  4. 创建 Tool Registry 并注册内置工具
+//  5. 组装 Agent Engine 并启动主循环
 package main
 
 import (

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -1,5 +1,14 @@
-// Package main 是 harness9 agent 二进制的入口点。它组装核心组件 —
-// 环境配置加载、LLM Provider、Tool Registry 和 Agent Engine — 并启动 agent loop。
+// Package main 是 harness9 agent 二进制的入口点（Entry Point）。
+// 它按照依赖顺序组装核心组件 — 环境配置加载、LLM Provider、Tool Registry 和 Agent Engine —
+// 并启动 Agent Loop 执行用户任务。
+//
+// 启动流程：
+//
+//	1. 确定物理工作路径（WorkDir）
+//	2. 从 .env 文件加载环境变量（API Key、Base URL 等）
+//	3. 创建 LLM Provider（模型后端适配器）
+//	4. 创建 Tool Registry 并注册内置工具
+//	5. 组装 Agent Engine 并启动主循环
 package main
 
 import (
@@ -16,37 +25,47 @@ import (
 )
 
 func main() {
-	// 获取物理工作路径
+	// Step 1: 获取物理工作路径，作为 agent 的操作沙箱（Sandbox）边界。
+	// 所有工具（如文件读取）的访问范围被限制在此目录树内。
 	workDir, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("[main] 获取工作目录失败: %v", err)
 	}
 
-	// 加载环境变量
+	// Step 2: 加载 .env 环境变量配置。
+	// 从项目根目录读取 .env 文件，提取 API Key 和 Base URL 等敏感配置。
+	// 已存在的系统环境变量不会被覆盖（系统级 > 文件级）。
 	if err := env.Load(filepath.Join(workDir, ".env")); err != nil {
 		log.Fatalf("[main] 加载环境配置失败: %v", err)
 	}
 
-	// 初始化 LLM Provider
+	// Step 3: 初始化 LLM Provider（大模型后端适配器）。
+	// 当前使用 OpenAI 兼容端点，通过 OPENAI_API_KEY 和 OPENAI_BASE_URL
+	// 环境变量配置认证和端点，可灵活对接 OpenAI / Azure / OpenRouter 等服务。
 	llm, err := provider.NewOpenAIProvider("openai/gpt-5.4-mini")
 	if err != nil {
 		log.Fatalf("[main] 创建 Provider 失败: %v", err)
 	}
 
-	// 创建Tool Registry
+	// Step 4: 创建工具注册表（Tool Registry）并注册内置工具。
+	// Registry 是引擎与工具系统之间的桥梁，负责工具发现与执行分发。
 	registry := tools.NewRegistry()
 
-	// 创建ReadFile工具，并注册到Registry
+	// 注册 ReadFile 工具：提供受限工作区内的安全文件读取能力。
 	readFileTool := tools.NewReadFileTool(workDir)
 	registry.Register(readFileTool)
 
-	// 创建 Agent Engine
+	// Step 5: 创建 Agent Engine（核心编排器）。
+	// 参数 enableThinking=false 表示使用标准单阶段 ReAct 模式。
+	// 设置为 true 则启用两阶段 Thinking-Action 模式（慢思考 + 精准行动）。
 	eng := engine.NewAgentEngine(llm, registry, workDir, false)
 
-	// 执行 Agent
+	// Step 6: 构造用户任务并启动 Agent Loop。
+	// 设置 5 分钟全局超时，防止 LLM 陷入无限循环消耗 Token。
 	prompt := "查看下我当前的工作路径下 poem.txt 文件，总结其核心内容"
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
+
 	err = eng.Run(ctx, prompt)
 	if err != nil {
 		log.Fatalf("[main] 引擎异常退出: %v", err)

--- a/internal/engine/agent_loop.go
+++ b/internal/engine/agent_loop.go
@@ -376,6 +376,8 @@ func joinContent(thinking, action string) string {
 	}
 }
 
+// toJSON 将任意值序列化为 JSON 字符串，用于日志输出。
+// 序列化失败时返回错误提示文本，不会 panic。
 func toJSON(v interface{}) string {
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -384,8 +386,11 @@ func toJSON(v interface{}) string {
 	return string(b)
 }
 
+// maxLogOutputLen 日志中单条输出的最大字节数，防止工具返回的超大内容撑爆日志。
 const maxLogOutputLen = 512
 
+// truncStr 截断过长的字符串，超出部分替换为截断提示。
+// 用于在日志中安全输出工具执行结果，同时保留长度信息供调试参考。
 func truncStr(s string) string {
 	if len(s) <= maxLogOutputLen {
 		return s

--- a/internal/engine/agent_loop_test.go
+++ b/internal/engine/agent_loop_test.go
@@ -1,3 +1,17 @@
+// engine 包的单元测试（Unit Tests）。
+// 使用可编程的 Mock Provider 和预设 Registry，在不依赖真实 LLM API 的情况下
+// 对 Agent Loop 的核心行为进行端到端（End-to-End）验证。
+//
+// 测试覆盖范围：
+//   - Two-Stage ReAct 完整流程（Thinking → Action → Observation 循环）
+//   - 标准 ReAct 模式（单阶段）
+//   - MaxTurns 安全阀机制
+//   - Context 取消传播
+//   - System Prompt 中 WorkDir 注入
+//   - Thinking+Action 消息合并（避免连续 assistant 消息）
+//   - 工具错误结果回传
+//   - 工具执行超时
+//   - Phase 1 ToolCalls 清洗（安全防御）
 package engine
 
 import (
@@ -11,19 +25,24 @@ import (
 	"github.com/harness9/internal/tools"
 )
 
-// countingProvider 是一个可编程的 LLM Provider 桩实现，
-// 按预设序列返回响应，并记录所有调用参数。
+// countingProvider 是一个可编程的 LLM Provider 桩实现（Stub / Mock），
+// 按预设的响应序列依次返回结果，并记录所有 Generate 调用的参数。
+// 线程安全：使用 sync.Mutex 保护内部状态。
 type countingProvider struct {
 	mu        sync.Mutex
 	responses []func(tools []schema.ToolDefinition) *schema.Message
 	calls     []providerCall
 }
 
+// providerCall 记录一次 Generate 调用的完整参数，用于事后断言验证。
 type providerCall struct {
 	messages []schema.Message
 	tools    []schema.ToolDefinition
 }
 
+// Generate 实现 LLMProvider 接口。按 FIFO 顺序从 responses 队列中取出下一个响应，
+// 同时将本次调用的参数记录到 calls 切片中。
+// 每个响应函数接收当前的 availableTools 参数，使测试可以断言工具列表内容。
 func (p *countingProvider) Generate(_ context.Context, messages []schema.Message, tools []schema.ToolDefinition) (*schema.Message, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -42,7 +61,8 @@ func (p *countingProvider) Generate(_ context.Context, messages []schema.Message
 	return fn(tools), nil
 }
 
-// staticRegistry 返回固定工具列表，对任何调用都返回成功结果。
+// staticRegistry 返回固定工具列表，对任何 Execute 调用都返回预设的成功结果。
+// 用于测试中不需要验证工具执行逻辑的场景。
 type staticRegistry struct {
 	tools  []schema.ToolDefinition
 	output string
@@ -62,7 +82,8 @@ func (r *staticRegistry) Execute(_ context.Context, call schema.ToolCall) schema
 	}
 }
 
-// errorRegistry 对任何调用都返回错误结果。
+// errorRegistry 对任何 Execute 调用都返回预设的错误结果。
+// 用于验证引擎正确处理工具执行失败、以及 LLM 自愈重试的场景。
 type errorRegistry struct {
 	tools  []schema.ToolDefinition
 	output string
@@ -82,17 +103,26 @@ func (r *errorRegistry) Execute(_ context.Context, call schema.ToolCall) schema.
 	}
 }
 
+// TestTwoStageReact_CompleteFlow 验证 Two-Stage ReAct 的完整流程：
+//
+//	Turn 1: Phase 1 Thinking (tools=nil) → Phase 2 Action (tools=[bash], 发起 ToolCall)
+//	Turn 2: Phase 1 Thinking (tools=nil) → Phase 2 Action (tools=[bash], 最终回复)
+//
+// 断言：
+//   - 共 4 次 Generate 调用（2 turns × 2 phases）
+//   - Phase 1 调用都收到空工具列表（nil tools）
+//   - Phase 2 调用都收到可用工具列表
 func TestTwoStageReact_CompleteFlow(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
-			// Turn 1 Phase 1: Thinking
+			// Turn 1 Phase 1: Thinking（无工具的深度推理阶段）
 			func(tools []schema.ToolDefinition) *schema.Message {
 				if len(tools) != 0 {
 					t.Error("Phase 1 应该收到空工具列表")
 				}
 				return &schema.Message{Role: schema.RoleAssistant, Content: "thinking about files"}
 			},
-			// Turn 1 Phase 2: Action with tool call
+			// Turn 1 Phase 2: Action with tool call（基于思考结果发起工具调用）
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{
 					Role:    schema.RoleAssistant,
@@ -102,11 +132,11 @@ func TestTwoStageReact_CompleteFlow(t *testing.T) {
 					},
 				}
 			},
-			// Turn 2 Phase 1: Thinking
+			// Turn 2 Phase 1: Thinking（分析工具返回结果）
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{Role: schema.RoleAssistant, Content: "I see main.go"}
 			},
-			// Turn 2 Phase 2: Final answer (no tool calls)
+			// Turn 2 Phase 2: Final answer（无 ToolCall，循环终止）
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{Role: schema.RoleAssistant, Content: "done!"}
 			},
@@ -129,7 +159,7 @@ func TestTwoStageReact_CompleteFlow(t *testing.T) {
 		t.Fatalf("expected 4 Generate calls, got %d", len(p.calls))
 	}
 
-	// 验证 Phase 1 调用都收到了 nil tools
+	// 验证 Phase 1 调用都收到了空工具列表（Thinking 阶段剥夺工具）
 	if len(p.calls[0].tools) != 0 {
 		t.Error("Turn 1 Phase 1 should have nil tools")
 	}
@@ -137,7 +167,7 @@ func TestTwoStageReact_CompleteFlow(t *testing.T) {
 		t.Error("Turn 2 Phase 1 should have nil tools")
 	}
 
-	// 验证 Phase 2 调用都收到了可用工具
+	// 验证 Phase 2 调用都收到了可用工具（Action 阶段恢复工具）
 	if len(p.calls[1].tools) != 1 {
 		t.Error("Turn 1 Phase 2 should have 1 tool")
 	}
@@ -146,6 +176,8 @@ func TestTwoStageReact_CompleteFlow(t *testing.T) {
 	}
 }
 
+// TestStandardReact_NoThinking 验证 EnableThinking=false 时退化为标准单阶段 ReAct。
+// 断言：只有 1 次 Generate 调用，且直接收到可用工具列表。
 func TestStandardReact_NoThinking(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
@@ -174,6 +206,8 @@ func TestStandardReact_NoThinking(t *testing.T) {
 	}
 }
 
+// TestMaxTurnsLimit 验证 MaxTurns 安全阀机制。
+// 当 LLM 持续发起 ToolCall（永不终止）时，引擎应在达到最大 Turn 数后强制退出。
 func TestMaxTurnsLimit(t *testing.T) {
 	callCount := 0
 	p := &countingProvider{
@@ -220,6 +254,8 @@ func TestMaxTurnsLimit(t *testing.T) {
 	}
 }
 
+// TestContextCancellation 验证 Context 取消信号的传播。
+// 当外部 context 被取消时（如超时或手动中断），引擎应在下一次循环迭代中检测到并优雅退出。
 func TestContextCancellation(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
@@ -237,6 +273,7 @@ func TestContextCancellation(t *testing.T) {
 	r := &staticRegistry{output: "ok"}
 	eng := NewAgentEngine(p, r, "/test", false)
 
+	// 立即取消 context，模拟用户中断
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -249,6 +286,8 @@ func TestContextCancellation(t *testing.T) {
 	}
 }
 
+// TestWorkDirInSystemPrompt 验证 System Prompt 中正确注入了工作区路径。
+// 引擎初始化时将 WorkDir 嵌入 System Prompt，使 LLM 了解其工作上下文。
 func TestWorkDirInSystemPrompt(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
@@ -267,6 +306,7 @@ func TestWorkDirInSystemPrompt(t *testing.T) {
 		t.Fatal("expected at least 1 Generate call")
 	}
 
+	// 验证第一条消息是 System Prompt 且包含工作区路径
 	firstMsg := p.calls[0].messages[0]
 	if firstMsg.Role != schema.RoleSystem {
 		t.Fatal("first message should be system")
@@ -276,6 +316,12 @@ func TestWorkDirInSystemPrompt(t *testing.T) {
 	}
 }
 
+// TestMergedAssistantMessage_NoConsecutiveDuplicates 验证 Two-Stage ReAct 的关键设计约束：
+// 每个 Turn 最终只向 contextHistory 注入一条 assistant 消息。
+//
+// 这是 Anthropic Messages API 等厂商要求的 user/assistant 严格交替规则的保障。
+// 若 Phase 1 Thinking 和 Phase 2 Action 分别作为独立消息注入，会导致连续 assistant
+// 消息，引发 API 调用失败。
 func TestMergedAssistantMessage_NoConsecutiveDuplicates(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
@@ -283,7 +329,7 @@ func TestMergedAssistantMessage_NoConsecutiveDuplicates(t *testing.T) {
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{Role: schema.RoleAssistant, Content: "thinking"}
 			},
-			// Turn 1 Phase 2: Action with tool call (keeps loop going)
+			// Turn 1 Phase 2: Action with tool call（保持循环继续）
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{
 					Role:    schema.RoleAssistant,
@@ -297,7 +343,7 @@ func TestMergedAssistantMessage_NoConsecutiveDuplicates(t *testing.T) {
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{Role: schema.RoleAssistant, Content: "thinking2"}
 			},
-			// Turn 2 Phase 2: Final (no tool calls)
+			// Turn 2 Phase 2: Final（无 ToolCall，循环终止）
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
 			},
@@ -317,7 +363,7 @@ func TestMergedAssistantMessage_NoConsecutiveDuplicates(t *testing.T) {
 		t.Fatalf("expected 4 calls, got %d", len(p.calls))
 	}
 
-	// 检查 Phase 2 的上下文中没有连续 assistant 消息
+	// 检查所有 Phase 2 调用的上下文中没有连续 assistant 消息
 	// call[1] = Turn 1 Phase 2, call[3] = Turn 2 Phase 2
 	for _, callIdx := range []int{1, 3} {
 		msgs := p.calls[callIdx].messages
@@ -331,6 +377,9 @@ func TestMergedAssistantMessage_NoConsecutiveDuplicates(t *testing.T) {
 	}
 }
 
+// TestToolErrorResult 验证工具执行失败时，错误结果作为 Observation 正确回传给 LLM。
+// 模拟场景：工具返回 IsError=true 的结果，引擎将其注入上下文，
+// LLM 在下一轮可以看到错误信息并尝试自愈（Self-Healing）。
 func TestToolErrorResult(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
@@ -356,7 +405,7 @@ func TestToolErrorResult(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// 第二次调用收到的消息应包含工具错误结果
+	// 第二次调用收到的消息应包含工具错误结果（Observation）
 	if len(p.calls) < 2 {
 		t.Fatal("expected 2 calls")
 	}
@@ -370,6 +419,7 @@ func TestToolErrorResult(t *testing.T) {
 	}
 }
 
+// TestToolTimeout 验证 WithToolTimeout 选项正确为每个工具执行创建带超时的子 context。
 func TestToolTimeout(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
@@ -379,13 +429,14 @@ func TestToolTimeout(t *testing.T) {
 		},
 	}
 
-	// 使用一个会检查 context 取消的 registry
+	// 使用一个会检查 context 是否有 deadline 的 registry
 	timeoutRegistry := &timeoutCheckRegistry{}
 	eng := NewAgentEngine(p, timeoutRegistry, "/test", false, WithToolTimeout(100*time.Millisecond))
 
 	_ = eng.Run(context.Background(), "test")
 }
 
+// timeoutCheckRegistry 用于 TestToolTimeout，验证 Execute 收到的 context 有 deadline 设置。
 type timeoutCheckRegistry struct{}
 
 func (r *timeoutCheckRegistry) Register(_ tools.BaseTool) {}
@@ -395,12 +446,15 @@ func (r *timeoutCheckRegistry) GetAvailableTools() []schema.ToolDefinition {
 }
 
 func (r *timeoutCheckRegistry) Execute(ctx context.Context, call schema.ToolCall) schema.ToolResult {
-	// 验证 context 有 deadline
 	_, ok := ctx.Deadline()
-	_ = ok
+	if !ok {
+		panic("expected context to have a deadline set by WithToolTimeout")
+	}
 	return schema.ToolResult{ToolCallID: call.ID, Output: "ok"}
 }
 
+// TestJoinContent 使用表驱动测试（Table-Driven Tests）验证 Thinking + Action
+// 内容合并函数 joinContent 的各种边界情况。
 func TestJoinContent(t *testing.T) {
 	tests := []struct {
 		thinking string
@@ -421,9 +475,15 @@ func TestJoinContent(t *testing.T) {
 	}
 }
 
+// TestPhase1ToolCallsSanitized 验证 Phase 1 Thinking 阶段的 ToolCalls 被安全清洗。
+//
+// 安全防御场景：即使 LLM 在无工具模式下违反指令返回了 ToolCalls，
+// 引擎会在将 Thinking 响应传递给 Phase 2 之前清除 ToolCalls 字段，
+// 防止 Phase 2 的上下文中出现"幽灵"工具调用请求。
 func TestPhase1ToolCallsSanitized(t *testing.T) {
 	p := &countingProvider{
 		responses: []func(tools []schema.ToolDefinition) *schema.Message{
+			// Phase 1: 模拟 LLM 违反指令，在无工具模式下仍返回 ToolCalls
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{
 					Role:    schema.RoleAssistant,
@@ -433,6 +493,7 @@ func TestPhase1ToolCallsSanitized(t *testing.T) {
 					},
 				}
 			},
+			// Phase 2: 正常返回
 			func(tools []schema.ToolDefinition) *schema.Message {
 				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
 			},
@@ -445,13 +506,13 @@ func TestPhase1ToolCallsSanitized(t *testing.T) {
 	_ = eng.Run(context.Background(), "test")
 
 	// Phase 2 (call index 1) 应该收到 Phase 1 的思考消息，
-	// 但该消息不应包含 ToolCalls
+	// 但该消息不应包含 ToolCalls（已被引擎清洗）
 	if len(p.calls) < 2 {
 		t.Fatal("expected 2 calls")
 	}
 
 	phase2Messages := p.calls[1].messages
-	// Phase 2 context 最后一条 assistant 消息应该是 Phase 1 的 thinking（已被清理）
+	// Phase 2 临时上下文中最后一条 assistant 消息应该是 Phase 1 的 thinking（已被清洗）
 	lastAssistant := phase2Messages[len(phase2Messages)-1]
 	if lastAssistant.Role != schema.RoleAssistant {
 		t.Fatal("expected last message to be assistant")

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -1,3 +1,6 @@
+// env 包的单元测试（Unit Tests）。
+// 覆盖 .env 文件解析的各种场景：正常解析、文件缺失、系统环境变量优先、
+// 以及 parseLine 的边界情况（引号处理、空行、注释等）。
 package env
 
 import (
@@ -6,6 +9,9 @@ import (
 	"testing"
 )
 
+// TestLoad_ExistingFile 验证 Load 正确解析包含各种格式的 .env 文件：
+//
+//	普通值、双引号值、单引号值、空值
 func TestLoad_ExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	envFile := filepath.Join(dir, ".env")
@@ -24,6 +30,7 @@ TEST_KEY_4=
 		t.Fatalf("Load failed: %v", err)
 	}
 
+	// 表驱动测试（Table-Driven Tests）：验证各种格式的键值对都被正确解析
 	tests := []struct {
 		key, want string
 	}{
@@ -41,6 +48,8 @@ TEST_KEY_4=
 	}
 }
 
+// TestLoad_FileNotFound 验证 .env 文件不存在时的优雅降级：
+// Load 应返回 nil（而非错误），使程序可以在没有 .env 文件时仍正常运行。
 func TestLoad_FileNotFound(t *testing.T) {
 	err := Load("/nonexistent/.env")
 	if err != nil {
@@ -48,6 +57,8 @@ func TestLoad_FileNotFound(t *testing.T) {
 	}
 }
 
+// TestLoad_DoesNotOverride 验证已存在的系统环境变量不会被 .env 文件覆盖。
+// 这确保了"系统环境变量 > .env 文件"的优先级策略。
 func TestLoad_DoesNotOverride(t *testing.T) {
 	os.Setenv("EXISTING_KEY", "system_value")
 	defer os.Unsetenv("EXISTING_KEY")
@@ -69,6 +80,10 @@ func TestLoad_DoesNotOverride(t *testing.T) {
 	}
 }
 
+// TestParseLine 使用表驱动测试（Table-Driven Tests）验证 parseLine 的各种边界情况：
+//
+//	普通键值对、双引号值去除、空值、带空格的键值、注释行、无等号行、
+//	无键行、不匹配引号（不应去除）、无引号值。
 func TestParseLine(t *testing.T) {
 	tests := []struct {
 		line    string

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -16,9 +16,17 @@ import (
 //
 // 通过 ANTHROPIC_API_KEY 和 ANTHROPIC_BASE_URL 环境变量配置认证和端点，
 // 使同一实现可灵活对接不同的 Anthropic 兼容服务。
+//
+// 注意：Anthropic Messages API 与 OpenAI Chat Completion API 的关键差异：
+//   - System Prompt 不在 messages 数组中，而是作为独立的 system 参数传入
+//   - 响应使用 Content Blocks（text / tool_use）而非单一的 content + tool_calls 结构
+//   - 必须指定 maxTokens 参数（OpenAI 可省略）
 type AnthropicProvider struct {
-	client    anthropic.Client
-	model     string
+	// client Anthropic SDK 客户端，封装了 HTTP 通信、认证和重试逻辑。
+	client anthropic.Client
+	// model 模型标识符，如 "claude-sonnet-4-20250514"。
+	model string
+	// maxTokens 单次响应的最大输出 Token 数。Anthropic API 要求必须指定此参数。
 	maxTokens int64
 }
 

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -18,8 +18,10 @@ import (
 // 通过 OPENAI_API_KEY 和 OPENAI_BASE_URL 环境变量配置认证和端点，
 // 使同一实现可灵活对接不同的 OpenAI 兼容服务。
 type OpenAIProvider struct {
+	// client OpenAI SDK 客户端，封装了 HTTP 通信、认证和重试逻辑。
 	client openai.Client
-	model  string
+	// model 模型标识符，如 "gpt-4o"、"openai/gpt-5.4-mini" 等，直接传递给 Chat Completion API。
+	model string
 }
 
 // NewOpenAIProvider 创建 OpenAI 兼容的 Provider 实例。

--- a/internal/schema/message.go
+++ b/internal/schema/message.go
@@ -5,20 +5,22 @@ package schema
 
 import "encoding/json"
 
-// Role 枚举了多轮对话中可能出现的参与者角色，遵循主流 Chat Completion API
-// （OpenAI、Anthropic、Google 等）使用的 system / user / assistant 三元组。
+// Role 枚举了多轮对话（Multi-Turn Conversation）中可能出现的参与者角色，
+// 遵循主流 Chat Completion API（OpenAI、Anthropic、Google 等）使用的
+// system / user / assistant 三元组。
 type Role string
 
 const (
-	// RoleSystem 系统提示词：定义 agent 的性格、约束和行为边界，通常在会话开始时注入一次。
+	// RoleSystem 系统提示词（System Prompt）：定义 agent 的性格、约束和行为边界，
+	// 通常在会话开始时注入一次。LLM 在所有后续 Turn 中都会参考此消息。
 	RoleSystem Role = "system"
 
-	// RoleUser 用户角色：包含人类操作者的输入 prompt，以及工具执行后回传的 Observation，
-	// 供模型进行下一轮 Reasoning。
+	// RoleUser 用户角色（User）：包含人类操作者的输入 Prompt，以及工具执行后回传的
+	// Observation（观察结果），供模型进行下一轮 Reasoning（推理）。
 	RoleUser Role = "user"
 
-	// RoleAssistant 模型输出角色：一条 assistant 消息可能包含纯文本推理 (Reasoning)、
-	// 一个或多个工具调用请求 (parallel ToolCall)，或两者的组合。
+	// RoleAssistant 模型输出角色（Assistant）：一条 assistant 消息可能包含纯文本推理
+	// （Reasoning）、一个或多个工具调用请求（Parallel ToolCall），或两者的组合。
 	RoleAssistant Role = "assistant"
 )
 
@@ -36,27 +38,28 @@ type Message struct {
 	// 而没有文本推理，此字段可能为空。
 	Content string `json:"content"`
 
-	// ToolCalls 当 assistant 请求工具调用时非空。切片支持并行调用 (parallel tool calling)：
+	// ToolCalls 当 assistant 请求工具调用时非空。切片支持并行调用（Parallel Tool Calling）：
 	// 引擎并发执行所有调用，并将每个结果作为独立的 Observation 消息回传。
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
 
 	// ToolCallID 用于 Observation（user 角色）消息中，标识此消息是对哪个 ToolCall
-	// 的响应，使 LLM 能够将 Observation 与其原始请求进行匹配。
+	// 的响应（Request-Response 关联），使 LLM 能够将 Observation 与其原始请求进行匹配。
 	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 // ToolCall 代表模型发出的单个工具调用请求。模型指定要调用的已注册工具名称，
 // 并提供符合该工具 Input Schema 的 JSON 参数载荷。
 type ToolCall struct {
-	// ID 由 LLM Provider 分配的唯一标识符，用于将工具执行结果 (ToolResult) 与
-	// 原始请求进行关联。
+	// ID 由 LLM Provider 分配的唯一标识符（Unique Identifier），用于将工具执行结果
+	// （ToolResult）与原始请求（ToolCall）进行关联（Request-Response Matching）。
 	ID string `json:"id"`
 
-	// Name 目标工具在 Registry 中的标识符（例如 "bash"、"edit"、"glob"）。
+	// Name 目标工具在 Registry（注册表）中的标识符（如 "bash"、"read_file"、"glob"）。
 	Name string `json:"name"`
 
-	// Arguments 存放工具调用的原始 JSON 参数。使用 json.RawMessage 延迟反序列化，
-	// 将解析责任交给具体的工具实现，避免在引擎层进行过早的类型断言。
+	// Arguments 存放工具调用的原始 JSON 参数载荷（Payload）。使用 json.RawMessage
+	// 延迟反序列化（Lazy Deserialization），将解析责任交给具体的工具实现，
+	// 避免在引擎层进行过早的类型断言（Premature Type Assertion）。
 	Arguments json.RawMessage `json:"arguments"`
 }
 
@@ -70,7 +73,7 @@ type ToolResult struct {
 	Output string `json:"output"`
 
 	// IsError 标记工具执行是否失败。当为 true 时，引擎可将错误暴露给 LLM，
-	// 使其尝试自愈 (self-healing)，例如修正命令语法后重试。
+	// 使其尝试自愈（Self-Healing），例如修正命令语法后重试。
 	IsError bool `json:"is_error"`
 }
 
@@ -83,8 +86,8 @@ type ToolDefinition struct {
 	// Description 工具用途和行为的自然语言描述，供 LLM 决定何时以及如何调用该工具。
 	Description string `json:"description"`
 
-	// InputSchema 描述工具参数格式的 JSON Schema。使用 interface{} 类型以兼容
+	// InputSchema 描述工具参数格式的 JSON Schema。使用 any 类型以兼容
 	// 不同 SDK 的参数格式要求（OpenAI 需要 shared.FunctionParameters，
-	// Anthropic 需要 map[string]any），各 Provider 实现负责类型转换。
-	InputSchema interface{} `json:"input_schema"`
+	// Anthropic 需要 map[string]any），各 Provider 实现负责类型转换（Type Adaptation）。
+	InputSchema any `json:"input_schema"`
 }

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -1,3 +1,6 @@
+// 内置工具：ReadFile — 安全的文件读取工具。
+// 提供 Sandbox 沙箱路径限制，防止路径遍历攻击（Path Traversal），
+// 并限制最大读取长度以保护系统资源。
 package tools
 
 import (
@@ -12,20 +15,32 @@ import (
 	"github.com/harness9/internal/schema"
 )
 
+// maxReadLen 单次文件读取的最大字节数。超出部分会被截断并附加提示信息，
+// 防止意外将超大文件内容注入到 LLM 上下文窗口中导致 Token 爆炸。
 const maxReadLen = 4096
 
+// ReadFileTool 实现了 BaseTool 接口，提供受限工作区内的安全文件读取能力。
+// 安全机制：所有路径解析后会校验是否在工作区（WorkDir）范围内，
+// 拒绝类似 "../../etc/passwd" 的路径遍历攻击（Path Traversal Attack）。
 type ReadFileTool struct {
+	// workDir 工具允许访问的根目录（Sandbox Boundary），
+	// 所有读取操作被限制在此目录树内。
 	workDir string
 }
 
+// NewReadFileTool 创建绑定到指定工作区的文件读取工具。
+// workDir 会被 filepath.Clean 清洗，确保路径规范化。
 func NewReadFileTool(workDir string) *ReadFileTool {
 	return &ReadFileTool{workDir: filepath.Clean(workDir)}
 }
 
+// Name 返回工具标识符 "read_file"。
 func (t *ReadFileTool) Name() string {
 	return "read_file"
 }
 
+// Definition 返回工具的元信息，包含描述和 JSON Schema 参数定义。
+// LLM 会根据此定义决定何时调用该工具以及如何构造参数。
 func (t *ReadFileTool) Definition() schema.ToolDefinition {
 	return schema.ToolDefinition{
 		Name:        t.Name(),
@@ -43,10 +58,16 @@ func (t *ReadFileTool) Definition() schema.ToolDefinition {
 	}
 }
 
+// readFileArgs 定义 read_file 工具的 JSON 参数结构，
+// 对应 LLM 在 ToolCall 中传递的 Arguments 载荷（Payload）。
 type readFileArgs struct {
 	Path string `json:"path"`
 }
 
+// Execute 执行文件读取操作。流程如下：
+//  1. 反序列化 JSON 参数，提取目标路径
+//  2. 通过 safePath 校验并解析为绝对路径（含沙箱边界检查）
+//  3. 读取文件内容，超过 maxReadLen 的部分被截断
 func (t *ReadFileTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var input readFileArgs
 	if err := json.Unmarshal(args, &input); err != nil {
@@ -64,6 +85,7 @@ func (t *ReadFileTool) Execute(ctx context.Context, args json.RawMessage) (strin
 	}
 	defer file.Close()
 
+	// 使用 LimitReader 限制读取量，+1 用于检测是否超出上限
 	content, err := io.ReadAll(io.LimitReader(file, maxReadLen+1))
 	if err != nil {
 		return "", fmt.Errorf("读取文件内容失败: %w", err)
@@ -76,6 +98,12 @@ func (t *ReadFileTool) Execute(ctx context.Context, args json.RawMessage) (strin
 	return string(content), nil
 }
 
+// safePath 将用户输入的相对路径解析为绝对路径，并校验是否在工作区范围内。
+// 这是防止路径遍历攻击（Path Traversal Attack）的核心安全屏障：
+// 任何试图通过 "../" 逃逸工作区的路径都会被拒绝。
+//
+// 例如：workDir="/project"，输入 "../../etc/passwd" 会被拒绝，
+// 输入 "src/main.go" 会被解析为 "/project/src/main.go"。
 func (t *ReadFileTool) safePath(inputPath string) (string, error) {
 	cleanWorkDir := filepath.Clean(t.workDir)
 	joined := filepath.Join(cleanWorkDir, inputPath)
@@ -84,6 +112,7 @@ func (t *ReadFileTool) safePath(inputPath string) (string, error) {
 		return "", fmt.Errorf("解析路径失败: %w", err)
 	}
 
+	// 安全校验：确保解析后的绝对路径仍以工作区目录为前缀
 	if !strings.HasPrefix(absPath, cleanWorkDir+string(os.PathSeparator)) && absPath != cleanWorkDir {
 		return "", fmt.Errorf("路径 '%s' 超出工作区范围", inputPath)
 	}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -1,12 +1,12 @@
 // Package tools 提供 harness9 agent 框架的工具注册表（Registry）抽象及内置工具实现。
-// Registry 接口将工具发现与工具执行解耦，使引擎可以在不了解具体工具实现的前提下
-// 查询可用工具列表并分发调用。
+// Registry 接口将工具发现（Tool Discovery）与工具执行（Tool Execution）解耦，使引擎
+// 可以在不了解具体工具实现的前提下查询可用工具列表并分发调用。
 //
-// 工具通过实现 BaseTool 接口注册到 Registry 中。每个工具需要提供名称、参数定义（JSON Schema）
-// 和执行逻辑。引擎在每个 agent loop Turn 中与 Registry 交互两次：
+// 工具通过实现 BaseTool 接口注册到 Registry 中。每个工具需要提供名称、参数定义
+// （JSON Schema）和执行逻辑。引擎在每个 agent loop Turn 中与 Registry 交互两次：
 //
 //  1. 调用 LLM 之前，获取 ToolDefinition 列表，使模型了解可调用哪些工具
-//  2. LLM 发出 ToolCall 后，通过 Execute 分发每个调用并收集结果作为 Observation
+//  2. LLM 发出 ToolCall 后，通过 Execute 分发每个调用并收集结果作为 Observation（观察）
 package tools
 
 import (
@@ -18,28 +18,56 @@ import (
 	"github.com/harness9/internal/schema"
 )
 
+// BaseTool 定义了所有工具必须实现的核心接口（Tool Interface）。
+// 每个工具需提供：唯一名称、JSON Schema 参数定义、以及同步执行逻辑。
+// 框架通过此接口实现工具的多态调用，无需在引擎层了解具体工具的实现细节。
 type BaseTool interface {
+	// Name 返回工具的唯一标识符，用于 LLM 在 ToolCall 中引用此工具。
+	// 例如 "bash"、"read_file"、"edit" 等。
 	Name() string
+
+	// Definition 返回工具的元信息（ToolDefinition），包含名称、描述和参数 JSON Schema。
+	// 此信息会被转发给 LLM Provider，使模型了解工具的用途和参数格式。
 	Definition() schema.ToolDefinition
+
+	// Execute 执行工具逻辑。args 为 LLM 传递的原始 JSON 参数，
+	// 由具体工具实现负责反序列化和校验。
+	// 返回工具执行的文本输出，或失败时的错误信息。
 	Execute(ctx context.Context, args json.RawMessage) (string, error)
 }
 
+// Registry 定义了工具注册表（Tool Registry）的接口，负责工具的注册、发现与执行。
+// 引擎通过此接口与工具系统交互，实现关注点分离：
+// 引擎关注循环编排，Registry 关注工具生命周期管理。
 type Registry interface {
+	// Register 将一个 BaseTool 实现注册到工具表中。
+	// 若注册同名工具，后注册的会覆盖先注册的。
 	Register(tool BaseTool)
+
+	// GetAvailableTools 返回所有已注册工具的 ToolDefinition 列表，
+	// 供 LLM 在 Generate 调用时了解可用工具集。
 	GetAvailableTools() []schema.ToolDefinition
+
+	// Execute 根据 ToolCall 中的工具名称查找并执行对应工具，
+	// 返回封装后的 ToolResult（包含输出或错误信息）。
 	Execute(ctx context.Context, call schema.ToolCall) schema.ToolResult
 }
 
+// registryImpl 是 Registry 接口的默认实现，使用 map 存储工具实例。
+// 工具名称作为键，确保查找的时间复杂度为 O(1)。
 type registryImpl struct {
+	// tools 以工具名称为键的映射表，存储所有已注册的 BaseTool 实现。
 	tools map[string]BaseTool
 }
 
+// NewRegistry 创建并返回一个空的工具注册表实例。
 func NewRegistry() Registry {
 	return &registryImpl{
 		tools: make(map[string]BaseTool),
 	}
 }
 
+// Register 将工具注册到注册表中。如果同名工具已存在，会记录日志并覆盖旧实现。
 func (r *registryImpl) Register(tool BaseTool) {
 	name := tool.Name()
 	if _, exists := r.tools[name]; exists {
@@ -49,14 +77,19 @@ func (r *registryImpl) Register(tool BaseTool) {
 	log.Printf("[Registry] 成功挂载工具: %s", name)
 }
 
+// GetAvailableTools 遍历注册表，收集所有工具的 ToolDefinition 并返回。
+// 返回的列表顺序不固定（map 迭代顺序不确定）。
 func (r *registryImpl) GetAvailableTools() []schema.ToolDefinition {
-	var defs []schema.ToolDefinition
+	defs := make([]schema.ToolDefinition, 0, len(r.tools))
 	for _, tool := range r.tools {
 		defs = append(defs, tool.Definition())
 	}
 	return defs
 }
 
+// Execute 根据工具名称查找并执行对应工具。若工具不存在，返回包含错误信息的 ToolResult。
+// 工具执行失败时，错误会被捕获并封装为 IsError=true 的 ToolResult，
+// 使引擎能够将错误信息作为 Observation 回传给 LLM，支持自愈（Self-Healing）重试。
 func (r *registryImpl) Execute(ctx context.Context, call schema.ToolCall) schema.ToolResult {
 	tool, exists := r.tools[call.Name]
 	if !exists {


### PR DESCRIPTION
## Summary
- 为 schema/provider/engine/tools/env 各包添加详细包级文档、接口注释和字段注释
- 关键术语补充中英文对照（如 Path Traversal、Self-Healing、Lazy Deserialization、Parallel Tool Calling）
- 补充测试文件包级文档和每个测试函数的场景说明

## 附带修复
- 修复 `GetAvailableTools` 返回 `nil` 而非空切片（JSON 序列化为 `[]` 而非 `null`）
- 修复 `TestToolTimeout` 中 deadline 断言死代码，改为 panic 触发
- `InputSchema` 类型从 `interface{}` 迁移为 `any`

## Test Plan
- [x] `go build ./...` 编译通过
- [x] `go test ./...` 全部通过
- [x] `go vet ./...` 无警告