### PR TITLE
feat: add streaming support (RunStream + GenerateStream)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# pre-commit hook: run gofmt check on all staged .go files.
+# Rejects the commit if any file is not formatted.
+#
+# Install: git config core.hooksPath .githooks
+
+staged=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')
+if [ -z "$staged" ]; then
+	exit 0
+fi
+
+unformatted=""
+for f in $staged; do
+	output=$(gofmt -l "$f" 2>/dev/null)
+	if [ -n "$output" ]; then
+		unformatted="$unformatted\n  $f"
+	fi
+done
+
+if [ -n "$unformatted" ]; then
+	echo "❌ pre-commit: gofmt check failed. Run 'gofmt -w' on these files:$unformatted"
+	echo ""
+	echo "  gofmt -w$unformatted"
+	exit 1
+fi
+
+exit 0

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -1,18 +1,8 @@
-// Package main 是 harness9 agent 二进制的入口点（Entry Point）。
-// 它按照依赖顺序组装核心组件 — 环境配置加载、LLM Provider、Tool Registry 和 Agent Engine —
-// 并启动 Agent Loop 执行用户任务。
-//
-// 启动流程：
-//
-//  1. 确定物理工作路径（WorkDir）
-//  2. 从 .env 文件加载环境变量（API Key、Base URL 等）
-//  3. 创建 LLM Provider（模型后端适配器）
-//  4. 创建 Tool Registry 并注册内置工具
-//  5. 组装 Agent Engine 并启动主循环
 package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -21,53 +11,83 @@ import (
 	"github.com/harness9/internal/engine"
 	"github.com/harness9/internal/env"
 	"github.com/harness9/internal/provider"
+	"github.com/harness9/internal/schema"
 	"github.com/harness9/internal/tools"
 )
 
 func main() {
-	// Step 1: 获取物理工作路径，作为 agent 的操作沙箱（Sandbox）边界。
-	// 所有工具（如文件读取）的访问范围被限制在此目录树内。
 	workDir, err := os.Getwd()
 	if err != nil {
 		log.Fatalf("[main] 获取工作目录失败: %v", err)
 	}
 
-	// Step 2: 加载 .env 环境变量配置。
-	// 从项目根目录读取 .env 文件，提取 API Key 和 Base URL 等敏感配置。
-	// 已存在的系统环境变量不会被覆盖（系统级 > 文件级）。
 	if err := env.Load(filepath.Join(workDir, ".env")); err != nil {
 		log.Fatalf("[main] 加载环境配置失败: %v", err)
 	}
 
-	// Step 3: 初始化 LLM Provider（大模型后端适配器）。
-	// 当前使用 OpenAI 兼容端点，通过 OPENAI_API_KEY 和 OPENAI_BASE_URL
-	// 环境变量配置认证和端点，可灵活对接 OpenAI / Azure / OpenRouter 等服务。
 	llm, err := provider.NewOpenAIProvider("openai/gpt-5.4-mini")
 	if err != nil {
 		log.Fatalf("[main] 创建 Provider 失败: %v", err)
 	}
 
-	// Step 4: 创建工具注册表（Tool Registry）并注册内置工具。
-	// Registry 是引擎与工具系统之间的桥梁，负责工具发现与执行分发。
 	registry := tools.NewRegistry()
-
-	// 注册 ReadFile 工具：提供受限工作区内的安全文件读取能力。
 	readFileTool := tools.NewReadFileTool(workDir)
 	registry.Register(readFileTool)
 
-	// Step 5: 创建 Agent Engine（核心编排器）。
-	// 参数 enableThinking=false 表示使用标准单阶段 ReAct 模式。
-	// 设置为 true 则启用两阶段 Thinking-Action 模式（慢思考 + 精准行动）。
 	eng := engine.NewAgentEngine(llm, registry, workDir, false)
 
-	// Step 6: 构造用户任务并启动 Agent Loop。
-	// 设置 5 分钟全局超时，防止 LLM 陷入无限循环消耗 Token。
 	prompt := "查看下我当前的工作路径下 poem.txt 文件，总结其核心内容"
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	err = eng.Run(ctx, prompt)
-	if err != nil {
+	useStream := len(os.Args) > 1 && os.Args[1] == "stream"
+
+	if useStream {
+		fmt.Println("=== 流式调用模式 ===")
+		runStream(ctx, eng, prompt)
+	} else {
+		fmt.Println("=== 阻塞式调用模式 ===")
+		runBlocking(ctx, eng, prompt)
+	}
+}
+
+func runBlocking(ctx context.Context, eng *engine.AgentEngine, prompt string) {
+	if err := eng.Run(ctx, prompt); err != nil {
 		log.Fatalf("[main] 引擎异常退出: %v", err)
 	}
+}
+
+func runStream(ctx context.Context, eng *engine.AgentEngine, prompt string) {
+	stream, err := eng.RunStream(ctx, prompt)
+	if err != nil {
+		log.Fatalf("[main] RunStream 启动失败: %v", err)
+	}
+
+	for evt := range stream {
+		switch evt.Type {
+		case engine.EventThinkingDelta:
+			fmt.Print(evt.Data.(string))
+		case engine.EventActionDelta:
+			fmt.Print(evt.Data.(string))
+		case engine.EventToolStart:
+			if tc, ok := evt.Data.(schema.ToolCall); ok {
+				fmt.Printf("\n[tool-start] %s (%s)\n", tc.Name, tc.ID)
+			}
+		case engine.EventToolResult:
+			if tr, ok := evt.Data.(schema.ToolResult); ok {
+				fmt.Printf("\n[tool-result] %s\n", truncStr(tr.Output, 200))
+			}
+		case engine.EventDone:
+			fmt.Println("\n[done]")
+		case engine.EventError:
+			fmt.Printf("\n[error] %v\n", evt.Data)
+		}
+	}
+}
+
+func truncStr(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
 }

--- a/docs/核心功能/agent-loop.md
+++ b/docs/核心功能/agent-loop.md
@@ -42,11 +42,14 @@ harness9 的核心是一个 **Two-Stage ReAct** 循环引擎，将传统 Reasoni
 | 组件 | 代码位置 | 职责 |
 |------|---------|------|
 | `schema` | `internal/schema/message.go` | 定义跨组件共享的核心数据类型 |
-| `LLMProvider` | `internal/provider/interface.go` | 抽象 LLM 通信层，封装 API 差异 |
+| `schema.StreamChunk` | `internal/schema/stream.go` | Provider 层流式增量数据类型 |
+| `LLMProvider` | `internal/provider/interface.go` | 抽象 LLM 通信层，封装 API 差异（含阻塞 + 流式） |
 | `OpenAIProvider` | `internal/provider/openai.go` | OpenAI 兼容 API 适配器（OpenAI / OpenRouter / Azure） |
-| `ClaudeProvider` | `internal/provider/anthropic.go` | Anthropic 兼容 API 适配器（Anthropic / OpenRouter） |
+| `AnthropicProvider` | `internal/provider/anthropic.go` | Anthropic 兼容 API 适配器（Anthropic / OpenRouter） |
 | `Registry` | `internal/tools/registry.go` | 解耦工具发现与执行 |
-| `AgentEngine` | `internal/engine/agent_loop.go` | 编排 Two-Stage ReAct 主循环，驱动各组件协作 |
+| `AgentEngine.Run` | `internal/engine/agent_loop.go` | 阻塞式 Two-Stage ReAct 主循环 |
+| `AgentEngine.RunStream` | `internal/engine/stream.go` | 流式 Two-Stage ReAct 主循环，逐 token 输出 |
+| `engine.Event` | `internal/engine/stream.go` | 引擎面向客户端的流式事件类型 |
 | `env` | `internal/env/env.go` | 基于 .env 文件的环境变量配置加载 |
 
 ## 2. Two-Stage ReAct 设计理念
@@ -184,6 +187,79 @@ Role (string)
 - **`ToolDefinition.InputSchema` 使用 `interface{}`**：不同 LLM SDK 对工具参数格式要求不同（OpenAI 需要 `shared.FunctionParameters`，Anthropic 需要 `map[string]any`），使用 `interface{}` 允许各 Provider 实现直接传递原生 `map[string]interface{}`，避免额外的 JSON 往返序列化开销。各 Provider 内部负责类型转换（`convertToFunctionParameters` / `extractSchemaFields`）。
 - **`ToolCallID` 关联机制**：工具执行结果 (Observation) 通过 `ToolCallID` 与原始 `ToolCall` 关联。
 - **`ToolResult.IsError` 自愈标记**：当工具执行失败时，引擎将错误暴露给 LLM，使其能尝试修正参数并重试（Self-Healing）。
+
+### 3.3 流式数据类型
+
+#### Provider 层 — `schema.StreamChunk`（`internal/schema/stream.go`）
+
+Provider 通过 `GenerateStream` 方法返回 `<-chan StreamChunk`，每个 chunk 代表 LLM 的一次增量产出：
+
+```
+StreamChunk
+├── Type     StreamChunkType  chunk 类型标识
+├── Delta    string           文本增量（text_delta 时有效）
+├── ToolCall *ToolCallDelta   工具调用增量（tool_call_start/delta 时有效）
+├── Message  *Message         完整响应（done 时有效）
+└── Error    string           错误信息（error 时有效）
+
+ToolCallDelta
+├── Index     int             工具调用在数组中的索引
+├── ID        string          工具调用 ID（start 时有效）
+├── Name      string          工具名称（start 时有效）
+└── Arguments json.RawMessage 参数增量（delta 时有效）
+```
+
+**chunk 类型生命周期：**
+
+```
+text_delta ──────────────────────┐    (多次，逐 token)
+                                  │
+tool_call_start ─── tool_call_delta ──┤    (每个工具调用重复此模式)
+                                  │
+                                  ▼
+                               done      (流结束，携带完整 Message)
+```
+
+| StreamChunkType | 含义 | 携带数据 |
+|----------------|------|---------|
+| `text_delta` | 文本增量，逐 token | `Delta` |
+| `tool_call_start` | 新工具调用开始 | `ToolCall.ID`, `ToolCall.Name` |
+| `tool_call_delta` | 工具参数 JSON 增量 | `ToolCall.Arguments`（部分 JSON） |
+| `done` | 流结束 | `Message`（完整响应，含 ToolCalls） |
+| `error` | 出错 | `Error` |
+
+#### Engine 层 — `engine.Event`（`internal/engine/stream.go`）
+
+引擎通过 `RunStream` 方法返回 `<-chan Event`，将 Provider 的底层 StreamChunk 转化为面向客户端的语义事件：
+
+```
+Event
+├── Type EventType  事件类型
+├── Turn int        当前 Turn 编号
+└── Data any        事件载荷（类型随 Type 变化）
+```
+
+| EventType | 含义 | Data 类型 |
+|-----------|------|----------|
+| `thinking_delta` | Thinking 阶段的文本增量 | `string` |
+| `action_delta` | Action 阶段的文本增量 | `string` |
+| `tool_start` | 工具开始执行 | `*schema.ToolCallDelta`（含 Name、ID） |
+| `tool_result` | 工具执行完成 | `schema.ToolResult` |
+| `done` | 循环正常结束 | `nil` |
+| `error` | 出错 | `string` |
+
+**事件流转示例：**
+
+```
+Turn 1:
+  thinking_delta × N    ← Phase 1 逐 token 思考
+  action_delta × N      ← Phase 2 逐 token 行动（含工具调用请求）
+  tool_start            ← 工具开始执行
+  tool_result           ← 工具执行完成
+Turn 2:
+  action_delta × N      ← 最终回复（无工具调用）
+  done                  ← 循环结束
+```
 
 ## 4. Agent Loop 循环流程
 
@@ -381,22 +457,110 @@ for i, toolCall := range responseMsg.ToolCalls {
 }
 ```
 
+### 4.8 流式架构（`RunStream`）
+
+`RunStream` 是 `Run` 的流式对应方法，共享相同的 Two-Stage ReAct 循环逻辑，但通过 Go channel 逐事件输出。核心数据流：
+
+```
+┌─────────────┐  GenerateStream()  ┌──────────────────┐
+│  LLMProvider │ ───────────────── │  chan StreamChunk  │
+│  (OpenAI /   │                   │  (逐 token delta)  │
+│   Anthropic) │                   └────────┬─────────┘
+└─────────────┘                             │
+                                            ▼
+                                   ┌──────────────────┐
+                                   │   streamPhase()   │
+                                   │   读 StreamChunk   │
+                                   │   转发为 Event     │
+                                   └────────┬─────────┘
+                                            │
+                                            ▼
+┌─────────────┐  Execute()         ┌──────────────────┐
+│  Registry    │ ─────────────────  │    chan Event     │
+│  (工具执行)   │                    │  (面向客户端)      │
+└─────────────┘                    └────────┬─────────┘
+                                            │
+                                            ▼
+                                   ┌──────────────────┐
+                                   │   客户端消费者     │
+                                   │   (CLI / 飞书 /   │
+                                   │    SSE handler)   │
+                                   └──────────────────┘
+```
+
+**`streamPhase` 方法**是 `RunStream` 的核心，替代阻塞模式中直接调用 `Generate` 的位置。它调用 `GenerateStream`，从 `StreamChunk` channel 中读取并转发为语义化的 `Event`：
+
+```go
+func (e *AgentEngine) streamPhase(ctx context.Context, ch chan<- Event,
+    turn int, deltaType EventType, history []schema.Message,
+    tools []schema.ToolDefinition) *schema.Message {
+
+    stream, err := e.provider.GenerateStream(ctx, history, tools)
+    // ... 从 stream 读取，转发 text_delta → Event{Type: deltaType}
+    // ... 累积完整 Message（StreamChunkDone 携带）
+    return msg
+}
+```
+
+**流式工具执行**使用 `executeToolsStreaming`，在工具启动和完成时发送事件：
+
+```go
+sendEvent(ctx, ch, Event{Type: EventToolStart, Turn: turn, Data: tc})
+// ... 执行工具
+sendEvent(ctx, ch, Event{Type: EventToolResult, Turn: turn, Data: result})
+```
+
+**context 取消感知**：所有 channel 发送都通过 `select` 监听 `ctx.Done()`，确保取消时不会阻塞：
+
+```go
+func sendEvent(ctx context.Context, ch chan<- Event, evt Event) bool {
+    select {
+    case <-ctx.Done():
+        return false
+    case ch <- evt:
+        return true
+    }
+}
+```
+
 ## 5. 接口抽象与解耦设计
 
 ### 5.1 LLMProvider 接口
 
 ```go
 type LLMProvider interface {
+    // 阻塞式调用：返回完整响应 Message
     Generate(ctx context.Context, messages []schema.Message,
              availableTools []schema.ToolDefinition) (*schema.Message, error)
+
+    // 流式调用：通过 channel 逐 chunk 返回增量
+    GenerateStream(ctx context.Context, messages []schema.Message,
+                   availableTools []schema.ToolDefinition) (<-chan schema.StreamChunk, error)
 }
 ```
 
 **设计理念：**
 - `availableTools` 参数支持 `nil`（Phase 1 剥夺工具）和非空（Phase 2 恢复工具）
 - 引擎只依赖接口，切换模型只需替换 Provider 实现
+- 双模式共存：`Generate` 用于阻塞场景，`GenerateStream` 用于流式场景
+- `GenerateStream` 返回的 channel 在流结束后自动关闭，最后一个有效 chunk 的 Type 为 `StreamChunkDone`
 
 ### 5.2 具体实现
+
+两个 Provider 均采用 **统一的消息转换层** 架构，`Generate` 和 `GenerateStream` 共享同一套转换逻辑：
+
+```
+                    ┌──────────────────┐
+                    │  convertMessages  │ ← schema.Message → SDK 原生消息
+                    │  convertTools     │ ← schema.ToolDefinition → SDK 原生工具
+                    └───────┬──────────┘
+                            │
+               ┌────────────┼─────────────┐
+               ▼                           ▼
+        Generate()                 GenerateStream()
+        SDK.New()                  SDK.NewStreaming()
+        → *Message                 → chan StreamChunk
+```
 
 #### OpenAIProvider（`internal/provider/openai.go`）
 
@@ -423,7 +587,23 @@ p, err := provider.NewOpenAIProvider("gpt-4o")
 
 `InputSchema` 的 `interface{}` → `shared.FunctionParameters` 转换由 `convertToFunctionParameters` 函数完成：优先尝试直接类型断言，失败时通过 JSON 往返转换并报告错误。
 
-#### ClaudeProvider（`internal/provider/anthropic.go`）
+**流式实现：**
+
+`GenerateStream` 使用 OpenAI SDK 的 `client.Chat.Completions.NewStreaming()` 返回 `*ssestream.Stream[ChatCompletionChunk]`。内部使用 `openaiToolCallAccumulator` 累积工具调用参数：
+
+```go
+stream := p.client.Chat.Completions.NewStreaming(ctx, reqParams)
+
+for stream.Next() {
+    chunk := stream.Current()
+    // 1. delta.Content → StreamChunkTextDelta
+    // 2. delta.ToolCalls[].ID != "" → StreamChunkToolCallStart
+    // 3. delta.ToolCalls[].Function.Arguments → StreamChunkToolCallDelta
+}
+// 流结束后发送 StreamChunkDone（含完整 Message）
+```
+
+#### AnthropicProvider（`internal/provider/anthropic.go`）
 
 Anthropic 兼容实现，支持 Anthropic 官方和 OpenRouter 等 Anthropic 兼容端点：
 
@@ -445,6 +625,16 @@ p, err := provider.NewAnthropicProvider("claude-sonnet-4-20250514", 4096)
 | ToolUseBlock 的 Input 类型 | `json.Unmarshal` 将 `Arguments` 解析为 `map[string]interface{}` |
 | `required` 字段类型 | `extractSchemaFields` 安全处理 `[]interface{}` → `[]string` 转换 |
 | `MaxTokens` 必须显式指定 | 通过构造函数参数传入，默认 4096 |
+
+**流式实现：**
+
+`GenerateStream` 使用 Anthropic SDK 的 `client.Messages.NewStreaming()` 返回 `*ssestream.Stream[MessageStreamEventUnion]`。事件类型映射：
+
+| Anthropic 事件 | 处理 |
+|----------------|------|
+| `content_block_start` (type=tool_use) | → `StreamChunkToolCallStart`，记录 ID/Name |
+| `content_block_delta` (type=text_delta) | → `StreamChunkTextDelta` |
+| `content_block_delta` (type=input_json_delta) | → `StreamChunkToolCallDelta`，累积 partial JSON |
 
 两个 Provider 的构造函数均返回 `(*Provider, error)` 而非 `panic`，遵循 Go 的错误处理惯例，允许调用方（如 main）优雅处理配置缺失。
 
@@ -492,9 +682,31 @@ eng := engine.NewAgentEngine(p, r, workDir, true,
 | `WithMaxTurns(n)` | `int` | 50 | 单次 Run 最大 Turn 数，0 = 不限制 |
 | `WithToolTimeout(d)` | `time.Duration` | 60s | 单个工具执行超时，0 = 使用原始 context |
 
+**双模式调用：**
+
+```go
+// 阻塞式：同步等待完整结果
+err := eng.Run(ctx, prompt)
+
+// 流式：通过 channel 逐事件返回
+stream, err := eng.RunStream(ctx, prompt)
+for evt := range stream {
+    switch evt.Type {
+    case engine.EventActionDelta:
+        fmt.Print(evt.Data.(string))  // 逐 token 输出
+    case engine.EventDone:
+        // 循环结束
+    }
+}
+```
+
+两种模式共享同一个 `AgentEngine` 实例和配置，运行时可自由选择。
+
 ## 6. 日志与可观测性
 
-引擎采用结构化日志格式，统一使用 `[engine]` 前缀和 `key=value` 风格：
+引擎采用结构化日志格式，阻塞模式使用 `[engine]` 前缀，流式模式使用 `[engine-stream]` 前缀，统一 `key=value` 风格：
+
+**阻塞模式日志：**
 
 ```
 [engine] 启动 | workdir=/Users/zsa/project thinking=true maxTurns=50 toolTimeout=1m0s
@@ -510,12 +722,29 @@ eng := engine.NewAgentEngine(p, r, workDir, true,
 [engine] 循环结束 | 总Turns=2 | contextMessages=5
 ```
 
+**流式模式日志：**
+
+```
+[engine-stream] 启动 | workdir=/Users/zsa/project thinking=false maxTurns=50 toolTimeout=1m0s
+[engine-stream] Turn 1 | contextMessages=2
+[engine-stream] Turn 1 | Action (tools=1)
+[engine-stream] Turn 1 | 执行 1 个工具调用
+[engine-stream] Turn 1 | 工具启动 | name=read_file id=call_abc
+[engine-stream] Turn 1 | 工具完成 | name=read_file id=call_abc
+[engine-stream] Turn 1 | Observation 注入完成 | contextMessages=4
+[engine-stream] Turn 2 | contextMessages=4
+[engine-stream] Turn 2 | Action (tools=1)
+[engine-stream] Turn 2 | 任务完成，模型未请求工具调用
+```
+
 **日志分层：**
 
 | 层级 | 前缀 | 内容 | 输出方式 |
 |------|------|------|---------|
-| 引擎内部 | `[engine]` | Turn 计数、阶段转换、工具状态 | `log.Printf`（stderr，带时间戳） |
-| 模型输出 | `[thinking]` / `[assistant]` | LLM 产出的文本内容 | `fmt.Printf`（stdout，无时间戳） |
+| 引擎内部（阻塞） | `[engine]` | Turn 计数、阶段转换、工具状态 | `log.Printf`（stderr） |
+| 引擎内部（流式） | `[engine-stream]` | 同上 | `log.Printf`（stderr） |
+| 模型输出（阻塞） | `[thinking]` / `[assistant]` | LLM 产出的文本内容 | `fmt.Printf`（stdout） |
+| 模型输出（流式） | 无前缀 | 通过 Event channel 交给客户端处理 | 由消费者控制 |
 
 ## 7. 完整数据流图
 
@@ -557,10 +786,34 @@ Turn 2:
   → 终止条件满足，循环退出
 ```
 
+### 7.1 流式模式数据流
+
+以相同任务在流式模式（`RunStream`）下为例，客户端通过 Event channel 接收增量：
+
+```
+Turn 1:
+  streamPhase(action) → GenerateStream(ctx, history, [get_weather])
+    Event{action_delta, "让"}       ← 逐 token
+    Event{action_delta, "我"}
+    Event{action_delta, "查询"}
+    Event{tool_start, {name:"get_weather", id:"call_abc"}}
+    Event{tool_start, {name:"get_weather", id:"call_def"}}
+
+  executeToolsStreaming() → 并发执行两个工具
+    Event{tool_result, {output:"北京: 晴, 25°C", ...}}
+    Event{tool_result, {output:"上海: 多云, 22°C", ...}}
+
+Turn 2:
+  streamPhase(action) → GenerateStream(ctx, history, [get_weather])
+    Event{action_delta, "北京今天天气不错"}   ← 逐 token
+    Event{action_delta, "，适合出游！"}
+    Event{done}                              ← 循环结束
+```
+
 ## 8. Provider 实现对比
 
-| 维度 | OpenAIProvider | ClaudeProvider |
-|------|---------------|----------------|
+| 维度 | OpenAIProvider | AnthropicProvider |
+|------|---------------|------------------|
 | API 协议 | Chat Completion | Messages |
 | System prompt | 作为 messages 数组中的 system 消息 | 作为独立 `params.System` 参数 |
 | 工具调用响应 | `ToolCalls[].Function.Arguments`（JSON 字符串） | `Content[]` 中 `tool_use` block 的 `Input`（结构化对象） |
@@ -568,9 +821,13 @@ Turn 2:
 | 工具结果回传 | `openai.ToolMessage(content, toolCallID)` | `anthropic.NewToolResultBlock(toolCallID, content, isError)` |
 | InputSchema 转换 | `convertToFunctionParameters` → `shared.FunctionParameters` | `extractSchemaFields` → `properties` + `required` |
 | MaxTokens | 不需要显式指定 | 必须显式传入 |
-| 构造函数 | `NewOpenAIProvider(model) (*OpenAIProvider, error)` | `NewAnthropicProvider(model, maxTokens) (*ClaudeProvider, error)` |
+| 构造函数 | `NewOpenAIProvider(model) (*OpenAIProvider, error)` | `NewAnthropicProvider(model, maxTokens) (*AnthropicProvider, error)` |
+| 流式 SDK 方法 | `client.Chat.Completions.NewStreaming()` | `client.Messages.NewStreaming()` |
+| 流式 chunk 类型 | `ChatCompletionChunk` | `MessageStreamEventUnion` |
+| 流式文本增量 | `Choices[0].Delta.Content` | `content_block_delta` + `text_delta` |
+| 流式工具增量 | `Choices[0].Delta.ToolCalls[]` | `content_block_start(tool_use)` + `input_json_delta` |
 
-两个 Provider 的消息转换逻辑均实现为 `Generate` 方法，将 `schema.Message` → SDK 原生参数 的映射封装在 Provider 内部，引擎层无需感知 API 差异。
+两个 Provider 的消息转换逻辑均提取为 `convertMessages` / `convertTools` 方法，`Generate` 和 `GenerateStream` 共享同一套转换逻辑。`schema.Message` → SDK 原生参数的映射封装在 Provider 内部，引擎层无需感知 API 差异。
 
 ## 9. 与主流框架的对比
 
@@ -591,7 +848,7 @@ Turn 2:
 | 限制 | 当前状态 | 演进方向 |
 |------|---------|---------|
 | **上下文窗口控制** | 无 token 估算和截断，contextHistory 无限增长 | 双层压缩：micro-compact（清除旧工具输出）+ LLM summarize |
-| **流式输出** | 仅支持非流式 `Generate` | 新增 `Stream` 接口方法，支持 SSE/WebSocket |
+| **流式输出** | ✅ 已实现 `RunStream` + `GenerateStream`，支持逐 token delta | 扩展 SSE HTTP 端点，对接飞书等实时推送渠道 |
 | **权限控制** | 无 | 工具执行前统一 PermissionChecker，支持交互式确认 |
 | **Hook 系统** | 无 | PreToolUse / PostToolUse / Stop / TurnComplete 事件钩子 |
 | **自适应思考** | EnableThinking 为静态配置 | 根据任务复杂度自动决定是否启用 Phase 1 |
@@ -604,10 +861,12 @@ Turn 2:
 | **剥夺-恢复策略** | Phase 1 传 nil tools 剥夺行动能力，Phase 2 恢复工具 |
 | **单消息合并** | Thinking + Action 合并为一条 assistant 消息，保证 API 兼容性 |
 | **接口隔离** | `LLMProvider` 和 `Registry` 各司其职，引擎只依赖抽象 |
+| **双模式共存** | `Run`（阻塞）和 `RunStream`（流式）共享引擎配置，运行时按需选择 |
+| **channel 驱动流式** | Provider → `chan StreamChunk` → Engine → `chan Event`，Go 原生 CSP 模型 |
 | **函数选项** | `WithMaxTurns` / `WithToolTimeout` 可选配置，保持构造函数简洁 |
 | **并发安全** | 索引隔离写入 + WaitGroup + 显式参数传递，无数据竞争 |
 | **三重保障终止** | 自然终止 + MaxTurns 限制 + Context 取消 |
-| **可观测性** | 结构化日志 `[engine]` 前缀 + key=value 格式 |
-| **防御性编程** | Phase 1 ToolCalls 清除、工具独立超时 |
+| **可观测性** | 结构化日志 `[engine]` / `[engine-stream]` 前缀 + key=value 格式 |
+| **防御性编程** | Phase 1 ToolCalls 清除、工具独立超时、流式 context 取消感知 |
 | **延迟解析** | `json.RawMessage` 用于 Arguments 延迟反序列化；`interface{}` 用于 InputSchema 兼容多 SDK |
 | **自愈能力** | `ToolResult.IsError` 支持模型感知错误并自动重试 |

--- a/internal/engine/agent_loop_test.go
+++ b/internal/engine/agent_loop_test.go
@@ -61,6 +61,23 @@ func (p *countingProvider) Generate(_ context.Context, messages []schema.Message
 	return fn(tools), nil
 }
 
+func (p *countingProvider) GenerateStream(ctx context.Context, messages []schema.Message, tools []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	msg, err := p.Generate(ctx, messages, tools)
+	if err != nil {
+		return nil, err
+	}
+
+	ch := make(chan schema.StreamChunk, 2)
+	go func() {
+		defer close(ch)
+		if msg.Content != "" {
+			ch <- schema.StreamChunk{Type: schema.StreamChunkTextDelta, Delta: msg.Content}
+		}
+		ch <- schema.StreamChunk{Type: schema.StreamChunkDone, Message: msg}
+	}()
+	return ch, nil
+}
+
 // staticRegistry 返回固定工具列表，对任何 Execute 调用都返回预设的成功结果。
 // 用于测试中不需要验证工具执行逻辑的场景。
 type staticRegistry struct {

--- a/internal/engine/stream.go
+++ b/internal/engine/stream.go
@@ -1,0 +1,358 @@
+// Package engine 实现了 harness9 的核心 agent loop — 驱动
+// Two-Stage ReAct（Thinking → Action → Observation）循环的编排层。
+//
+// 本文件（stream.go）提供流式输出能力，是 agent_loop.go 中阻塞式 Run 方法的
+// 流式对应。RunStream 通过 Go channel 逐事件输出 agent loop 的运行状态，
+// 使客户端能够实时接收 LLM 逐 token 输出、工具执行进度等信息。
+//
+// # 流式架构
+//
+// 数据流经两层 channel 转换：
+//
+//	Provider.GenerateStream() → chan StreamChunk → streamPhase() → chan Event → 客户端
+//
+// Provider 层产出底层的 token 级增量（StreamChunk），引擎层将其转化为面向客户端的
+// 语义事件（Event），客户端只需关心业务含义，无需处理 SDK 差异。
+//
+// # 与阻塞模式的关系
+//
+// RunStream 与 Run 共享相同的 Two-Stage ReAct 循环逻辑和配置（MaxTurns、ToolTimeout
+// 等），但有以下关键区别：
+//   - Run 使用 provider.Generate（阻塞式），RunStream 使用 provider.GenerateStream（流式）
+//   - Run 通过 fmt.Printf 直接输出文本到 stdout，RunStream 通过 Event channel 输出
+//   - Run 在循环结束后返回 error，RunStream 通过 EventError 事件报告错误
+//   - 两种模式使用不同的日志前缀：[engine] vs [engine-stream]
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/harness9/internal/schema"
+)
+
+// EventType 枚举了引擎面向客户端的流式事件类型。
+// 与 Provider 层的 StreamChunkType 不同，Event 是经过引擎语义化处理的事件：
+// 引擎知道当前处于 Thinking 阶段还是 Action 阶段，将 text_delta 转化为
+// EventThinkingDelta 或 EventActionDelta；引擎在工具执行前后发送
+// EventToolStart 和 EventToolResult。
+type EventType string
+
+const (
+	// EventThinkingDelta 表示 Thinking 阶段的文本增量。
+	// 仅在 EnableThinking == true 时产生。Data 类型为 string（token 文本）。
+	EventThinkingDelta EventType = "thinking_delta"
+
+	// EventActionDelta 表示 Action 阶段的文本增量。
+	// 无论是否启用 Thinking 模式，Action 阶段的文本输出都会触发此事件。
+	// Data 类型为 string（token 文本）。
+	EventActionDelta EventType = "action_delta"
+
+	// EventToolStart 表示引擎开始执行一个工具调用。
+	// 在引擎通过 Registry 分发工具执行时触发（而非 LLM 流式输出工具调用请求时）。
+	// Data 类型为 schema.ToolCall（含 Name、ID、Arguments）。
+	EventToolStart EventType = "tool_start"
+
+	// EventToolResult 表示一个工具执行完成。
+	// 每个并发执行的工具完成后都会独立触发此事件，顺序不固定。
+	// Data 类型为 schema.ToolResult（含 Output、IsError）。
+	EventToolResult EventType = "tool_result"
+
+	// EventDone 表示 agent loop 正常结束。
+	// 当模型不再请求工具调用（自然终止）时触发。Data 为 nil。
+	EventDone EventType = "done"
+
+	// EventError 表示 agent loop 中发生了错误。
+	// 可能的原因：MaxTurns 超限、context 取消、Provider 流式错误等。
+	// Data 类型为 string（错误描述）。
+	EventError EventType = "error"
+)
+
+// Event 是引擎面向客户端的流式事件单元。RunStream 方法返回 <-chan Event，
+// 客户端从 channel 中读取事件来实现实时交互。
+//
+// 典型的消费方式：
+//
+//	for evt := range stream {
+//	    switch evt.Type {
+//	    case engine.EventActionDelta:
+//	        fmt.Print(evt.Data.(string))  // 逐 token 输出
+//	    case engine.EventToolResult:
+//	        result := evt.Data.(schema.ToolResult)
+//	        fmt.Println(result.Output)
+//	    case engine.EventDone:
+//	        // 循环结束
+//	    case engine.EventError:
+//	        log.Fatal(evt.Data.(string))
+//	    }
+//	}
+type Event struct {
+	// Type 事件类型，决定 Data 字段的实际类型。
+	// 参见 EventType 常量的文档说明。
+	Type EventType `json:"type"`
+
+	// Turn 当前事件所属的 Turn 编号。Turn 从 1 开始递增。
+	// 客户端可通过此字段判断当前是第几轮循环。
+	Turn int `json:"turn,omitempty"`
+
+	// Data 事件载荷，类型随 Type 变化：
+	//   - EventThinkingDelta / EventActionDelta → string（token 文本）
+	//   - EventToolStart   → schema.ToolCall（含 Name、ID、Arguments）
+	//   - EventToolResult  → schema.ToolResult（含 Output、IsError）
+	//   - EventDone        → nil
+	//   - EventError       → string（错误描述）
+	Data any `json:"data,omitempty"`
+}
+
+// sendEvent 向 Event channel 发送事件，同时感知 context 取消。
+// 使用 select 监听 ctx.Done()，确保在 context 被取消时不会阻塞在 channel 发送上。
+// 返回 false 表示 context 已取消，调用方应立即退出 goroutine。
+func sendEvent(ctx context.Context, ch chan<- Event, evt Event) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- evt:
+		return true
+	}
+}
+
+// RunStream 是 Run 的流式对应方法，通过 Go channel 逐事件输出 agent loop 的运行状态。
+//
+// 与 Run 的核心区别：
+//   - Run 调用 provider.Generate（阻塞等待完整响应），RunStream 调用 provider.GenerateStream（逐 token 增量）
+//   - Run 通过 fmt.Printf 直接输出文本，RunStream 通过 Event channel 输出，由消费者决定展示方式
+//   - Run 返回 error，RunStream 通过 EventError 事件报告错误
+//
+// 内部启动一个独立的 goroutine 运行主循环，返回只读 channel 供消费者读取。
+// channel 在循环结束（正常或异常）后自动关闭。
+//
+// 参数和配置与 Run 完全一致，两种模式共享同一个 AgentEngine 实例。
+func (e *AgentEngine) RunStream(ctx context.Context, userPrompt string) (<-chan Event, error) {
+	ch := make(chan Event)
+
+	go func() {
+		defer close(ch)
+
+		log.Printf("[engine-stream] 启动 | workdir=%s thinking=%v maxTurns=%d toolTimeout=%v",
+			e.WorkDir, e.EnableThinking, e.MaxTurns, e.ToolTimeout)
+
+		// 初始化对话上下文，与 Run 保持一致：
+		// 注入 system prompt（含工作区路径）定义 agent 身份，附上用户任务描述。
+		contextHistory := []schema.Message{
+			{
+				Role: schema.RoleSystem,
+				Content: fmt.Sprintf(
+					"You are harness9, an expert coding assistant. "+
+						"You have full access to tools in the workspace. "+
+						"Your working directory is: %s",
+					e.WorkDir,
+				),
+			},
+			{
+				Role:    schema.RoleUser,
+				Content: userPrompt,
+			},
+		}
+
+		turnCount := 0
+
+		for {
+			turnCount++
+
+			// --- 安全阀：防止无限循环 ---
+			if e.MaxTurns > 0 && turnCount > e.MaxTurns {
+				sendEvent(ctx, ch, Event{Type: EventError, Data: fmt.Sprintf("已达最大 Turn 数 (%d)", e.MaxTurns)})
+				return
+			}
+
+			// 检查 context 是否已取消（支持超时和手动中断）
+			select {
+			case <-ctx.Done():
+				sendEvent(ctx, ch, Event{Type: EventError, Data: ctx.Err().Error()})
+				return
+			default:
+			}
+
+			log.Printf("[engine-stream] Turn %d | contextMessages=%d", turnCount, len(contextHistory))
+
+			availableTools := e.registry.GetAvailableTools()
+
+			var responseMsg *schema.Message
+
+			if e.EnableThinking {
+				// Phase 1: Thinking — 使用 EventThinkingDelta 转发 token 增量
+				thinkMsg := e.streamPhase(ctx, ch, turnCount, EventThinkingDelta, contextHistory, nil)
+				if thinkMsg == nil {
+					return
+				}
+				log.Printf("[engine-stream] Turn %d | Phase 1 完成 | 思考长度=%d chars", turnCount, len(thinkMsg.Content))
+
+				// 构建临时上下文，将 Phase 1 思考注入 Phase 2 调用。
+				// 与 Run 的逻辑一致：思考仅在 Phase 2 调用期间存在，不持久化到主 contextHistory。
+				phase2History := make([]schema.Message, len(contextHistory), len(contextHistory)+1)
+				copy(phase2History, contextHistory)
+				phase2History = append(phase2History, *thinkMsg)
+
+				// Phase 2: Action — 使用 EventActionDelta 转发 token 增量
+				responseMsg = e.streamPhase(ctx, ch, turnCount, EventActionDelta, phase2History, availableTools)
+				if responseMsg == nil {
+					return
+				}
+
+				// 合并 Thinking + Action 为单条 assistant 消息（避免连续 assistant 消息）
+				merged := &schema.Message{
+					Role:      schema.RoleAssistant,
+					Content:   joinContent(thinkMsg.Content, responseMsg.Content),
+					ToolCalls: responseMsg.ToolCalls,
+				}
+				responseMsg = merged
+
+				log.Printf("[engine-stream] Turn %d | Two-Stage 合并完成 | thinking=%d chars action=%d chars toolCalls=%d",
+					turnCount, len(thinkMsg.Content), len(responseMsg.Content), len(responseMsg.ToolCalls))
+			} else {
+				// 标准 ReAct 模式：单阶段，直接使用 EventActionDelta
+				log.Printf("[engine-stream] Turn %d | Action (tools=%d)", turnCount, len(availableTools))
+				responseMsg = e.streamPhase(ctx, ch, turnCount, EventActionDelta, contextHistory, availableTools)
+				if responseMsg == nil {
+					return
+				}
+			}
+
+			contextHistory = append(contextHistory, *responseMsg)
+
+			// --- 终止条件检测：模型不再请求工具调用 ---
+			if len(responseMsg.ToolCalls) == 0 {
+				log.Printf("[engine-stream] Turn %d | 任务完成，模型未请求工具调用", turnCount)
+				sendEvent(ctx, ch, Event{Type: EventDone})
+				return
+			}
+
+			// --- ToolCall 阶段（并发执行，带独立超时，同时发送事件） ---
+			results := e.executeToolsStreaming(ctx, ch, turnCount, responseMsg.ToolCalls)
+
+			// --- Observation 阶段：将工具结果追加到上下文 ---
+			for i, toolCall := range responseMsg.ToolCalls {
+				observationMsg := schema.Message{
+					Role:       schema.RoleUser,
+					Content:    results[i].Output,
+					ToolCallID: toolCall.ID,
+				}
+				contextHistory = append(contextHistory, observationMsg)
+			}
+
+			log.Printf("[engine-stream] Turn %d | Observation 注入完成 | contextMessages=%d",
+				turnCount, len(contextHistory))
+		}
+	}()
+
+	return ch, nil
+}
+
+// streamPhase 是 RunStream 中替代直接调用 provider.Generate 的核心方法。
+// 它调用 provider.GenerateStream 获取流式 channel，将底层 StreamChunk 逐个读取
+// 并转换为面向客户端的语义 Event。
+//
+// 工作流程：
+//  1. 调用 provider.GenerateStream 获取 <-chan StreamChunk
+//  2. 从 channel 逐个读取 chunk：
+//     - text_delta → 转发为 deltaType（EventThinkingDelta 或 EventActionDelta）事件
+//     - tool_call_start → 忽略（工具执行事件在 executeToolsStreaming 中发送）
+//     - done → 提取完整的 Message（含累积的 Content 和 ToolCalls）
+//     - error → 发送 EventError 事件并返回 nil
+//  3. 返回累积的完整 Message，供 RunStream 注入到对话上下文
+//
+// deltaType 参数决定文本增量事件的类型：
+//   - Thinking 阶段传入 EventThinkingDelta
+//   - Action 阶段传入 EventActionDelta
+//
+// 返回 nil 表示应终止 RunStream（错误或 context 取消）。
+func (e *AgentEngine) streamPhase(ctx context.Context, ch chan<- Event, turn int, deltaType EventType, history []schema.Message, tools []schema.ToolDefinition) *schema.Message {
+	stream, err := e.provider.GenerateStream(ctx, history, tools)
+	if err != nil {
+		log.Printf("[engine-stream] Turn %d | GenerateStream 失败: %v", turn, err)
+		sendEvent(ctx, ch, Event{Type: EventError, Turn: turn, Data: err.Error()})
+		return nil
+	}
+
+	// 从 Provider 的 StreamChunk channel 中读取并转发。
+	// Provider 在流结束时自动关闭 channel 并在最后一个 StreamChunkDone 中携带完整 Message。
+	var msg *schema.Message
+	for chunk := range stream {
+		switch chunk.Type {
+		case schema.StreamChunkTextDelta:
+			if !sendEvent(ctx, ch, Event{Type: deltaType, Turn: turn, Data: chunk.Delta}) {
+				return nil
+			}
+		case schema.StreamChunkToolCallStart:
+			// 工具调用请求已到达，但实际执行在 executeToolsStreaming 中进行。
+			// EventToolStart 在那里发送，保证语义正确。
+		case schema.StreamChunkDone:
+			msg = chunk.Message
+		case schema.StreamChunkError:
+			log.Printf("[engine-stream] Turn %d | Provider 流式错误: %s", turn, chunk.Error)
+			sendEvent(ctx, ch, Event{Type: EventError, Turn: turn, Data: chunk.Error})
+			return nil
+		}
+	}
+
+	// 防御性检查：Provider 必须在流结束前发送 StreamChunkDone。
+	if msg == nil {
+		sendEvent(ctx, ch, Event{Type: EventError, Turn: turn, Data: "provider stream ended without done chunk"})
+		return nil
+	}
+
+	return msg
+}
+
+// executeToolsStreaming 并发执行所有工具调用，与阻塞模式的 executeToolsConcurrently 逻辑一致，
+// 但在工具启动和完成时通过 Event channel 发送事件，使客户端能够实时感知工具执行进度。
+//
+// 事件发送时序：
+//
+//	EventToolStart(name=read_file, id=call_1)   ← 工具 1 开始
+//	EventToolStart(name=bash, id=call_2)        ← 工具 2 开始
+//	EventToolResult(output=..., id=call_1)       ← 工具 1 完成
+//	EventToolResult(output=..., id=call_2)       ← 工具 2 完成
+//
+// 由于工具并发执行，EventToolResult 的顺序不固定（先完成的先发送）。
+func (e *AgentEngine) executeToolsStreaming(ctx context.Context, ch chan<- Event, turn int, toolCalls []schema.ToolCall) []schema.ToolResult {
+	log.Printf("[engine-stream] Turn %d | 执行 %d 个工具调用", turn, len(toolCalls))
+
+	results := make([]schema.ToolResult, len(toolCalls))
+	var wg sync.WaitGroup
+
+	for i, toolCall := range toolCalls {
+		wg.Add(1)
+		go func(idx int, tc schema.ToolCall) {
+			defer wg.Done()
+
+			// 为每个工具创建带独立超时的子 context。
+			// 超时不影响其他工具执行，仅将当前工具标记为失败。
+			toolCtx := ctx
+			var cancel context.CancelFunc
+			if e.ToolTimeout > 0 {
+				toolCtx, cancel = context.WithTimeout(ctx, e.ToolTimeout)
+				defer cancel()
+			}
+
+			log.Printf("[engine-stream] Turn %d | 工具启动 | name=%s id=%s", turn, tc.Name, tc.ID)
+
+			sendEvent(ctx, ch, Event{Type: EventToolStart, Turn: turn, Data: tc})
+
+			results[idx] = e.registry.Execute(toolCtx, tc)
+
+			if results[idx].IsError {
+				log.Printf("[engine-stream] Turn %d | 工具失败 | name=%s id=%s", turn, tc.Name, tc.ID)
+			} else {
+				log.Printf("[engine-stream] Turn %d | 工具完成 | name=%s id=%s", turn, tc.Name, tc.ID)
+			}
+
+			sendEvent(ctx, ch, Event{Type: EventToolResult, Turn: turn, Data: results[idx]})
+		}(i, toolCall)
+	}
+
+	wg.Wait()
+	return results
+}

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -21,6 +22,11 @@ import (
 //   - System Prompt 不在 messages 数组中，而是作为独立的 system 参数传入
 //   - 响应使用 Content Blocks（text / tool_use）而非单一的 content + tool_calls 结构
 //   - 必须指定 maxTokens 参数（OpenAI 可省略）
+//
+// 内部架构采用统一的消息转换层：Generate 和 GenerateStream 共享同一套 convertMessages /
+// convertTools 转换逻辑，仅在底层 SDK 调用方式上有所不同：
+//   - Generate 使用 client.Messages.New()（阻塞式）
+//   - GenerateStream 使用 client.Messages.NewStreaming()（流式）
 type AnthropicProvider struct {
 	// client Anthropic SDK 客户端，封装了 HTTP 通信、认证和重试逻辑。
 	client anthropic.Client
@@ -30,15 +36,6 @@ type AnthropicProvider struct {
 	maxTokens int64
 }
 
-// NewAnthropicProvider 创建 Anthropic 兼容的 Provider 实例。
-//
-// 参数:
-//   - model: 模型标识符（如 "claude-sonnet-4-20250514"、"anthropic/claude-sonnet-4.6" 等）
-//   - maxTokens: 单次响应的最大 token 数（建议 4096+）
-//
-// 环境变量:
-//   - ANTHROPIC_API_KEY: API 认证密钥，缺失时返回错误
-//   - ANTHROPIC_BASE_URL: API 端点基址，缺失时返回错误
 func NewAnthropicProvider(model string, maxTokens int64) (*AnthropicProvider, error) {
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
@@ -58,17 +55,199 @@ func NewAnthropicProvider(model string, maxTokens int64) (*AnthropicProvider, er
 	}, nil
 }
 
-// Generate 实现 LLMProvider 接口，将内部 schema.Message 转换为 Anthropic SDK 的参数格式，
-// 调用 Messages API 并将响应映射回 schema.Message。
+// Generate 实现 LLMProvider 接口的阻塞式调用。
+// 通过共享的 convertMessages / convertTools 完成类型转换后，
+// 调用 Anthropic SDK 的 Messages API 获取完整响应。
+func (p *AnthropicProvider) Generate(ctx context.Context, msgs []schema.Message, availableTools []schema.ToolDefinition) (*schema.Message, error) {
+	anthropicMsgs, systemPrompt, err := p.convertMessages(msgs)
+	if err != nil {
+		return nil, err
+	}
+	anthropicTools, err := p.convertTools(availableTools)
+	if err != nil {
+		return nil, err
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(p.model),
+		MaxTokens: p.maxTokens,
+		Messages:  anthropicMsgs,
+	}
+
+	if systemPrompt != "" {
+		params.System = []anthropic.TextBlockParam{
+			{Text: systemPrompt},
+		}
+	}
+
+	if len(anthropicTools) > 0 {
+		params.Tools = anthropicTools
+	}
+
+	resp, err := p.client.Messages.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("Anthropic 兼容 API 请求失败: %w", err)
+	}
+
+	return p.extractMessage(resp.Content), nil
+}
+
+// GenerateStream 实现 LLMProvider 接口的流式调用。
+// 使用 Anthropic SDK 的 NewStreaming API，将 MessageStreamEventUnion 逐个读取并转换为
+// 统一的 StreamChunk 通过 channel 输出。
+//
+// Anthropic 流式事件类型映射：
+//   - content_block_start (type=tool_use) → StreamChunkToolCallStart（含 ID、Name）
+//   - content_block_delta (type=text_delta) → StreamChunkTextDelta（文本增量）
+//   - content_block_delta (type=input_json_delta) → StreamChunkToolCallDelta（参数增量）
+//
+// 工具调用参数使用 anthropicToolCallAccumulator 按 Index 累积，
+// Anthropic SDK 通过 input_json_delta 的 PartialJSON 字段逐片段传输参数。
+func (p *AnthropicProvider) GenerateStream(ctx context.Context, msgs []schema.Message, availableTools []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	anthropicMsgs, systemPrompt, err := p.convertMessages(msgs)
+	if err != nil {
+		return nil, err
+	}
+	anthropicTools, err := p.convertTools(availableTools)
+	if err != nil {
+		return nil, err
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(p.model),
+		MaxTokens: p.maxTokens,
+		Messages:  anthropicMsgs,
+	}
+
+	if systemPrompt != "" {
+		params.System = []anthropic.TextBlockParam{
+			{Text: systemPrompt},
+		}
+	}
+
+	if len(anthropicTools) > 0 {
+		params.Tools = anthropicTools
+	}
+
+	stream := p.client.Messages.NewStreaming(ctx, params)
+
+	ch := make(chan schema.StreamChunk)
+	go func() {
+		defer close(ch)
+
+		var contentBuf strings.Builder
+		toolAccs := make(map[int]*anthropicToolCallAccumulator)
+
+		for stream.Next() {
+			event := stream.Current()
+
+			switch event.Type {
+			case "content_block_start":
+				cb := event.AsContentBlockStart()
+				if cb.ContentBlock.Type == "tool_use" {
+					idx := int(cb.Index)
+					toolAccs[idx] = &anthropicToolCallAccumulator{
+						index: idx,
+						id:    cb.ContentBlock.ID,
+						name:  cb.ContentBlock.Name,
+					}
+					if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+						Type: schema.StreamChunkToolCallStart,
+						ToolCall: &schema.ToolCallDelta{
+							Index: idx,
+							ID:    cb.ContentBlock.ID,
+							Name:  cb.ContentBlock.Name,
+						},
+					}) {
+						return
+					}
+				}
+
+			case "content_block_delta":
+				delta := event.AsContentBlockDelta()
+				switch delta.Delta.Type {
+				case "text_delta":
+					td := delta.Delta.AsTextDelta()
+					contentBuf.WriteString(td.Text)
+					if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+						Type:  schema.StreamChunkTextDelta,
+						Delta: td.Text,
+					}) {
+						return
+					}
+				case "input_json_delta":
+					ijd := delta.Delta.AsInputJSONDelta()
+					idx := int(delta.Index)
+					if acc, ok := toolAccs[idx]; ok {
+						acc.args.WriteString(ijd.PartialJSON)
+					}
+					if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+						Type: schema.StreamChunkToolCallDelta,
+						ToolCall: &schema.ToolCallDelta{
+							Index:     idx,
+							Arguments: json.RawMessage(ijd.PartialJSON),
+						},
+					}) {
+						return
+					}
+				}
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			sendStreamChunk(ctx, ch, schema.StreamChunk{
+				Type:  schema.StreamChunkError,
+				Error: fmt.Sprintf("Anthropic 流式错误: %v", err),
+			})
+			return
+		}
+
+		msg := &schema.Message{
+			Role:    schema.RoleAssistant,
+			Content: contentBuf.String(),
+		}
+		for i := 0; i < len(toolAccs); i++ {
+			if acc, ok := toolAccs[i]; ok {
+				msg.ToolCalls = append(msg.ToolCalls, schema.ToolCall{
+					ID:        acc.id,
+					Name:      acc.name,
+					Arguments: []byte(acc.args.String()),
+				})
+			}
+		}
+
+		sendStreamChunk(ctx, ch, schema.StreamChunk{
+			Type:    schema.StreamChunkDone,
+			Message: msg,
+		})
+	}()
+
+	return ch, nil
+}
+
+// anthropicToolCallAccumulator 累积 Anthropic 流式响应中单个工具调用的完整信息。
+// Anthropic SDK 在流式模式下，工具调用的传输分为：
+//   - content_block_start: 包含 Index、ID、Name（在 StreamChunkToolCallStart 中发送）
+//   - input_json_delta: 包含 PartialJSON 片段（在 StreamChunkToolCallDelta 中发送）
+//
+// 使用 Index 作为 key 存储在 map 中，支持多个并行工具调用的独立累积。
+type anthropicToolCallAccumulator struct {
+	index int
+	id    string
+	name  string
+	args  strings.Builder
+}
+
+// convertMessages 将内部 schema.Message 转换为 Anthropic SDK 的消息参数格式。
+// Generate 和 GenerateStream 共享此方法。
 //
 // 转换规则：
-//   - schema.RoleSystem    → params.System (Anthropic 的 system prompt 不在 messages 数组中)
-//   - schema.RoleUser      → anthropic.NewUserMessage (含 ToolResultBlock 或 TextBlock)
-//   - schema.RoleAssistant → anthropic.NewAssistantMessage (含 TextBlock 和 ToolUseBlock)
-//   - schema.ToolDefinition → anthropic.ToolParam
+//   - schema.RoleSystem   → 提取为独立的 systemPrompt 返回值（Anthropic API 要求）
+//   - schema.RoleUser     → anthropic.NewUserMessage（含 ToolResultBlock 或 TextBlock）
+//   - schema.RoleAssistant → anthropic.NewAssistantMessage（含 TextBlock 和 ToolUseBlock）
 //
-// 注意：Anthropic Messages API 要求 system prompt 作为独立参数传入，而非 messages 数组的一部分。
-func (p *AnthropicProvider) Generate(ctx context.Context, msgs []schema.Message, availableTools []schema.ToolDefinition) (*schema.Message, error) {
+// 返回 (anthropicMsgs, systemPrompt, error)，systemPrompt 为空表示无系统提示词。
+func (p *AnthropicProvider) convertMessages(msgs []schema.Message) ([]anthropic.MessageParam, string, error) {
 	var anthropicMsgs []anthropic.MessageParam
 	var systemPrompt string
 
@@ -94,7 +273,7 @@ func (p *AnthropicProvider) Generate(ctx context.Context, msgs []schema.Message,
 			for _, tc := range msg.ToolCalls {
 				var inputMap map[string]interface{}
 				if err := json.Unmarshal(tc.Arguments, &inputMap); err != nil {
-					return nil, fmt.Errorf("unmarshal tool call %q arguments: %w", tc.Name, err)
+					return nil, "", fmt.Errorf("unmarshal tool call %q arguments: %w", tc.Name, err)
 				}
 				blocks = append(blocks, anthropic.ContentBlockParamUnion{
 					OfToolUse: &anthropic.ToolUseBlockParam{
@@ -108,6 +287,17 @@ func (p *AnthropicProvider) Generate(ctx context.Context, msgs []schema.Message,
 				anthropicMsgs = append(anthropicMsgs, anthropic.NewAssistantMessage(blocks...))
 			}
 		}
+	}
+
+	return anthropicMsgs, systemPrompt, nil
+}
+
+// convertTools 将内部 schema.ToolDefinition 转换为 Anthropic SDK 的工具参数格式。
+// 通过 extractSchemaFields 提取 properties 和 required 字段。
+// 返回 nil 表示无工具可用（用于 Phase 1 Thinking 的 nil tools 场景）。
+func (p *AnthropicProvider) convertTools(availableTools []schema.ToolDefinition) ([]anthropic.ToolUnionParam, error) {
+	if len(availableTools) == 0 {
+		return nil, nil
 	}
 
 	var anthropicTools []anthropic.ToolUnionParam
@@ -127,40 +317,24 @@ func (p *AnthropicProvider) Generate(ctx context.Context, msgs []schema.Message,
 		}
 		anthropicTools = append(anthropicTools, anthropic.ToolUnionParam{OfTool: &tp})
 	}
+	return anthropicTools, nil
+}
 
-	params := anthropic.MessageNewParams{
-		Model:     anthropic.Model(p.model),
-		MaxTokens: p.maxTokens,
-		Messages:  anthropicMsgs,
-	}
-
-	if systemPrompt != "" {
-		params.System = []anthropic.TextBlockParam{
-			{Text: systemPrompt},
-		}
-	}
-
-	if len(anthropicTools) > 0 {
-		params.Tools = anthropicTools
-	}
-
-	resp, err := p.client.Messages.New(ctx, params)
-	if err != nil {
-		return nil, fmt.Errorf("Anthropic 兼容 API 请求失败: %w", err)
-	}
-
+// extractMessage 从 Anthropic SDK 的 ContentBlockUnion 切片中提取 schema.Message。
+// 遍历所有 Content Block，合并 text 类型的文本和 tool_use 类型的工具调用。
+func (p *AnthropicProvider) extractMessage(content []anthropic.ContentBlockUnion) *schema.Message {
 	resultMsg := &schema.Message{
 		Role: schema.RoleAssistant,
 	}
 
-	for _, block := range resp.Content {
+	for _, block := range content {
 		switch block.Type {
 		case "text":
 			resultMsg.Content += block.Text
 		case "tool_use":
 			argsBytes, err := json.Marshal(block.Input)
 			if err != nil {
-				return nil, fmt.Errorf("marshal tool_use %q input: %w", block.Name, err)
+				continue
 			}
 			resultMsg.ToolCalls = append(resultMsg.ToolCalls, schema.ToolCall{
 				ID:        block.ID,
@@ -170,11 +344,9 @@ func (p *AnthropicProvider) Generate(ctx context.Context, msgs []schema.Message,
 		}
 	}
 
-	return resultMsg, nil
+	return resultMsg
 }
 
-// extractSchemaFields 从 interface{} 类型的 InputSchema 中提取 properties 和 required 字段。
-// 安全处理 []interface{} 到 []string 的类型转换（JSON 反序列化后 required 的实际类型）。
 func extractSchemaFields(input interface{}) (map[string]any, []string, error) {
 	m, ok := input.(map[string]interface{})
 	if !ok {

--- a/internal/provider/interface.go
+++ b/internal/provider/interface.go
@@ -11,19 +11,54 @@ import (
 // LLMProvider 定义了与大型语言模型交互的统一契约。实现封装了 API 特定细节，
 // 包括认证、端点解析、请求/响应映射、流式传输和重试策略。
 //
-// 引擎在 agent loop 的每个 Turn 中调用 Generate，传入完整的对话上下文和当前可用的
-// 工具集合。Provider 返回一条 assistant Message，可能包含纯文本推理、一个或多个
-// 工具调用请求，或两者的组合。
+// 引擎在 agent loop 的每个 Turn 中调用 Generate 或 GenerateStream，传入完整的对话上下文
+// 和当前可用的工具集合。Provider 返回一条 assistant Message，可能包含纯文本推理、
+// 一个或多个工具调用请求，或两者的组合。
+//
+// 双模式设计：
+//   - Generate: 阻塞式调用，同步返回完整响应，适用于批处理或不需要实时输出的场景
+//   - GenerateStream: 流式调用，通过 channel 逐 chunk 返回增量，适用于实时交互场景
+//
+// 两个方法共享相同的消息转换逻辑（convertMessages / convertTools），
+// 只是底层 SDK 调用方式不同（New vs NewStreaming）。
 type LLMProvider interface {
-	// Generate 将对话历史和可用工具定义发送给 LLM，返回模型的响应 Message。
+	// Generate 将对话历史和可用工具定义发送给 LLM，返回模型的完整响应 Message。
 	//
 	// 参数:
 	//   - ctx: 控制底层 HTTP 调用的取消和超时
 	//   - messages: 完整的对话上下文，包含 system prompt、之前的 user/assistant 消息、
 	//     以及工具 Observation
-	//   - availableTools: 当前 Turn 中模型可调用的工具定义列表
+	//   - availableTools: 当前 Turn 中模型可调用的工具定义列表；
+	//     传入 nil 剥夺所有工具（Phase 1 Thinking），传入非空恢复工具（Phase 2 Action）
 	//
 	// 返回的 Message 中 ToolCalls 字段在模型决定调用工具时填充；否则 Content 包含
 	// 最终文本回复，agent loop 终止。
 	Generate(ctx context.Context, messages []schema.Message, availableTools []schema.ToolDefinition) (*schema.Message, error)
+
+	// GenerateStream 以流式方式调用 LLM，通过 channel 逐 chunk 返回响应增量。
+	//
+	// 参数与 Generate 完全一致。返回的 channel 中每个 chunk 代表 LLM 的一次增量产出：
+	//   - StreamChunkTextDelta: 文本增量（逐 token）
+	//   - StreamChunkToolCallStart: 新工具调用开始（含 ID、Name）
+	//   - StreamChunkToolCallDelta: 工具参数 JSON 增量
+	//   - StreamChunkDone: 流结束，携带完整的 Message
+	//   - StreamChunkError: 出错
+	//
+	// 返回的 channel 会在流结束时自动关闭。调用方必须从 channel 读取直到关闭，
+	// 以确保底层 HTTP 连接被正确释放。
+	GenerateStream(ctx context.Context, messages []schema.Message, availableTools []schema.ToolDefinition) (<-chan schema.StreamChunk, error)
+}
+
+// sendStreamChunk 向 StreamChunk channel 发送 chunk，同时感知 context 取消。
+// 使用 select 监听 ctx.Done()，确保在 context 被取消时（如超时或手动中断）
+// 不会阻塞在 channel 发送上，避免 goroutine 泄漏。
+//
+// 返回 false 表示 context 已取消，调用方应立即退出当前 goroutine。
+func sendStreamChunk(ctx context.Context, ch chan<- schema.StreamChunk, chunk schema.StreamChunk) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case ch <- chunk:
+		return true
+	}
 }

--- a/internal/provider/mock.go
+++ b/internal/provider/mock.go
@@ -15,28 +15,85 @@ import (
 //	Action 调用 1 (tools=[bash]) → 模型发出 bash 工具调用
 //	Action 调用 2 (tools=[bash]) → 模型返回最终文本回复，agent loop 终止
 //
-// 这使得引擎的 agent loop 可以在不依赖真实 LLM API Key 或网络访问的情况下
-// 进行端到端验证，包括 Two-Stage ReAct 的 Thinking 阶段。
-//
-// mockProvider 是线程安全的：使用 atomic.Int32 管理内部状态，支持并发 Generate 调用。
+// mockProvider 是线程安全的：使用 atomic.Int32 管理内部状态，支持并发调用。
+// Generate 和 GenerateStream 共享同一套 simulateResponse 逻辑，确保行为一致。
 type mockProvider struct {
-	// turn 记录非 Thinking 模式下的 Generate 调用次数。
+	// turn 记录非 Thinking 模式下的调用次数。
 	// Thinking 阶段的调用（tools=nil）不计入 turn。
 	turn atomic.Int32
 }
 
-// Generate 模拟 LLM 响应周期。行为根据传入的工具列表和调用次数变化：
-//
-//   - tools 为空（Thinking 阶段）：返回一段深度思考文本，模拟模型在没有工具
-//     的情况下进行推理和规划
-//   - tools 非空，turn==1：模拟首次行动 — 返回 bash 工具调用请求
-//   - tools 非空，turn>1：模拟最终回复 — 返回纯文本，触发 loop 终止
+// Generate 实现 LLMProvider 接口的阻塞式调用。
+// 委托给 simulateResponse 生成确定性响应。
 func (m *mockProvider) Generate(_ context.Context, _ []schema.Message, tools []schema.ToolDefinition) (*schema.Message, error) {
+	return m.simulateResponse(tools), nil
+}
+
+// GenerateStream 实现 LLMProvider 接口的流式调用。
+// 将 simulateResponse 的结果拆分为 StreamChunk 序列通过 channel 发送：
+//   - 文本内容 → StreamChunkTextDelta（一次性发送全部文本）
+//   - 工具调用 → StreamChunkToolCallStart + StreamChunkToolCallDelta
+//   - 结束 → StreamChunkDone（含完整 Message）
+//
+// 这是一个简化的流式模拟：不逐 token 发送，而是一次性发送完整文本。
+// 对于测试而言足够，因为测试关心的是事件类型和顺序，而非增量粒度。
+func (m *mockProvider) GenerateStream(ctx context.Context, _ []schema.Message, tools []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	msg := m.simulateResponse(tools)
+
+	ch := make(chan schema.StreamChunk)
+	go func() {
+		defer close(ch)
+
+		if msg.Content != "" {
+			if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+				Type:  schema.StreamChunkTextDelta,
+				Delta: msg.Content,
+			}) {
+				return
+			}
+		}
+
+		for i, tc := range msg.ToolCalls {
+			if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+				Type: schema.StreamChunkToolCallStart,
+				ToolCall: &schema.ToolCallDelta{
+					Index: i,
+					ID:    tc.ID,
+					Name:  tc.Name,
+				},
+			}) {
+				return
+			}
+			if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+				Type: schema.StreamChunkToolCallDelta,
+				ToolCall: &schema.ToolCallDelta{
+					Index:     i,
+					Arguments: tc.Arguments,
+				},
+			}) {
+				return
+			}
+		}
+
+		sendStreamChunk(ctx, ch, schema.StreamChunk{
+			Type:    schema.StreamChunkDone,
+			Message: msg,
+		})
+	}()
+	return ch, nil
+}
+
+// simulateResponse 根据 tools 参数和内部 turn 计数器生成确定性响应。
+// 行为：
+//   - tools 为空（Thinking 阶段）：返回深度思考文本
+//   - tools 非空，turn==1：返回 bash 工具调用请求
+//   - tools 非空，turn>1：返回纯文本最终回复（触发 loop 终止）
+func (m *mockProvider) simulateResponse(tools []schema.ToolDefinition) *schema.Message {
 	if len(tools) == 0 {
 		return &schema.Message{
 			Role:    schema.RoleAssistant,
 			Content: "【深度思考】目标是检查文件。我不能直接盲猜，我需要先调用 bash 工具执行 ls 命令，看看当前目录下有什么，然后再做定夺。",
-		}, nil
+		}
 	}
 
 	t := m.turn.Add(1)
@@ -47,17 +104,17 @@ func (m *mockProvider) Generate(_ context.Context, _ []schema.Message, tools []s
 			ToolCalls: []schema.ToolCall{
 				{ID: "call_123", Name: "bash", Arguments: []byte(`{"command": "ls -la"}`)},
 			},
-		}, nil
+		}
 	}
 
 	return &schema.Message{
 		Role:    schema.RoleAssistant,
 		Content: "根据工具返回的结果，我看到了 main.go，任务圆满完成！",
-	}, nil
+	}
 }
 
-// NewMockProvider 构造并返回一个新的 mockProvider 实例。turn 计数器从 0 开始，
-// 确保首次 Generate 调用（Thinking 阶段除外）触发 ToolCall 响应。
+// NewMockProvider 构造并返回一个新的 mockProvider 实例。
+// turn 计数器从 0 开始，确保首次调用（Thinking 阶段除外）触发 ToolCall 响应。
 func NewMockProvider() LLMProvider {
 	return &mockProvider{}
 }

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -328,5 +328,3 @@ func convertToFunctionParameters(input interface{}) (shared.FunctionParameters, 
 	}
 	return params, nil
 }
-
-

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/harness9/internal/schema"
 	"github.com/openai/openai-go/v3"
@@ -17,6 +18,11 @@ import (
 //
 // 通过 OPENAI_API_KEY 和 OPENAI_BASE_URL 环境变量配置认证和端点，
 // 使同一实现可灵活对接不同的 OpenAI 兼容服务。
+//
+// 内部架构采用统一的消息转换层：Generate 和 GenerateStream 共享同一套 convertMessages /
+// convertTools 转换逻辑，仅在底层 SDK 调用方式上有所不同：
+//   - Generate 使用 client.Chat.Completions.New()（阻塞式）
+//   - GenerateStream 使用 client.Chat.Completions.NewStreaming()（流式）
 type OpenAIProvider struct {
 	// client OpenAI SDK 客户端，封装了 HTTP 通信、认证和重试逻辑。
 	client openai.Client
@@ -24,14 +30,6 @@ type OpenAIProvider struct {
 	model string
 }
 
-// NewOpenAIProvider 创建 OpenAI 兼容的 Provider 实例。
-//
-// 参数:
-//   - model: 模型标识符（如 "gpt-4o"、"openai/gpt-5.4-mini" 等），直接传递给 API
-//
-// 环境变量:
-//   - OPENAI_API_KEY: API 认证密钥，缺失时返回错误
-//   - OPENAI_BASE_URL: API 端点基址（如 "https://api.openai.com/v1"），缺失时返回错误
 func NewOpenAIProvider(model string) (*OpenAIProvider, error) {
 	apiKey := os.Getenv("OPENAI_API_KEY")
 	if apiKey == "" {
@@ -48,29 +46,192 @@ func NewOpenAIProvider(model string) (*OpenAIProvider, error) {
 	}, nil
 }
 
-// Generate 实现 LLMProvider 接口，将内部 schema.Message 转换为 OpenAI SDK 的参数格式，
-// 调用 Chat Completion API 并将响应映射回 schema.Message。
+// Generate 实现 LLMProvider 接口的阻塞式调用。
+// 通过共享的 convertMessages / convertTools 完成类型转换后，
+// 调用 OpenAI SDK 的 Chat Completions API 获取完整响应。
+func (p *OpenAIProvider) Generate(ctx context.Context, msgs []schema.Message, availableTools []schema.ToolDefinition) (*schema.Message, error) {
+	openaiMsgs := p.convertMessages(msgs)
+	openaiTools, err := p.convertTools(availableTools)
+	if err != nil {
+		return nil, err
+	}
+
+	reqParams := openai.ChatCompletionNewParams{
+		Model:    p.model,
+		Messages: openaiMsgs,
+	}
+	if len(openaiTools) > 0 {
+		reqParams.Tools = openaiTools
+	}
+
+	resp, err := p.client.Chat.Completions.New(ctx, reqParams)
+	if err != nil {
+		return nil, fmt.Errorf("OpenAI 兼容 API 请求失败: %w", err)
+	}
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("OpenAI 兼容 API 返回了空的 Choices")
+	}
+
+	return p.extractMessage(resp.Choices[0].Message), nil
+}
+
+// GenerateStream 实现 LLMProvider 接口的流式调用。
+// 使用 OpenAI SDK 的 NewStreaming API，将 ChatCompletionChunk 逐个读取并转换为
+// 统一的 StreamChunk 通过 channel 输出。
+//
+// 流式处理流程：
+//  1. 调用 convertMessages / convertTools 构建 SDK 请求参数
+//  2. 通过 client.Chat.Completions.NewStreaming() 创建流式连接
+//  3. 在独立 goroutine 中迭代 stream.Next()，处理每个 chunk：
+//     - delta.Content → StreamChunkTextDelta（逐 token 文本）
+//     - delta.ToolCalls[].ID != "" → StreamChunkToolCallStart（新工具调用）
+//     - delta.ToolCalls[].Function.Arguments → StreamChunkToolCallDelta（参数增量）
+//  4. 使用 openaiToolCallAccumulator 按 Index 累积工具调用的完整参数
+//  5. 流结束后发送 StreamChunkDone（含累积完成的完整 Message）
+//
+// 所有 channel 发送都通过 sendStreamChunk 进行，支持 context 取消感知。
+func (p *OpenAIProvider) GenerateStream(ctx context.Context, msgs []schema.Message, availableTools []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	openaiMsgs := p.convertMessages(msgs)
+	openaiTools, err := p.convertTools(availableTools)
+	if err != nil {
+		return nil, err
+	}
+
+	reqParams := openai.ChatCompletionNewParams{
+		Model:    p.model,
+		Messages: openaiMsgs,
+	}
+	if len(openaiTools) > 0 {
+		reqParams.Tools = openaiTools
+	}
+
+	stream := p.client.Chat.Completions.NewStreaming(ctx, reqParams)
+
+	ch := make(chan schema.StreamChunk)
+	go func() {
+		defer close(ch)
+
+		var contentBuf strings.Builder
+		toolAccs := make(map[int]*openaiToolCallAccumulator)
+
+		for stream.Next() {
+			chunk := stream.Current()
+			if len(chunk.Choices) == 0 {
+				continue
+			}
+
+			delta := chunk.Choices[0].Delta
+
+			if delta.Content != "" {
+				contentBuf.WriteString(delta.Content)
+				if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+					Type:  schema.StreamChunkTextDelta,
+					Delta: delta.Content,
+				}) {
+					return
+				}
+			}
+
+			for _, tc := range delta.ToolCalls {
+				idx := int(tc.Index)
+				acc := toolAccs[idx]
+				if acc == nil {
+					acc = &openaiToolCallAccumulator{index: idx}
+					toolAccs[idx] = acc
+				}
+				if tc.ID != "" {
+					acc.id = tc.ID
+					acc.name = tc.Function.Name
+					if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+						Type: schema.StreamChunkToolCallStart,
+						ToolCall: &schema.ToolCallDelta{
+							Index: idx,
+							ID:    tc.ID,
+							Name:  tc.Function.Name,
+						},
+					}) {
+						return
+					}
+				}
+				if tc.Function.Arguments != "" {
+					acc.args.WriteString(tc.Function.Arguments)
+					if !sendStreamChunk(ctx, ch, schema.StreamChunk{
+						Type: schema.StreamChunkToolCallDelta,
+						ToolCall: &schema.ToolCallDelta{
+							Index:     idx,
+							Arguments: json.RawMessage(tc.Function.Arguments),
+						},
+					}) {
+						return
+					}
+				}
+			}
+		}
+
+		if err := stream.Err(); err != nil {
+			sendStreamChunk(ctx, ch, schema.StreamChunk{
+				Type:  schema.StreamChunkError,
+				Error: fmt.Sprintf("OpenAI 流式错误: %v", err),
+			})
+			return
+		}
+
+		msg := &schema.Message{
+			Role:    schema.RoleAssistant,
+			Content: contentBuf.String(),
+		}
+		for i := 0; i < len(toolAccs); i++ {
+			if acc, ok := toolAccs[i]; ok {
+				msg.ToolCalls = append(msg.ToolCalls, schema.ToolCall{
+					ID:        acc.id,
+					Name:      acc.name,
+					Arguments: []byte(acc.args.String()),
+				})
+			}
+		}
+
+		sendStreamChunk(ctx, ch, schema.StreamChunk{
+			Type:    schema.StreamChunkDone,
+			Message: msg,
+		})
+	}()
+
+	return ch, nil
+}
+
+// openaiToolCallAccumulator 累积 OpenAI 流式响应中单个工具调用的完整信息。
+// OpenAI SDK 在流式模式下，每个工具调用的 ID/Name 和 Arguments 分多次 chunk 传输：
+//   - 首个 chunk 包含 ID 和 Name（在 tool_call_start 中发送）
+//   - 后续 chunk 包含 Arguments 的部分 JSON 文本（在 tool_call_delta 中发送）
+//
+// 使用 Index 作为 key 存储在 map 中，支持多个并行工具调用的独立累积。
+type openaiToolCallAccumulator struct {
+	index int
+	id    string
+	name  string
+	args  strings.Builder
+}
+
+// convertMessages 将内部 schema.Message 转换为 OpenAI SDK 的消息参数格式。
+// Generate 和 GenerateStream 共享此方法，避免重复的转换逻辑。
 //
 // 转换规则：
 //   - schema.RoleSystem   → openai.SystemMessage
 //   - schema.RoleUser     → openai.UserMessage 或 openai.ToolMessage（带 ToolCallID 时）
 //   - schema.RoleAssistant → openai.ChatCompletionAssistantMessageParam（含 ToolCalls）
-//   - schema.ToolDefinition → openai.ChatCompletionFunctionTool
-//
-// 返回的 Message 中，ToolCalls 在模型决定调用工具时填充；否则 Content 包含纯文本回复。
-func (p *OpenAIProvider) Generate(ctx context.Context, msgs []schema.Message, availableTools []schema.ToolDefinition) (*schema.Message, error) {
-	var openaiMsgs []openai.ChatCompletionMessageParamUnion
+func (p *OpenAIProvider) convertMessages(msgs []schema.Message) []openai.ChatCompletionMessageParamUnion {
+	var result []openai.ChatCompletionMessageParamUnion
 
 	for _, msg := range msgs {
 		switch msg.Role {
 		case schema.RoleSystem:
-			openaiMsgs = append(openaiMsgs, openai.SystemMessage(msg.Content))
+			result = append(result, openai.SystemMessage(msg.Content))
 
 		case schema.RoleUser:
 			if msg.ToolCallID != "" {
-				openaiMsgs = append(openaiMsgs, openai.ToolMessage(msg.Content, msg.ToolCallID))
+				result = append(result, openai.ToolMessage(msg.Content, msg.ToolCallID))
 			} else {
-				openaiMsgs = append(openaiMsgs, openai.UserMessage(msg.Content))
+				result = append(result, openai.UserMessage(msg.Content))
 			}
 		case schema.RoleAssistant:
 			astParam := openai.ChatCompletionAssistantMessageParam{}
@@ -98,10 +259,20 @@ func (p *OpenAIProvider) Generate(ctx context.Context, msgs []schema.Message, av
 				astParam.ToolCalls = toolCalls
 			}
 
-			openaiMsgs = append(openaiMsgs, openai.ChatCompletionMessageParamUnion{
+			result = append(result, openai.ChatCompletionMessageParamUnion{
 				OfAssistant: &astParam,
 			})
 		}
+	}
+
+	return result
+}
+
+// convertTools 将内部 schema.ToolDefinition 转换为 OpenAI SDK 的工具参数格式。
+// 返回 nil 表示无工具可用（用于 Phase 1 Thinking 的 nil tools 场景）。
+func (p *OpenAIProvider) convertTools(availableTools []schema.ToolDefinition) ([]openai.ChatCompletionToolUnionParam, error) {
+	if len(availableTools) == 0 {
+		return nil, nil
 	}
 
 	var openaiTools []openai.ChatCompletionToolUnionParam
@@ -119,24 +290,12 @@ func (p *OpenAIProvider) Generate(ctx context.Context, msgs []schema.Message, av
 			},
 		))
 	}
+	return openaiTools, nil
+}
 
-	reqParams := openai.ChatCompletionNewParams{
-		Model:    p.model,
-		Messages: openaiMsgs,
-	}
-	if len(openaiTools) > 0 {
-		reqParams.Tools = openaiTools
-	}
-
-	resp, err := p.client.Chat.Completions.New(ctx, reqParams)
-	if err != nil {
-		return nil, fmt.Errorf("OpenAI 兼容 API 请求失败: %w", err)
-	}
-	if len(resp.Choices) == 0 {
-		return nil, fmt.Errorf("OpenAI 兼容 API 返回了空的 Choices")
-	}
-
-	choice := resp.Choices[0].Message
+// extractMessage 从 OpenAI SDK 的 ChatCompletionMessage 中提取 schema.Message。
+// 过滤非 function 类型的 ToolCalls，统一转换为 schema.ToolCall。
+func (p *OpenAIProvider) extractMessage(choice openai.ChatCompletionMessage) *schema.Message {
 	resultMsg := &schema.Message{
 		Role:    schema.RoleAssistant,
 		Content: choice.Content,
@@ -152,11 +311,9 @@ func (p *OpenAIProvider) Generate(ctx context.Context, msgs []schema.Message, av
 		}
 	}
 
-	return resultMsg, nil
+	return resultMsg
 }
 
-// convertToFunctionParameters 将 interface{} 类型的 InputSchema 转换为 OpenAI SDK 要求的
-// shared.FunctionParameters。优先尝试直接类型断言，失败时通过 JSON 往返进行转换。
 func convertToFunctionParameters(input interface{}) (shared.FunctionParameters, error) {
 	if m, ok := input.(map[string]interface{}); ok {
 		return shared.FunctionParameters(m), nil
@@ -171,3 +328,5 @@ func convertToFunctionParameters(input interface{}) (shared.FunctionParameters, 
 	}
 	return params, nil
 }
+
+

--- a/internal/schema/stream.go
+++ b/internal/schema/stream.go
@@ -1,0 +1,100 @@
+// Package schema — 流式数据类型。
+// 本文件定义 Provider 层的流式增量类型（StreamChunk、ToolCallDelta），
+// 用于 GenerateStream 方法通过 channel 逐 chunk 传递 LLM 响应增量。
+package schema
+
+import "encoding/json"
+
+// StreamChunkType 枚举了 LLM 流式响应中可能出现的增量 chunk 类型。
+// 每种类型对应 LLM 流式输出过程中的一个语义阶段，形成完整的流式生命周期：
+//
+//	text_delta ──────────────────────┐    (多次，逐 token 文本)
+//	                                  │
+//	tool_call_start ─── tool_call_delta ──┤    (每个工具调用重复此模式)
+//	                                  │
+//	                                  ▼
+//	                               done      (流结束，携带完整 Message)
+type StreamChunkType string
+
+const (
+	// StreamChunkTextDelta 表示一段文本增量（token-by-token）。
+	// 每次收到此 chunk 时，Delta 字段包含一个 token 的文本内容。
+	// 引擎层会将其映射为 EventThinkingDelta 或 EventActionDelta 事件。
+	StreamChunkTextDelta StreamChunkType = "text_delta"
+
+	// StreamChunkToolCallStart 表示一个新的工具调用开始。
+	// 此时 ToolCall 字段包含工具调用的 Index、ID 和 Name，
+	// 但参数尚未开始传输（Arguments 为空）。
+	StreamChunkToolCallStart StreamChunkType = "tool_call_start"
+
+	// StreamChunkToolCallDelta 表示工具调用参数的 JSON 增量。
+	// ToolCall.Arguments 包含一段部分 JSON 文本，需要累积拼接后
+	// 才能得到完整的参数 JSON。多个 delta chunk 按顺序拼接即可。
+	StreamChunkToolCallDelta StreamChunkType = "tool_call_delta"
+
+	// StreamChunkDone 表示流式响应结束。Message 字段携带完整的响应 Message
+	// （含累积完成的 Content 文本和 ToolCalls 列表），供引擎直接注入到
+	// 对话上下文中，无需再次组装。
+	StreamChunkDone StreamChunkType = "done"
+
+	// StreamChunkError 表示流式过程中发生错误。Error 字段包含错误描述。
+	// 收到此 chunk 后，流可能立即关闭，不应再期待后续 chunk。
+	StreamChunkError StreamChunkType = "error"
+)
+
+// StreamChunk 是 LLM 流式响应的单个增量单元。Provider 通过 GenerateStream 方法
+// 返回 <-chan StreamChunk，引擎和消费者从 channel 中逐个读取以实现实时输出。
+//
+// 每个 chunk 的有效字段取决于 Type：
+//
+//	Type == text_delta         → Delta 有效，包含一个 token 的文本
+//	Type == tool_call_start    → ToolCall 有效，包含 Index、ID、Name
+//	Type == tool_call_delta    → ToolCall 有效，包含 Index、Arguments（部分 JSON）
+//	Type == done               → Message 有效，包含完整的响应 Message
+//	Type == error              → Error 有效，包含错误描述
+type StreamChunk struct {
+	// Type 标识此 chunk 的类型，决定其他字段的有效性。
+	Type StreamChunkType `json:"type"`
+
+	// Delta 文本增量。仅在 Type == text_delta 时有效，包含一个 token 的文本。
+	// 多次 text_delta 的 Delta 拼接即为完整的文本响应。
+	Delta string `json:"delta,omitempty"`
+
+	// ToolCall 工具调用增量信息。在 Type 为 tool_call_start 或 tool_call_delta 时有效。
+	// 工具调用的完整信息需要通过 Index 关联多次 chunk 来累积。
+	ToolCall *ToolCallDelta `json:"tool_call,omitempty"`
+
+	// Message 完整的响应消息。仅在 Type == done 时有效。
+	// Provider 在流结束时将累积的完整 Message 放入此字段，
+	// 引擎可直接使用此 Message 注入到对话上下文中。
+	Message *Message `json:"message,omitempty"`
+
+	// Error 错误描述。仅在 Type == error 时有效。
+	Error string `json:"error,omitempty"`
+}
+
+// ToolCallDelta 描述工具调用的增量信息。LLM 在流式模式下，每个工具调用的
+// 传输分为两个阶段：
+//
+//  1. tool_call_start — 包含 Index、ID、Name，标识一个新的工具调用开始
+//  2. tool_call_delta — 包含 Index、Arguments（部分 JSON），逐步传输参数
+//
+// 消费者需要按 Index 累积同一个工具调用的所有 delta，最终拼接出完整的参数 JSON。
+type ToolCallDelta struct {
+	// Index 工具调用在数组中的位置索引。LLM 可能同时发起多个并行工具调用，
+	// Index 用于将增量 chunk 关联到正确的工具调用。值从 0 开始递增。
+	Index int `json:"index"`
+
+	// ID 工具调用的唯一标识符。仅在 tool_call_start chunk 中有效。
+	// 用于后续将 ToolResult 与原始 ToolCall 关联（Request-Response Matching）。
+	ID string `json:"id,omitempty"`
+
+	// Name 目标工具在 Registry 中的标识符（如 "bash"、"read_file"）。
+	// 仅在 tool_call_start chunk 中有效。
+	Name string `json:"name,omitempty"`
+
+	// Arguments 工具调用参数的部分 JSON 文本。仅在 tool_call_delta chunk 中有效。
+	// 多个 delta 的 Arguments 按顺序拼接后得到完整的 JSON 参数。
+	// 使用 json.RawMessage 延迟解析，与 ToolCall.Arguments 设计一致。
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}

--- a/internal/tools/base.go
+++ b/internal/tools/base.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/harness9/internal/schema"
+)
+
+// BaseTool 定义了所有工具必须实现的核心接口（Tool Interface）。
+// 每个工具需提供：唯一名称、JSON Schema 参数定义、以及同步执行逻辑。
+// 框架通过此接口实现工具的多态调用，无需在引擎层了解具体工具的实现细节。
+type BaseTool interface {
+	// Name 返回工具的唯一标识符，用于 LLM 在 ToolCall 中引用此工具。
+	// 例如 "bash"、"read_file"、"edit" 等。
+	Name() string
+
+	// Definition 返回工具的元信息（ToolDefinition），包含名称、描述和参数 JSON Schema。
+	// 此信息会被转发给 LLM Provider，使模型了解工具的用途和参数格式。
+	Definition() schema.ToolDefinition
+
+	// Execute 执行工具逻辑。args 为 LLM 传递的原始 JSON 参数，
+	// 由具体工具实现负责反序列化和校验。
+	// 返回工具执行的文本输出，或失败时的错误信息。
+	Execute(ctx context.Context, args json.RawMessage) (string, error)
+}

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -11,30 +11,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 
 	"github.com/harness9/internal/schema"
 )
-
-// BaseTool 定义了所有工具必须实现的核心接口（Tool Interface）。
-// 每个工具需提供：唯一名称、JSON Schema 参数定义、以及同步执行逻辑。
-// 框架通过此接口实现工具的多态调用，无需在引擎层了解具体工具的实现细节。
-type BaseTool interface {
-	// Name 返回工具的唯一标识符，用于 LLM 在 ToolCall 中引用此工具。
-	// 例如 "bash"、"read_file"、"edit" 等。
-	Name() string
-
-	// Definition 返回工具的元信息（ToolDefinition），包含名称、描述和参数 JSON Schema。
-	// 此信息会被转发给 LLM Provider，使模型了解工具的用途和参数格式。
-	Definition() schema.ToolDefinition
-
-	// Execute 执行工具逻辑。args 为 LLM 传递的原始 JSON 参数，
-	// 由具体工具实现负责反序列化和校验。
-	// 返回工具执行的文本输出，或失败时的错误信息。
-	Execute(ctx context.Context, args json.RawMessage) (string, error)
-}
 
 // Registry 定义了工具注册表（Tool Registry）的接口，负责工具的注册、发现与执行。
 // 引擎通过此接口与工具系统交互，实现关注点分离：


### PR DESCRIPTION
## Summary
- Add dual-mode architecture: blocking (`Run`/`Generate`) and streaming (`RunStream`/`GenerateStream`) coexist on the same `AgentEngine` instance
- Provider layer: `LLMProvider` interface gains `GenerateStream` returning `<-chan StreamChunk` with per-token deltas; OpenAI and Anthropic implementations use respective SDK streaming APIs
- Engine layer: `RunStream` returns `<-chan Event` with semantic events (`thinking_delta`, `action_delta`, `tool_start`, `tool_result`, `done`, `error`), context-cancellation-aware via `select`
- Refactor Provider internals: extract `convertMessages`/`convertTools` shared by both `Generate` and `GenerateStream`; extract `BaseTool` interface into `base.go`
- Add `schema.StreamChunk`/`ToolCallDelta` types for provider-level streaming, `engine.Event`/`EventType` for engine-level events
- Update `docs/核心功能/agent-loop.md` with streaming architecture, data flow diagrams, and provider streaming details

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./...` all existing tests pass (including `countingProvider.GenerateStream` stub)
- [x] `./harness9` (blocking mode) verified — no regression
- [x] `./harness9 stream` (streaming mode) verified — per-token output, tool events, done signal