### PR TITLE
feat(tools): write_file 改为 atomic write-to-tmp + rename (memory PR #1 / precursor)

### DIFF
--- a/internal/tools/write_file.go
+++ b/internal/tools/write_file.go
@@ -7,6 +7,23 @@
 //     避免 LLM 因 ENOENT 错误而频繁重试。
 //  3. 覆盖写入（Overwrite Semantics）：与 os.WriteFile 一致，目标文件已存在时直接覆盖，
 //     LLM 需在 prompt 层自行判断是否应先 read_file 检查内容再写入。
+//  4. 原子写入（Atomic Write）：使用 write-to-tmp + rename 模式，
+//     避免进程被 kill / 断电 / 中断时留下半写的目标文件。
+//     详见 atomicWriteFile 文档。
+//
+// # Known Limitations
+//
+//   - 原子性仅限同文件系统（POSIX 约束）。tmp 文件强制与目标同 dir 创建
+//     （os.CreateTemp(filepath.Dir(target), ...)）以避免跨 FS 退化成
+//     copy+unlink。如果调用方显式把 memory/ 挂成独立 mount，该目录树
+//     自身仍需在同一个 FS 上才能保证原子性。
+//   - Windows 下 os.Rename 在目标已存在时返回错误（与 POSIX 不同），
+//     atomic overwrite 语义在 Windows 上不成立。harness9 v1 不承诺 Windows
+//     一等支持，相关测试用例使用 runtime.GOOS == "windows" 直接 skip。
+//     正式支持 Windows 时需改走 MoveFileExW 的 MOVEFILE_REPLACE_EXISTING 标志。
+//   - 并发多 writer 写同一文件时，tmp+rename 保证不产生半写文件，但最终内容
+//     是某一方的完整内容（后 rename 者胜出），另一方的修改会丢。这是 "single
+//     writer per file" 假设下的预期行为，业务层需通过 LockPath 避免。
 package tools
 
 import (
@@ -17,6 +34,19 @@ import (
 	"path/filepath"
 
 	"github.com/harness9/internal/schema"
+)
+
+// osCreateTemp / osRename / osFileSync 作为可替换的函数变量，目的是在单元
+// 测试中注入失败分支（例如模拟 rename 失败以验证 tmp 清理 + 目标文件保持原状、
+// 或模拟 fsync 失败以验证不会继续 rename 导致 "rename 了但内容 stale"）。
+// 生产路径始终走标准库实现。
+//
+// 这个模式避免了引入完整的 filesystem abstraction 带来的复杂度，在测试尺度上
+// 足够用。
+var (
+	osCreateTemp = os.CreateTemp
+	osRename     = os.Rename
+	osFileSync   = func(f *os.File) error { return f.Sync() }
 )
 
 // WriteFileTool 实现了 BaseTool 接口，提供受限工作区内的安全文件写入能力。
@@ -71,7 +101,7 @@ type writeFileArgs struct {
 //  1. 反序列化 JSON 参数，提取目标路径与文件内容
 //  2. 通过 safePath 校验并解析为绝对路径（含沙箱边界检查）
 //  3. 自动创建父级目录（若不存在）
-//  4. 以 0644 权限覆盖写入文件
+//  4. 以 0644 权限原子写入文件（write-to-tmp + rename）
 func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var input writeFileArgs
 	if err := json.Unmarshal(args, &input); err != nil {
@@ -93,10 +123,104 @@ func (t *WriteFileTool) Execute(ctx context.Context, args json.RawMessage) (stri
 		return "", fmt.Errorf("创建父目录失败: %w", err)
 	}
 
-	// 覆盖写入（Overwrite Semantics）：与 os.WriteFile 一致，文件已存在时直接覆盖。
-	if err := os.WriteFile(fullPath, []byte(input.Content), 0644); err != nil {
+	// 原子写入（Atomic Write）：write-to-tmp + rename，
+	// 进程被 kill 或磁盘满时不会留下半写的目标文件。
+	if err := atomicWriteFile(fullPath, []byte(input.Content), 0644); err != nil {
 		return "", fmt.Errorf("写入文件失败: %w", err)
 	}
 
 	return fmt.Sprintf("成功将 %d 字节写入到文件: %s", len(input.Content), input.Path), nil
+}
+
+// atomicWriteFile 以原子方式将 data 写入 path：先写入同目录下的 tmp 文件，
+// 成功后通过 os.Rename 原子替换目标。任一步骤失败都会清理 tmp 并保留目标
+// 文件原样（如果存在）。
+//
+// fallbackPerm 是 target 不存在时新建文件所用的权限；target 已存在时会 Stat
+// 原文件继承其 mode，不使用 fallbackPerm（否则覆盖写入会把用户之前 chmod 过
+// 的权限静默还原为默认值）。
+//
+// 关键设计点:
+//
+//   - **tmp 必须与 target 在同一 dir**（os.CreateTemp(filepath.Dir(path), ...)）。
+//     os.Rename 的原子性仅在同文件系统内保证；跨 FS 会退化为 copy+unlink，
+//     进程被 kill 时可能留下部分 copy 完成的目标文件。
+//
+//   - **tmp 名字用 "." 开头**（形如 ".<basename>.tmp.<random>"）。进程中断
+//     留下的 tmp 文件在常规 ls / 图形化文件浏览器中默认不可见，避免用户
+//     误以为是项目残留文件或病毒。
+//
+//   - **权限继承（Permission Preservation）**：target 已存在时 Stat 拿原 mode
+//     并 Chmod 到 tmp，不用 fallbackPerm 覆盖用户意图。target 不存在时才用
+//     fallbackPerm。这一行为和 os.WriteFile 的语义保持一致。
+//
+//   - **fsync → Close → Chmod → Rename** 的顺序：
+//     Sync 把内容刷盘（防止断电后"rename 生效但内容丢失"），
+//     Close 释放 fd，
+//     Chmod 确保目标权限在"落地"时就正确（避免中间出现错误权限窗口），
+//     Rename 原子替换目标。
+//
+//   - **deferred cleanup 是无条件的**，只在成功 rename 后通过 committed flag
+//     跳过。rename 成功后 tmpPath 不再存在，Remove 也不会报错，但显式跳过
+//     可以避免在极少数情况下（例如另一进程快速创建了同名文件）误删。
+//
+// 参见 package-level Known Limitations 了解跨 FS 和 Windows 的限制。
+func atomicWriteFile(path string, data []byte, fallbackPerm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	// 权限继承：如果 target 已存在，用它的 mode；否则用 fallbackPerm。
+	// 这和 os.WriteFile 覆盖行为一致（os.WriteFile 对已存在文件不改 mode）。
+	finalPerm := fallbackPerm
+	if st, err := os.Stat(path); err == nil {
+		finalPerm = st.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("atomic: stat target %s: %w", path, err)
+	}
+
+	// "." 前缀让中断遗留的 tmp 文件默认隐藏，避免误解。
+	// os.CreateTemp 会把 pattern 里的 "*" 替换为随机后缀，生成诸如
+	// ".MEMORY.md.tmp.1234567890" 的完整文件名。
+	tmp, err := osCreateTemp(dir, "."+base+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("atomic: create temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+
+	// committed 在成功 rename 后置 true；defer 里读到 false 就清理 tmp。
+	// 这样无论中途哪一步 return error，tmp 都不会残留。
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("atomic: write tmp %s: %w", tmpPath, err)
+	}
+	// Sync 在 Close 之前：把 page cache 刷到磁盘，防止断电时"rename 已生效
+	// 但内容未真正持久化"的情况 —— 原子性的语义是"要么旧要么新"，不是
+	// "要么旧要么未定义"。Sync 失败（NFS / 坏块设备常见）必须直接早退，
+	// 不能继续 Rename，否则会得到"rename 完成但内容可能 stale"的结果。
+	if err := osFileSync(tmp); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("atomic: sync tmp %s: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("atomic: close tmp %s: %w", tmpPath, err)
+	}
+
+	// Chmod 在 Rename 前：避免目标文件短暂以 CreateTemp 默认的 0600 存在，
+	// 再被改成预期的 mode（期间有可见性/权限错误窗口）。
+	if err := os.Chmod(tmpPath, finalPerm); err != nil {
+		return fmt.Errorf("atomic: chmod tmp %s: %w", tmpPath, err)
+	}
+
+	if err := osRename(tmpPath, path); err != nil {
+		return fmt.Errorf("atomic: rename %s -> %s: %w", tmpPath, path, err)
+	}
+	committed = true
+	return nil
 }

--- a/internal/tools/write_file_test.go
+++ b/internal/tools/write_file_test.go
@@ -3,8 +3,12 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -108,4 +112,395 @@ func TestWriteFileTool_Execute_BadJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for malformed JSON args")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Atomic write semantics — tests below exercise atomicWriteFile directly and
+// through WriteFileTool.Execute. They verify:
+//   - 成功写入后没有 tmp 残留
+//   - 权限继承（target 已存在时保留原 mode；不存在时用 fallback）
+//   - rename 失败时 tmp 清理 + 目标文件保持原状
+//   - tmp 文件创建在 target 同目录（跨 FS 原子性的前提）
+//   - tmp 文件名以 "." 开头（默认隐藏）
+//   - 并发多 writer 写同一路径不产生半写内容
+// ---------------------------------------------------------------------------
+
+// listTmpArtifacts 返回 dir 下所有 name 中含 ".tmp." 的文件，用于检测 tmp 残留。
+func listTmpArtifacts(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir %s: %v", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+func TestWriteFileTool_Atomic_NoTmpResidueOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewWriteFileTool(dir)
+
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"path":"ok.txt","content":"hello"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if residue := listTmpArtifacts(t, dir); len(residue) != 0 {
+		t.Errorf("tmp residue after successful write: %v", residue)
+	}
+}
+
+func TestAtomicWriteFile_PermissionPreservation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file modes differ from POSIX; not enforced for v1")
+	}
+
+	tests := []struct {
+		name         string
+		existingMode os.FileMode // 0 表示 target 不存在
+		fallback     os.FileMode
+		wantMode     os.FileMode
+	}{
+		{
+			name:         "target absent uses fallback 0644",
+			existingMode: 0,
+			fallback:     0644,
+			wantMode:     0644,
+		},
+		{
+			name:         "target absent uses fallback 0600",
+			existingMode: 0,
+			fallback:     0600,
+			wantMode:     0600,
+		},
+		{
+			name:         "target present 0644 preserved despite fallback 0600",
+			existingMode: 0644,
+			fallback:     0600,
+			wantMode:     0644,
+		},
+		{
+			name:         "target present 0755 preserved (e.g. script)",
+			existingMode: 0755,
+			fallback:     0644,
+			wantMode:     0755,
+		},
+		{
+			name:         "target present 0600 preserved",
+			existingMode: 0600,
+			fallback:     0644,
+			wantMode:     0600,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			target := filepath.Join(dir, "target.txt")
+
+			if tc.existingMode != 0 {
+				if err := os.WriteFile(target, []byte("old"), tc.existingMode); err != nil {
+					t.Fatal(err)
+				}
+				// WriteFile 受 umask 影响，显式 Chmod 确保初始 mode 精确。
+				if err := os.Chmod(target, tc.existingMode); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := atomicWriteFile(target, []byte("new"), tc.fallback); err != nil {
+				t.Fatalf("atomicWriteFile: %v", err)
+			}
+
+			st, err := os.Stat(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if st.Mode().Perm() != tc.wantMode {
+				t.Errorf("mode = %v, want %v", st.Mode().Perm(), tc.wantMode)
+			}
+
+			data, err := os.ReadFile(target)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != "new" {
+				t.Errorf("content = %q, want %q", data, "new")
+			}
+		})
+	}
+}
+
+func TestAtomicWriteFile_RenameFailure_LeavesOriginalAndCleansTmp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("rename-over-existing semantics differ on Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("ORIGINAL"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origRename := osRename
+	osRename = func(oldpath, newpath string) error {
+		return errors.New("simulated rename failure")
+	}
+	defer func() { osRename = origRename }()
+
+	err := atomicWriteFile(target, []byte("NEW"), 0644)
+	if err == nil {
+		t.Fatal("expected error from rename failure")
+	}
+	if !strings.Contains(err.Error(), "simulated rename failure") {
+		t.Errorf("error should wrap simulated failure, got: %v", err)
+	}
+
+	// Original content must be intact.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("target should remain %q on rename failure, got %q", "ORIGINAL", got)
+	}
+
+	// Tmp must be cleaned up.
+	if residue := listTmpArtifacts(t, dir); len(residue) != 0 {
+		t.Errorf("tmp residue after failed rename: %v", residue)
+	}
+}
+
+func TestAtomicWriteFile_WriteFailure_LeavesOriginalAndCleansTmp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("write-failure injection uses read-only temp fd technique not portable to Windows")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("ORIGINAL"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Inject a CreateTemp that opens the tmp file read-only, causing Write to fail.
+	// Then fall through to the defer-cleanup path and verify target untouched + tmp gone.
+	origCreateTemp := osCreateTemp
+	osCreateTemp = func(d, pattern string) (*os.File, error) {
+		f, err := origCreateTemp(d, pattern)
+		if err != nil {
+			return nil, err
+		}
+		name := f.Name()
+		// Close original write fd and reopen read-only so Write will fail.
+		_ = f.Close()
+		return os.OpenFile(name, os.O_RDONLY, 0600)
+	}
+	defer func() { osCreateTemp = origCreateTemp }()
+
+	err := atomicWriteFile(target, []byte("NEW"), 0644)
+	if err == nil {
+		t.Fatal("expected error from write failure")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("target should remain %q on write failure, got %q", "ORIGINAL", got)
+	}
+
+	if residue := listTmpArtifacts(t, dir); len(residue) != 0 {
+		t.Errorf("tmp residue after failed write: %v", residue)
+	}
+}
+
+func TestAtomicWriteFile_TmpInSameDir(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(subdir, "target.txt")
+
+	var capturedDir string
+	origCreateTemp := osCreateTemp
+	osCreateTemp = func(d, pattern string) (*os.File, error) {
+		capturedDir = d
+		return origCreateTemp(d, pattern)
+	}
+	defer func() { osCreateTemp = origCreateTemp }()
+
+	if err := atomicWriteFile(target, []byte("x"), 0644); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+	if capturedDir != subdir {
+		t.Errorf("tmp dir = %q, want %q (target dir, for same-FS rename atomicity)", capturedDir, subdir)
+	}
+}
+
+func TestAtomicWriteFile_DotPrefixHidesTmp(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "visible.txt")
+
+	var capturedTmpName string
+	origCreateTemp := osCreateTemp
+	osCreateTemp = func(d, pattern string) (*os.File, error) {
+		f, err := origCreateTemp(d, pattern)
+		if f != nil {
+			capturedTmpName = filepath.Base(f.Name())
+		}
+		return f, err
+	}
+	defer func() { osCreateTemp = origCreateTemp }()
+
+	if err := atomicWriteFile(target, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(capturedTmpName, ".") {
+		t.Errorf("tmp name should start with '.' (hidden from default ls), got %q", capturedTmpName)
+	}
+	if !strings.Contains(capturedTmpName, ".tmp.") {
+		t.Errorf("tmp name should contain '.tmp.' for pattern recognition, got %q", capturedTmpName)
+	}
+}
+
+func TestAtomicWriteFile_Concurrent_NoCorruption(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "concurrent.txt")
+
+	// Two distinct contents large enough that a byte-level half-mix would be
+	// trivially detectable. Each is 1024 bytes + a signature prefix.
+	contentA := []byte("writer-A-" + strings.Repeat("a", 1024))
+	contentB := []byte("writer-B-" + strings.Repeat("b", 1024))
+
+	const iters = 100
+	var wg sync.WaitGroup
+	for i := 0; i < iters; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			if n%2 == 0 {
+				_ = atomicWriteFile(target, contentA, 0644)
+			} else {
+				_ = atomicWriteFile(target, contentB, 0644)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Final content must be exactly one writer's full content — never a prefix,
+	// never a blend.
+	if !bytesEqual(got, contentA) && !bytesEqual(got, contentB) {
+		prefix := got
+		if len(prefix) > 64 {
+			prefix = prefix[:64]
+		}
+		t.Errorf("corrupted final content: len=%d head=%q", len(got), prefix)
+	}
+
+	if residue := listTmpArtifacts(t, dir); len(residue) != 0 {
+		t.Errorf("tmp residue after concurrent writes: %v", residue)
+	}
+}
+
+func TestAtomicWriteFile_SyncFailure_LeavesOriginalAndCleansTmp(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fsync semantics differ on Windows; not enforced for v1")
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("ORIGINAL"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 注入 Sync 失败 (NFS / 坏块设备在生产中会撞到这个路径)。
+	// 正确行为: 直接 return error, 不继续 Rename, 否则会得到
+	// "rename 完成但内容可能 stale" 的假原子性结果。
+	origSync := osFileSync
+	osFileSync = func(f *os.File) error {
+		return errors.New("simulated fsync failure (NFS / bad block)")
+	}
+	defer func() { osFileSync = origSync }()
+
+	err := atomicWriteFile(target, []byte("NEW"), 0644)
+	if err == nil {
+		t.Fatal("expected error from sync failure")
+	}
+	if !strings.Contains(err.Error(), "simulated fsync failure") {
+		t.Errorf("error should wrap simulated sync failure, got: %v", err)
+	}
+	// 关键: 错误消息应该是 sync path, 不是 rename path — 证明早退生效了
+	if !strings.Contains(err.Error(), "sync") {
+		t.Errorf("error should be from sync stage (early-exit, no rename), got: %v", err)
+	}
+
+	// 目标文件必须保持 ORIGINAL (rename 没执行)。
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("target should remain %q on sync failure (no rename should have happened), got %q", "ORIGINAL", got)
+	}
+
+	// tmp 必须清理。
+	if residue := listTmpArtifacts(t, dir); len(residue) != 0 {
+		t.Errorf("tmp residue after failed sync: %v", residue)
+	}
+}
+
+func TestAtomicWriteFile_CreateTempFailure(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("ORIGINAL"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origCreateTemp := osCreateTemp
+	osCreateTemp = func(d, pattern string) (*os.File, error) {
+		return nil, errors.New("simulated create temp failure")
+	}
+	defer func() { osCreateTemp = origCreateTemp }()
+
+	err := atomicWriteFile(target, []byte("NEW"), 0644)
+	if err == nil {
+		t.Fatal("expected error from CreateTemp failure")
+	}
+
+	// Target must be unchanged; nothing to clean up because tmp never existed.
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("target should remain %q, got %q", "ORIGINAL", got)
+	}
+}
+
+// bytesEqual is a tiny helper to avoid pulling "bytes" for one Equal call.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Precursor PR for the memory module (ZSO-1). `write_file` 目前用 `os.WriteFile` 直接写目标文件,进程被 kill / 断电 / 磁盘失败时会留下半写的目标,破坏"要么旧要么新"的原子性承诺。本 PR 改为 **write-to-tmp + rename** 模式,为后续 `MEMORY.md` / `memory/YYYY-MM-DD.md` 的高频写入做好基础设施。

## 为什么现在做

即将要做 harness9 的 memory 模块 (对标 OpenClaw),memory 文件需要频繁更新,如果底层 write 不是原子的,一次 crash 就可能丢掉 agent 的长期记忆。`write_file` 的这个 gap 其实是**全框架公共 fix**,所有工具都受益,不只 memory。按架构师老王的 review 意见作为独立 PR 推,不捆绑到 memory PR 里。

## 关键设计点 (都写进包顶部注释和 `atomicWriteFile` 的 godoc)

- **tmp 必须与 target 在同一 dir** —— `os.CreateTemp(filepath.Dir(target), ...)`。`os.Rename` 原子性仅在同 FS 保证,跨 FS 退化为 copy+unlink。
- **tmp 名以 "." 开头** —— 进程中断遗留的 tmp 对 `ls` / 图形化文件浏览器默认隐藏,避免用户误以为是残留垃圾文件。
- **Sync 在 Close 前** —— NFS / 坏块设备 fsync 失败时**直接早退,不继续 Rename**。否则会得到"rename 完成但内容 stale"的假原子性结果。
- **权限继承 (Permission Preservation)** —— target 已存在时 Stat 拿原 mode,不存在时才用 fallback。和 `os.WriteFile` 覆盖语义一致,不会静默把用户 `chmod 0755` 的脚本还原为 0600。
- **Chmod 在 Rename 前** —— 目标"落地"即正确权限,中间没有错误权限窗口。
- **`committed` flag + deferred cleanup** —— 任一步骤失败 tmp 都不残留。

## 测试注入机制

新增三个包私有函数变量作为 seam:

```go
var (
    osCreateTemp = os.CreateTemp
    osRename     = os.Rename
    osFileSync   = func(f *os.File) error { return f.Sync() }
)
```

让单元测试能注入 CreateTemp / Rename / Sync 失败,验证清理路径。避免引入完整 filesystem abstraction 的复杂度。

## 测试覆盖

原有 6 个 test 保留,新增 10 个 (含 table-driven 子用例):

| Test | 覆盖点 |
|---|---|
| `TestWriteFileTool_Atomic_NoTmpResidueOnSuccess` | 成功写入后目录无 `.tmp.` 残留 |
| `TestAtomicWriteFile_PermissionPreservation` | 5 子用例: fallback 0644/0600; 继承 0644/0755/0600 |
| `TestAtomicWriteFile_RenameFailure_LeavesOriginalAndCleansTmp` | 注入 Rename 失败,target 保持原样 + tmp 清理 |
| `TestAtomicWriteFile_WriteFailure_LeavesOriginalAndCleansTmp` | 注入 CreateTemp 返回只读 fd 触发 Write 失败 |
| `TestAtomicWriteFile_SyncFailure_LeavesOriginalAndCleansTmp` | 注入 Sync 失败,验证早退 + 不 Rename (关键) |
| `TestAtomicWriteFile_CreateTempFailure` | CreateTemp 失败,target 不变 |
| `TestAtomicWriteFile_TmpInSameDir` | 验证 tmp dir == target dir |
| `TestAtomicWriteFile_DotPrefixHidesTmp` | 验证 tmp 名以 `.` 开头 + 含 `.tmp.` |
| `TestAtomicWriteFile_Concurrent_NoCorruption` | 100 goroutine 并发写 A/B 两种 1KB 内容,最终必须是完整一方 |

本地 `go test ./...`:

```
?   	github.com/harness9/cmd/harness9	[no test files]
ok  	github.com/harness9/internal/engine	0.031s
ok  	github.com/harness9/internal/env	0.025s
ok  	github.com/harness9/internal/provider	0.016s
?   	github.com/harness9/internal/schema	[no test files]
ok  	github.com/harness9/internal/tools	0.525s
```

## Known Limitations

写进包顶部注释:

1. 原子性仅限同 FS (tmp 强制同 dir 规避跨 FS 退化)
2. Windows 下 `os.Rename` target-exists 报错,原子 overwrite 语义不成立;harness9 v1 不承诺 Windows 一等支持,相关测试 `runtime.GOOS == "windows"` skip
3. 并发多 writer 不产生半写,但后 rename 者胜出 (单 writer per file 假设,业务层通过 LockPath 避免)

## 跟 memory 模块的关系

- 本 PR 单独合入 master
- 合并后基于 master 开 PR #2 `feat/memory-provider-and-get` (Provider interface + FileProvider.Get + memory_get tool)
- 再合并后开 PR #3 `feat/memory-search-and-autoload` (Search + LoadSessionContext + engine 注入 + design doc 定稿)
- design doc 在 ZSO-1 频道的 attachment 里 (v1 approved by 架构师老王),不在本 PR 内

## Test plan

- [x] 本地 `go test ./...` 全绿
- [ ] Reviewer 走一遍 atomicWriteFile 的 Sync → Close → Chmod → Rename 顺序无误
- [ ] Reviewer 确认测试里 3 个 seam (osCreateTemp / osRename / osFileSync) 的注入方式合理
- [ ] Reviewer 确认 Windows skip 处理 OK, Known Limitations 写清楚

🤖 Generated with [Claude Code](https://claude.com/claude-code)
