### PR TITLE
feat: Agent Skills + Context Engineering + CLI REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,36 @@
 
 ## 核心特性
 
+### 交互式 CLI（默认模式）
+
+直接在终端与 Agent 对话，无需配置飞书：
+
+```
+$ go run ./cmd/harness9
+harness9 │ 输入 "exit" 或按 Ctrl-C 退出
+
+harness9> 帮我分析 internal/engine/agent_loop.go 的结构
+harness9> 列出目录下所有 Go 文件并统计行数
+harness9> exit
+再见！
+```
+
+详见 [CLI 使用指南](docs/核心功能/cli.md)。
+
+### Agent Skills（按需加载的领域知识）
+
+在 `WORK_DIR/skills/` 下放置 Markdown 文件，Agent 启动时感知索引，按需加载全文。遵循 **Progressive Disclosure** 原则，System Prompt 始终精简：
+
+```
+your-project/
+├── skills/
+│   ├── refactor-guide.md    # 重构规范
+│   └── testing-standards.md # 测试标准
+└── AGENTS.md                # 项目级规范（自动注入 System Prompt）
+```
+
+详见 [Agent Skills 设计原理](docs/核心功能/agent-skills.md)。
+
 ### 标准 ReAct 循环
 
 每个 Turn 执行一次 LLM 调用（携带完整工具列表），工具结果作为 Observation 注入上下文，驱动下一轮推理：
@@ -91,9 +121,13 @@ for evt := range stream {
 }
 ```
 
-### 飞书 Bot 接入
+### 飞书 Bot 接入（可选）
 
-通过 WebSocket 长连接接收飞书私聊消息，无需公网 IP 或内网穿透。每条消息触发独立的 Agent 循环，实时推送思考进度和工具调用状态：
+通过 `--feishu` 标志启动飞书 Bot 模式，WebSocket 长连接接收消息，实时推送思考进度：
+
+```bash
+go run ./cmd/harness9 --feishu
+```
 
 ```
 🤔 思考中...
@@ -122,9 +156,9 @@ ToolResult{ToolCallID: id, Output: "command not found: foo", IsError: true}
 ### 环境要求
 
 - Go 1.25+
-- OpenAI 或 Anthropic API Key
+- OpenAI 或兼容 API Key（OpenRouter、Azure 等）
 
-### 安装 & 运行
+### 安装 & 启动 CLI
 
 ```bash
 # 克隆项目
@@ -133,13 +167,72 @@ cd harness9
 
 # 复制并填写 API 配置
 cp .env.example .env
-# 编辑 .env，填入 OPENAI_API_KEY、FEISHU_APP_ID 等配置
+# 编辑 .env，至少填入 OPENAI_API_KEY
 
-# 构建
-go build ./cmd/harness9
-
-# 运行飞书 Bot
+# 启动 CLI（默认模式，无需飞书配置）
 go run ./cmd/harness9
+```
+
+### 配置说明
+
+`.env` 文件：
+
+```env
+OPENAI_API_KEY=sk-...
+
+# 可选：指定 Agent 工作目录（默认为进程 cwd，通常无需设置）
+# WORK_DIR=/Users/yourname/myproject
+
+# 可选：切换模型
+LLM_MODEL=openai/gpt-4o-mini
+
+# 可选：使用 OpenRouter 或其他兼容 API
+# OPENAI_BASE_URL=https://openrouter.ai/api/v1
+```
+
+### 添加 Project Guidelines
+
+在 `WORK_DIR` 根目录放置 `AGENTS.md`，启动时自动注入 System Prompt：
+
+```markdown
+# 我的项目规范
+
+## 技术栈
+- Go 1.25、PostgreSQL 16
+
+## 编码规范
+- 所有函数必须有注释
+- 禁止直接操作数据库，必须通过 Repository 层
+```
+
+### 添加 Skills
+
+在 `WORK_DIR/skills/` 下放置 `.md` 文件：
+
+```markdown
+---
+name: refactor-guide
+description: Use when refactoring Go code — explains team conventions
+---
+
+# 重构规范
+
+1. 先运行 go vet，修复所有 warning
+2. 保持函数不超过 50 行
+...
+```
+
+### 启动飞书 Bot（可选）
+
+需额外配置飞书凭证：
+
+```bash
+# .env 中添加
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+
+# 启动
+go run ./cmd/harness9 --feishu
 ```
 
 ### 测试
@@ -157,7 +250,6 @@ package main
 import (
     "context"
     "log"
-    "time"
 
     "github.com/harness9/internal/engine"
     "github.com/harness9/internal/provider"
@@ -167,7 +259,7 @@ import (
 func main() {
     workDir := "/your/project"
 
-    p, err := provider.NewOpenAIProvider("gpt-4o")
+    p, err := provider.NewOpenAIProvider("gpt-4o-mini")
     if err != nil {
         log.Fatalf("init provider: %v", err)
     }
@@ -178,10 +270,7 @@ func main() {
     registry.Register(tools.NewWriteFileTool(workDir))
     registry.Register(tools.NewEditFileTool(workDir))
 
-    eng := engine.NewAgentEngine(p, registry, workDir,
-        engine.WithMaxTurns(50),
-        engine.WithToolTimeout(30*time.Second),
-    )
+    eng := engine.NewAgentEngine(p, registry, workDir)
 
     if err := eng.Run(context.Background(), "帮我列出当前目录下的所有 Go 文件"); err != nil {
         log.Fatalf("run: %v", err)
@@ -196,6 +285,8 @@ func main() {
 | 模块 | 说明 | 状态 |
 |------|------|:----:|
 | **Engine** | 标准 ReAct 主循环，阻塞 + 流式双模式 | ✅ |
+| **Context** | System Prompt 结构化组装（基础 + AGENTS.md + Skills 索引） | ✅ |
+| **Skills** | Skills 解析、索引、按需加载（`use_skill` 工具） | ✅ |
 | **Provider** | LLM 统一接口，OpenAI / Anthropic 适配器 | ✅ |
 | **Schema** | 跨组件共享的核心数据类型 | ✅ |
 | **Tools** | 工具注册表 + 内置工具（bash / read_file / write_file / edit_file） | ✅ |
@@ -211,15 +302,25 @@ func main() {
 harness9/
 ├── cmd/
 │   └── harness9/
-│       ├── main.go                  # 程序入口，组装各模块并启动飞书 Bot Server
+│       ├── main.go                  # 程序入口：CLI（默认）或飞书 Bot（--feishu）
+│       ├── cli.go                   # 交互式 CLI REPL 实现
 │       ├── bot.go                   # Bot 编排层（IMChannel × AgentEngine，事件流映射）
 │       └── bot_test.go              # Bot 事件映射单元测试
 ├── internal/
 │   ├── engine/
-│   │   ├── agent_loop.go            # 共享 runLoop + 阻塞式 Run
+│   │   ├── agent_loop.go            # 共享 runLoop + 阻塞式 Run + PromptBuilder 接口
 │   │   ├── agent_loop_test.go       # 主循环单元测试
 │   │   ├── stream.go                # 流式入口 RunStream + engine.Event 事件类型
 │   │   └── stream_test.go           # 流式接口单元测试
+│   ├── context/
+│   │   ├── builder.go               # DefaultPromptBuilder（组装 System Prompt）
+│   │   └── builder_test.go
+│   ├── skills/
+│   │   ├── skill.go                 # Skill 数据结构 + frontmatter 解析
+│   │   ├── index.go                 # Index：Summary() + GetFullContent()
+│   │   ├── loader.go                # LoadSkills(dir) → *Index
+│   │   ├── use_skill_tool.go        # use_skill 工具（实现 tools.BaseTool）
+│   │   └── skills_test.go           # Skills 系统单元测试（20 个测试用例）
 │   ├── imchannel/
 │   │   ├── channel.go               # IMChannel / Session 接口定义
 │   │   └── feishu/
@@ -248,13 +349,19 @@ harness9/
 │   │   ├── env.go                   # 零依赖 .env 加载器
 │   │   └── env_test.go
 │   └── logfmt/
-│       ├── format.go                # 块状日志格式化（FormatMsg/ToolStart/LoopStart 等）
+│       ├── format.go                # 块状日志格式化
 │       └── format_test.go
 ├── docs/
 │   └── 核心功能/
-│       ├── agent-loop.md            # Agent Loop 核心实现原理（标准 ReAct 设计）
+│       ├── cli.md                   # CLI 使用指南（本文档）
+│       ├── agent-skills.md          # Agent Skills 设计原理
+│       ├── agent-loop.md            # Agent Loop 核心实现原理
 │       ├── tool-calling.md          # Tool Calling 工具调用系统详解
 │       └── im-channel.md            # IM 渠道接入详解（飞书 Bot 实现原理）
+├── skills/                          # 示例 Skills（可复制到你的项目中使用）
+│   ├── go-coding-standards.md
+│   ├── debugging-guide.md
+│   └── architecture-overview.md
 ├── knowledge/                       # AI 技术动态知识库（采集 → 分析 → 文章）
 ├── .env.example                     # 环境变量配置模板
 ├── go.mod
@@ -268,7 +375,9 @@ harness9/
 
 | 文档 | 内容 |
 |------|------|
-| [Agent Loop 核心实现原理](docs/核心功能/agent-loop.md) | 标准 ReAct 设计原理、emitter 抽象、流式架构 |
+| [CLI 使用指南](docs/核心功能/cli.md) | 启动、环境变量、AGENTS.md、Skills 配置、常见问题 |
+| [Agent Skills 设计原理](docs/核心功能/agent-skills.md) | Progressive Disclosure、frontmatter 规范、use_skill 工具 |
+| [Agent Loop 核心实现原理](docs/核心功能/agent-loop.md) | 标准 ReAct 设计原理、PromptBuilder、流式架构 |
 | [Tool Calling 工具调用系统](docs/核心功能/tool-calling.md) | 工具接口、并发模型、内置工具详解、扩展指南 |
 | [IM 渠道接入详解](docs/核心功能/im-channel.md) | 飞书 Bot 实现原理、接口契约、事件映射规则 |
 | [AGENTS.md](AGENTS.md) | 项目开发规范、编码标准、架构决策 |

--- a/cmd/harness9/cli.go
+++ b/cmd/harness9/cli.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/harness9/internal/engine"
+)
+
+// RunCLI 启动交互式 REPL，从 os.Stdin 读取用户输入。
+// 直到 ctx 取消、用户输入 exit/quit 或 EOF 时返回。
+func RunCLI(ctx context.Context, eng *engine.AgentEngine) {
+	runCLI(ctx, eng, os.Stdin)
+}
+
+// runCLI 是 RunCLI 的可测试内核，允许注入任意 io.Reader 作为输入源。
+func runCLI(ctx context.Context, eng *engine.AgentEngine, in io.Reader) {
+	fmt.Println("harness9 │ 输入 \"exit\" 或按 Ctrl-C 退出")
+	fmt.Println()
+
+	reader := bufio.NewReader(in)
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\n再见！")
+			return
+		default:
+		}
+
+		fmt.Print("harness9> ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			// EOF 或管道关闭，正常退出
+			fmt.Println("\n再见！")
+			return
+		}
+
+		input := strings.TrimSpace(line)
+		if input == "" {
+			continue
+		}
+		if input == "exit" || input == "quit" {
+			fmt.Println("再见！")
+			return
+		}
+
+		if err := eng.Run(ctx, input); err != nil {
+			if ctx.Err() != nil {
+				fmt.Println("\n再见！")
+				return
+			}
+			fmt.Fprintf(os.Stderr, "错误: %v\n", err)
+		}
+	}
+}

--- a/cmd/harness9/cli_test.go
+++ b/cmd/harness9/cli_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/harness9/internal/engine"
+	"github.com/harness9/internal/provider/providertest"
+	"github.com/harness9/internal/tools"
+)
+
+func newTestEngine(t *testing.T) *engine.AgentEngine {
+	t.Helper()
+	return engine.NewAgentEngine(providertest.NewMock(), tools.NewRegistry(), t.TempDir())
+}
+
+// TestRunCLI_ExitCommand 验证输入 "exit" 时 runCLI 正常返回，不阻塞。
+func TestRunCLI_ExitCommand(t *testing.T) {
+	eng := newTestEngine(t)
+	input := strings.NewReader("exit\n")
+	runCLI(context.Background(), eng, input)
+}
+
+// TestRunCLI_QuitCommand 验证输入 "quit" 时 runCLI 正常返回。
+func TestRunCLI_QuitCommand(t *testing.T) {
+	eng := newTestEngine(t)
+	input := strings.NewReader("quit\n")
+	runCLI(context.Background(), eng, input)
+}
+
+// TestRunCLI_EOFExits 验证 stdin 关闭（EOF）时 runCLI 正常返回。
+func TestRunCLI_EOFExits(t *testing.T) {
+	eng := newTestEngine(t)
+	input := strings.NewReader("") // 空输入 → 立即 EOF
+	runCLI(context.Background(), eng, input)
+}
+
+// TestRunCLI_ContextCancel 验证 ctx 取消时 runCLI 正常返回。
+func TestRunCLI_ContextCancel(t *testing.T) {
+	eng := newTestEngine(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 立即取消
+	input := strings.NewReader("some input\n")
+	runCLI(ctx, eng, input)
+}

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -1,22 +1,23 @@
-// Command harness9 是 harness9 框架的飞书 Bot 服务入口。
+// Command harness9 是 harness9 框架的主入口。
 //
-// 启动后通过飞书 WebSocket 长连接持续监听私聊消息，
-// 每条消息触发一次独立的 AgentEngine 循环，执行结果回复到飞书。
+// 默认以交互式 CLI REPL 模式运行；传入 --feishu 标志则启动飞书 Bot 服务。
 //
-// 必要的环境变量（可通过 .env 文件或系统环境变量提供）：
+// 环境变量（可通过 .env 文件或系统环境变量提供）：
+//
+//	OPENAI_API_KEY     LLM Provider API Key（必填）
+//	WORK_DIR           Agent 工具的沙箱根目录（默认：进程工作目录）
+//	OPENAI_BASE_URL    自定义 OpenAI 兼容 API 地址（可选）
+//	LLM_MODEL          模型名称（默认：openai/gpt-4o-mini）
+//
+// 飞书模式额外需要：
 //
 //	FEISHU_APP_ID      飞书应用 App ID
 //	FEISHU_APP_SECRET  飞书应用 App Secret
-//	OPENAI_API_KEY     LLM Provider API Key
-//
-// 可选环境变量：
-//
-//	WORK_DIR           Agent 工具的沙箱根目录（默认：进程工作目录）
-//	OPENAI_BASE_URL    自定义 OpenAI 兼容 API 地址
 package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -24,39 +25,43 @@ import (
 	"path/filepath"
 	"syscall"
 
+	harctx "github.com/harness9/internal/context"
 	"github.com/harness9/internal/engine"
 	"github.com/harness9/internal/env"
 	"github.com/harness9/internal/imchannel/feishu"
 	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/provider"
+	"github.com/harness9/internal/skills"
 	"github.com/harness9/internal/tools"
 )
 
 func main() {
-	// 先取进程工作目录，用于定位 .env 文件
+	feishuMode := flag.Bool("feishu", false, "启动飞书 Bot 模式（需配置 FEISHU_APP_ID / FEISHU_APP_SECRET）")
+	flag.Parse()
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("获取工作目录失败: %v", err)))
 	}
 
-	// 加载 .env（不存在时静默跳过，由系统环境变量提供配置）
 	if err := env.Load(filepath.Join(cwd, ".env")); err != nil {
 		log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("加载环境配置失败: %v", err)))
 	}
 
-	// WORK_DIR 优先用 .env / 系统变量，未配置则回退到进程工作目录
 	workDir := os.Getenv("WORK_DIR")
 	if workDir == "" {
 		workDir = cwd
 	}
 
-	appID := os.Getenv("FEISHU_APP_ID")
-	appSecret := os.Getenv("FEISHU_APP_SECRET")
-	if appID == "" || appSecret == "" {
-		log.Fatal(logfmt.FormatMsg("main", "缺少飞书配置：FEISHU_APP_ID 或 FEISHU_APP_SECRET 未设置"))
+	// 加载 Skills（workdir/skills/，目录不存在时静默返回空 Index）
+	skillsIndex, err := skills.LoadSkills(filepath.Join(workDir, "skills"))
+	if err != nil {
+		log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("加载 skills 失败: %v", err)))
 	}
 
-	// 指定 LLM Provider，模型名称通过 LLM_MODEL 环境变量配置，未设置时使用默认值。
+	// 构建 System Prompt（基础 prompt + AGENTS.md + skills 索引）
+	promptBuilder := harctx.NewPromptBuilder(workDir, skillsIndex)
+
 	modelName := os.Getenv("LLM_MODEL")
 	if modelName == "" {
 		modelName = "openai/gpt-4o-mini"
@@ -66,33 +71,41 @@ func main() {
 		log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("创建 Provider 失败: %v", err)))
 	}
 
-	// 创建 ToolRegistry 并注册内置工具
 	registry := tools.NewRegistry()
 	for _, tool := range []tools.BaseTool{
 		tools.NewReadFileTool(workDir),
 		tools.NewWriteFileTool(workDir),
 		tools.NewBashTool(workDir),
 		tools.NewEditFileTool(workDir),
+		skills.NewUseSkillTool(skillsIndex),
 	} {
 		if err := registry.Register(tool); err != nil {
 			log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("注册工具 %s 失败: %v", tool.Name(), err)))
 		}
 	}
 
-	// 创建 AgentEngine
-	eng := engine.NewAgentEngine(llm, registry, workDir)
+	eng := engine.NewAgentEngine(llm, registry, workDir,
+		engine.WithPromptBuilder(promptBuilder),
+	)
 
-	// 创建飞书 Channel 并组装 Server
-	ch := feishu.NewChannel(appID, appSecret)
-	srv := NewServer(ch, eng)
-
-	// 监听系统信号，支持 Ctrl-C 优雅退出
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	log.Print(logfmt.FormatMsg("main", fmt.Sprintf("harness9 飞书 Bot 启动 │ workDir=%s appID=%s", workDir, appID)))
-	if err := srv.Start(ctx); err != nil {
-		log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("Server 退出: %v", err)))
+	if *feishuMode {
+		appID := os.Getenv("FEISHU_APP_ID")
+		appSecret := os.Getenv("FEISHU_APP_SECRET")
+		if appID == "" || appSecret == "" {
+			log.Fatal(logfmt.FormatMsg("main", "缺少飞书配置：FEISHU_APP_ID 或 FEISHU_APP_SECRET 未设置"))
+		}
+		log.Print(logfmt.FormatMsg("main", fmt.Sprintf("harness9 飞书 Bot 启动 │ workDir=%s appID=%s", workDir, appID)))
+		ch := feishu.NewChannel(appID, appSecret)
+		srv := NewServer(ch, eng)
+		if err := srv.Start(ctx); err != nil {
+			log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("Server 退出: %v", err)))
+		}
+	} else {
+		log.Print(logfmt.FormatMsg("main", fmt.Sprintf("harness9 CLI 启动 │ workDir=%s", workDir)))
+		RunCLI(ctx, eng)
 	}
 	log.Print(logfmt.FormatMsg("main", "harness9 正常退出"))
 }

--- a/docs/核心功能/agent-loop.md
+++ b/docs/核心功能/agent-loop.md
@@ -658,3 +658,26 @@ Turn 2:
 | **可观测性** | 结构化日志 `[engine]` / `[engine-stream]` 前缀 + key=value 格式 |
 | **延迟解析** | `json.RawMessage` 用于 Arguments 延迟反序列化；`interface{}` 用于 InputSchema 兼容多 SDK |
 | **自愈能力** | `ToolResult.IsError` 支持模型感知错误并自动重试 |
+
+## PromptBuilder 与 Skills 集成
+
+自 `context-engineering` 分支起，`runLoop` 中的 system prompt 不再硬编码，
+而是通过 `PromptBuilder` 接口动态构建：
+
+```go
+type PromptBuilder interface {
+    Build() string
+}
+```
+
+`WithPromptBuilder(pb PromptBuilder)` Option 将 builder 注入引擎。
+未设置时回退到内置默认文案（向后兼容）。
+
+`internal/context.DefaultPromptBuilder` 的实现按以下顺序组装 prompt：
+
+1. harness9 基础 prompt（角色定义 + workDir）
+2. `workdir/AGENTS.md`（不存在时跳过）
+3. Skills 索引摘要（来自 `internal/skills.Index.Summary()`）
+
+Skills 的全文内容通过 `use_skill` 工具按需加载（Progressive Disclosure），
+不影响基础 ReAct 循环的执行逻辑。

--- a/docs/核心功能/agent-skills.md
+++ b/docs/核心功能/agent-skills.md
@@ -1,0 +1,109 @@
+# Agent Skills 技术方案
+
+## 1. 设计原理：Progressive Disclosure
+
+Skills 系统遵循 **Progressive Disclosure（渐进式披露）** 原则：
+
+- **启动时**：只将 skills 的 `name` + `description` 索引注入 System Prompt，不加载全文
+- **运行时**：LLM 根据用户任务判断是否需要某个 skill，通过调用 `use_skill` 工具按需加载全文
+
+这样避免了将所有 skill 全文一次性注入 System Prompt 导致的 Token 膨胀，保持上下文窗口的高效利用。
+
+## 2. 目录结构
+
+用户在 `workdir/skills/` 下放置 `.md` 文件，harness9 启动时自动加载：
+
+```
+{workdir}/
+└── skills/
+    ├── go-refactor.md    # 自定义 skill
+    ├── testing-guide.md
+    └── deploy-guide.md
+```
+
+## 3. Skill 文件格式
+
+每个 skill 是一个标准 Markdown 文件，开头包含 YAML frontmatter：
+
+```markdown
+---
+name: go-refactor
+description: Use when refactoring Go code — team conventions and patterns
+trigger: "refactor, clean up, restructure, simplify"
+---
+
+# Go 重构指南
+
+## 重构前必做
+
+1. 运行 `go vet ./...` 确认无静态分析错误
+2. 运行 `go test ./...` 确认测试全部通过
+3. 查看 git diff 确认修改范围
+```
+
+### frontmatter 字段说明
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | **是** | skill 唯一标识（供 `use_skill` 工具调用） |
+| `description` | string | **是** | 简短描述，注入 System Prompt 索引，帮助 LLM 判断何时使用 |
+| `trigger` | string | 否 | 触发关键词，仅作文档说明，不做自动匹配 |
+
+## 4. System Prompt 注入效果
+
+harness9 启动后，System Prompt 末尾会附加 skills 索引：
+
+```
+## Available Skills
+
+Use the `use_skill` tool to load the full content of any skill when needed.
+
+- go-refactor: Use when refactoring Go code — team conventions and patterns
+- testing-guide: Use when writing or reviewing tests
+- deploy-guide: Use when deploying to production
+```
+
+## 5. LLM 调用 use_skill 工具
+
+LLM 在判断需要某个 skill 的完整内容时，会发起工具调用：
+
+```json
+{
+  "name": "use_skill",
+  "arguments": {
+    "skill_name": "go-refactor"
+  }
+}
+```
+
+工具返回该 skill 文件 frontmatter 之后的完整 body 内容，LLM 随后基于此内容指导任务执行。
+
+## 6. 模块实现
+
+| 模块 | 文件 | 职责 |
+|------|------|------|
+| `skills.Skill` | `internal/skills/skill.go` | 数据结构 + frontmatter 解析 |
+| `skills.Index` | `internal/skills/index.go` | 索引摘要 + 懒加载全文 |
+| `skills.LoadSkills` | `internal/skills/loader.go` | 扫描目录构建 Index |
+| `skills.UseSkillTool` | `internal/skills/use_skill_tool.go` | `use_skill` 工具实现 |
+| `context.DefaultPromptBuilder` | `internal/context/builder.go` | 组装 System Prompt |
+
+## 7. 错误处理
+
+| 场景 | 行为 |
+|------|------|
+| `skills/` 目录不存在 | 返回空 Index，静默跳过 |
+| skill 文件缺少 `name` 或 `description` | 跳过该文件，打印 warn 日志 |
+| `use_skill` 调用不存在的 skill | 返回包含可用名称列表的错误信息，LLM 可自愈 |
+| `AGENTS.md` 不存在 | PromptBuilder 跳过该段落 |
+
+## 8. CLI 启动方式
+
+```bash
+# 默认 CLI 模式（交互式 REPL）
+cd /your/project
+harness9
+
+# 飞书 Bot 模式（需配置 FEISHU_APP_ID / FEISHU_APP_SECRET）
+harness9 --feishu
+```

--- a/docs/核心功能/cli.md
+++ b/docs/核心功能/cli.md
@@ -1,0 +1,244 @@
+# harness9 CLI 使用指南
+
+harness9 默认以**交互式终端 Agent（CLI REPL）**模式运行。无需配置飞书即可直接在终端与 Agent 对话。
+
+---
+
+## 快速启动
+
+```bash
+# 进入项目目录
+cd /your/project
+
+# 确保 .env 已配置 OPENAI_API_KEY（或通过系统环境变量提供）
+cp .env.example .env
+# 编辑 .env，填入 OPENAI_API_KEY
+
+# 启动 CLI
+go run ./cmd/harness9
+```
+
+启动后看到提示符即表示 Agent 就绪：
+
+```
+harness9 │ 输入 "exit" 或按 Ctrl-C 退出
+
+harness9>
+```
+
+---
+
+## 环境变量
+
+| 变量 | 必填 | 默认值 | 说明 |
+|------|:----:|--------|------|
+| `OPENAI_API_KEY` | ✅ | — | LLM Provider API Key |
+| `WORK_DIR` | ❌ | 进程工作目录（`cwd`） | Agent 工具的沙箱根目录，所有文件操作被限制在此目录内 |
+| `LLM_MODEL` | ❌ | `openai/gpt-4o-mini` | 模型名称，支持任意 OpenAI 兼容模型 |
+| `OPENAI_BASE_URL` | ❌ | OpenAI 官方地址 | 自定义 API 地址，可接入 OpenRouter / Azure / 本地模型 |
+
+`.env` 文件示例（`.env.example`）：
+
+```env
+OPENAI_API_KEY=sk-...
+WORK_DIR=/Users/yourname/myproject
+LLM_MODEL=openai/gpt-4o-mini
+# OPENAI_BASE_URL=https://openrouter.ai/api/v1
+```
+
+> 系统环境变量优先于 `.env` 文件。已存在的系统变量不会被 `.env` 覆盖。
+
+---
+
+## 对话与操作
+
+### 基本对话
+
+在 `harness9>` 提示符后输入任何问题或指令，Agent 将在 `WORK_DIR` 下执行任务：
+
+```
+harness9> 列出当前目录下的所有 Go 文件
+harness9> 帮我分析 internal/engine/agent_loop.go 的结构
+harness9> 在 main.go 里添加一个 --version 标志
+```
+
+### 退出
+
+| 方式 | 说明 |
+|------|------|
+| 输入 `exit` | 正常退出 |
+| 输入 `quit` | 正常退出 |
+| `Ctrl-C` | 发送取消信号，Agent 完成当前操作后退出 |
+| `Ctrl-D`（EOF）| 正常退出 |
+
+### 空行
+
+直接按 Enter 跳过，不触发 Agent。
+
+---
+
+## 工作目录（WORK_DIR）
+
+`WORK_DIR` 是 Agent 的**沙箱边界**。所有文件读写、命令执行均在此目录内进行：
+
+- `read_file`、`write_file`、`edit_file` 工具会拒绝访问 `WORK_DIR` 以外的路径
+- `bash` 工具的工作目录也被设定为 `WORK_DIR`
+- 路径穿越攻击（`../../etc/passwd`）被自动拦截
+
+推荐将 `WORK_DIR` 指向你希望 Agent 协助操作的**具体项目目录**，而非系统根目录。
+
+---
+
+## Project Guidelines（AGENTS.md）
+
+在 `WORK_DIR` 根目录放置 `AGENTS.md` 文件，Agent 启动时会自动将其内容注入 System Prompt，作为项目级规范和上下文指南。
+
+**典型用途：**
+- 描述项目架构、技术栈、编码规范
+- 指定禁止操作（如"禁止修改 go.mod"）
+- 提供领域背景知识
+
+**格式：** 标准 Markdown，无格式限制。
+
+```markdown
+# 我的项目指南
+
+## 技术栈
+- Go 1.25
+- PostgreSQL 16
+
+## 规范
+- 所有函数必须有注释
+- 禁止直接操作数据库，必须通过 Repository 层
+```
+
+---
+
+## Agent Skills
+
+Skills 是可按需加载的领域知识文档。在 `WORK_DIR/skills/` 目录下放置 `.md` 文件即可：
+
+```
+your-project/
+├── skills/
+│   ├── refactor-guide.md      # 重构规范
+│   ├── testing-standards.md   # 测试标准
+│   └── api-design.md          # API 设计规范
+└── AGENTS.md
+```
+
+**Skill 文件格式（frontmatter + 内容）：**
+
+```markdown
+---
+name: refactor-guide
+description: Use when refactoring Go code — explains team conventions
+trigger: refactor, clean up, restructure
+---
+
+# 重构规范
+
+重构 Go 代码时，请遵循以下原则：
+1. 先运行 `go vet`，修复所有 warning
+2. 保持函数不超过 50 行
+...
+```
+
+**frontmatter 字段：**
+
+| 字段 | 必填 | 说明 |
+|------|:----:|------|
+| `name` | ✅ | Skill 唯一名称，供 `use_skill` 工具调用 |
+| `description` | ✅ | 简短描述，注入 System Prompt 供 Agent 感知 |
+| `trigger` | ❌ | 触发关键词（仅文档说明，不做自动匹配） |
+
+**工作机制（Progressive Disclosure）：**
+
+1. 启动时，所有 Skill 的 `name` 和 `description` 注入 System Prompt 形成索引
+2. Agent 需要时调用 `use_skill` 工具，按需加载指定 Skill 的完整内容
+3. 全文内容不预先注入，节省 Token，保持 System Prompt 精简
+
+Agent 在 System Prompt 中会看到类似：
+
+```
+## Available Skills
+
+Use the `use_skill` tool to load the full content of any skill when needed.
+
+- refactor-guide: Use when refactoring Go code — explains team conventions
+- testing-standards: Use when writing or reviewing tests
+```
+
+详见 [Agent Skills 设计原理](agent-skills.md)。
+
+---
+
+## 飞书 Bot 模式
+
+如需通过飞书使用 Agent，启动时传入 `--feishu` 标志：
+
+```bash
+go run ./cmd/harness9 --feishu
+```
+
+飞书模式额外需要在 `.env` 中配置：
+
+```env
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+```
+
+飞书模式详见 [IM 渠道接入详解](im-channel.md)。
+
+---
+
+## 使用示例
+
+### 代码分析
+
+```
+harness9> 帮我分析 internal/engine/agent_loop.go，说明它的主循环设计
+```
+
+### 代码修改
+
+```
+harness9> 在 internal/tools/ 下新建一个 list_dir 工具，列出目录内容
+```
+
+### 使用 Skill
+
+```
+harness9> 帮我重构 internal/provider/openai.go（Agent 会自动加载 go-coding-standards Skill）
+```
+
+### 运行测试
+
+```
+harness9> 帮我运行 go test ./... 并分析失败原因
+```
+
+---
+
+## 常见问题
+
+**Q: 启动报错 `创建 Provider 失败`**
+
+检查 `OPENAI_API_KEY` 是否正确设置，以及 `.env` 文件是否在运行命令的目录下。
+
+**Q: Agent 无法读取某个文件**
+
+确认文件路径在 `WORK_DIR` 内。Agent 使用相对于 `WORK_DIR` 的路径，绝对路径或 `../` 路径会被拦截。
+
+**Q: 想使用其他模型（如 Claude、OpenRouter）**
+
+设置 `OPENAI_BASE_URL` 指向兼容 OpenAI Chat Completions API 的端点，并将 `LLM_MODEL` 改为对应模型名称：
+
+```env
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+LLM_MODEL=anthropic/claude-sonnet-4-5
+```
+
+**Q: 每次对话是否有记忆？**
+
+当前版本每次 `harness9>` 输入都是独立的上下文，无跨 Prompt 的持久历史。会话记忆功能（memory 包）在后续迭代中提供。

--- a/internal/context/builder.go
+++ b/internal/context/builder.go
@@ -1,0 +1,59 @@
+// Package context 实现 harness9 的上下文工程（Context Engineering）模块。
+//
+// DefaultPromptBuilder 按 Progressive Disclosure 原则组装 Agent 的 System Prompt：
+//  1. harness9 基础 prompt（角色定义 + 工作目录声明）
+//  2. workdir/AGENTS.md 内容（用户项目规范，不存在时静默跳过）
+//  3. Skills 索引摘要（LLM 按需通过 use_skill 工具加载全文，空时跳过）
+package context
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/harness9/internal/skills"
+)
+
+// DefaultPromptBuilder 实现了 engine.PromptBuilder 接口。
+// Go 通过结构类型（Structural Typing）隐式满足接口，无需显式声明或 import engine 包。
+type DefaultPromptBuilder struct {
+	workDir     string
+	skillsIndex *skills.Index
+}
+
+// NewPromptBuilder 创建绑定到指定工作目录和 Skills Index 的 PromptBuilder。
+// skillsIndex 为 nil 时，跳过 skills 段落注入。
+func NewPromptBuilder(workDir string, idx *skills.Index) *DefaultPromptBuilder {
+	return &DefaultPromptBuilder{workDir: workDir, skillsIndex: idx}
+}
+
+// Build 组装并返回完整的 System Prompt 字符串。
+func (b *DefaultPromptBuilder) Build() string {
+	var parts []string
+
+	// 1. 基础 prompt
+	parts = append(parts, fmt.Sprintf(
+		"You are harness9, an expert coding assistant. "+
+			"You have full access to tools in the workspace. "+
+			"Your working directory is: %s",
+		b.workDir,
+	))
+
+	// 2. AGENTS.md（不存在或为空时静默跳过）
+	agentsPath := filepath.Join(b.workDir, "AGENTS.md")
+	if data, err := os.ReadFile(agentsPath); err == nil && len(data) > 0 {
+		parts = append(parts, "## Project Guidelines (AGENTS.md)\n\n"+string(data))
+	}
+
+	// 3. Skills 索引（空 Index 或 nil 时跳过整块）
+	if b.skillsIndex != nil && !b.skillsIndex.IsEmpty() {
+		parts = append(parts,
+			"## Available Skills\n\n"+
+				"Use the `use_skill` tool to load the full content of any skill when needed.\n\n"+
+				b.skillsIndex.Summary(),
+		)
+	}
+
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/context/builder_test.go
+++ b/internal/context/builder_test.go
@@ -1,0 +1,90 @@
+package context
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/harness9/internal/skills"
+)
+
+func TestBuild_BasePromptOnly(t *testing.T) {
+	dir := t.TempDir()
+	// skills 目录不存在 → 空 Index
+	idx, _ := skills.LoadSkills(filepath.Join(dir, "skills"))
+
+	b := NewPromptBuilder(dir, idx)
+	prompt := b.Build()
+
+	if !strings.Contains(prompt, "harness9") {
+		t.Error("prompt should contain 'harness9'")
+	}
+	if !strings.Contains(prompt, dir) {
+		t.Error("prompt should contain workDir")
+	}
+	if strings.Contains(prompt, "Project Guidelines") {
+		t.Error("prompt should not contain AGENTS.md section when file absent")
+	}
+	if strings.Contains(prompt, "Available Skills") {
+		t.Error("prompt should not contain skills section when index is empty")
+	}
+}
+
+func TestBuild_WithAgentsMd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# Project Guide\n\nAlways write tests first."), 0644); err != nil {
+		t.Fatal(err)
+	}
+	idx, _ := skills.LoadSkills(filepath.Join(dir, "skills"))
+
+	b := NewPromptBuilder(dir, idx)
+	prompt := b.Build()
+
+	if !strings.Contains(prompt, "Project Guidelines") {
+		t.Error("prompt should contain AGENTS.md section header")
+	}
+	if !strings.Contains(prompt, "Always write tests first.") {
+		t.Error("prompt should contain AGENTS.md content")
+	}
+}
+
+func TestBuild_WithSkills(t *testing.T) {
+	dir := t.TempDir()
+	skillsDir := filepath.Join(dir, "skills")
+	if err := os.Mkdir(skillsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillContent := "---\nname: go-refactor\ndescription: Go refactoring guide\n---\n\nAlways run go vet first."
+	if err := os.WriteFile(filepath.Join(skillsDir, "go-refactor.md"), []byte(skillContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	idx, err := skills.LoadSkills(skillsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewPromptBuilder(dir, idx)
+	prompt := b.Build()
+
+	if !strings.Contains(prompt, "Available Skills") {
+		t.Error("prompt should contain skills section header")
+	}
+	if !strings.Contains(prompt, "go-refactor: Go refactoring guide") {
+		t.Error("prompt should contain skill index entry")
+	}
+	// Progressive Disclosure：skill 全文不能出现在 System Prompt 中
+	if strings.Contains(prompt, "Always run go vet first.") {
+		t.Error("prompt must NOT contain skill body content (progressive disclosure violated)")
+	}
+}
+
+func TestBuild_NilSkillsIndex(t *testing.T) {
+	dir := t.TempDir()
+	b := NewPromptBuilder(dir, nil)
+	prompt := b.Build()
+	if !strings.Contains(prompt, "harness9") {
+		t.Error("prompt should contain 'harness9' even with nil skills index")
+	}
+}

--- a/internal/engine/agent_loop.go
+++ b/internal/engine/agent_loop.go
@@ -35,6 +35,18 @@ func WithMaxConcurrentTools(n int) Option {
 	return func(e *AgentEngine) { e.maxConcurrentTools = n }
 }
 
+// PromptBuilder 构造 Agent 的 system prompt。
+// 接口定义在 engine 包（使用者侧），由 internal/context 包实现。
+// 引擎通过此接口与 Context Engineering 模块解耦。
+type PromptBuilder interface {
+	Build() string
+}
+
+// WithPromptBuilder 设置自定义 PromptBuilder。未设置时使用内置默认文案。
+func WithPromptBuilder(pb PromptBuilder) Option {
+	return func(e *AgentEngine) { e.promptBuilder = pb }
+}
+
 // AgentEngine 是 harness9 agent loop 的核心编排器，将 LLM Provider（"大脑"）
 // 与 Tool Registry（"双手"）组合在一起，执行多轮 ReAct 循环直到任务完成。
 type AgentEngine struct {
@@ -44,6 +56,7 @@ type AgentEngine struct {
 	maxTurns           int
 	toolTimeout        time.Duration
 	maxConcurrentTools int
+	promptBuilder      PromptBuilder
 }
 
 // NewAgentEngine 创建新的 AgentEngine。默认值：maxTurns=50, toolTimeout=60s。
@@ -102,13 +115,8 @@ func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix 
 
 	contextHistory := []schema.Message{
 		{
-			Role: schema.RoleSystem,
-			Content: fmt.Sprintf(
-				"You are harness9, an expert coding assistant. "+
-					"You have full access to tools in the workspace. "+
-					"Your working directory is: %s",
-				e.workDir,
-			),
+			Role:    schema.RoleSystem,
+			Content: e.buildSystemPrompt(),
 		},
 		{Role: schema.RoleUser, Content: userPrompt},
 	}
@@ -163,6 +171,20 @@ func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix 
 
 	log.Print(logfmt.FormatLoopEnd(logPrefix, turnCount, time.Since(overallStart)))
 	return nil
+}
+
+// buildSystemPrompt 返回 system prompt 字符串。
+// 若设置了 PromptBuilder 则委托给它，否则回退到内置默认文案。
+func (e *AgentEngine) buildSystemPrompt() string {
+	if e.promptBuilder != nil {
+		return e.promptBuilder.Build()
+	}
+	return fmt.Sprintf(
+		"You are harness9, an expert coding assistant. "+
+			"You have full access to tools in the workspace. "+
+			"Your working directory is: %s",
+		e.workDir,
+	)
 }
 
 // executeTools 并发执行所有工具调用，每个工具带有独立的超时控制。

--- a/internal/engine/agent_loop_test.go
+++ b/internal/engine/agent_loop_test.go
@@ -267,3 +267,60 @@ func (r *timeoutCheckRegistry) Execute(ctx context.Context, call schema.ToolCall
 	}
 	return schema.ToolResult{ToolCallID: call.ID, Output: "ok"}
 }
+
+// mockPromptBuilder 是 PromptBuilder 接口的测试桩。
+type mockPromptBuilder struct {
+	content string
+}
+
+func (m *mockPromptBuilder) Build() string { return m.content }
+
+// TestWithPromptBuilder_CustomContent 验证 WithPromptBuilder 使自定义内容作为 system prompt 传入。
+func TestWithPromptBuilder_CustomContent(t *testing.T) {
+	customPrompt := "custom system prompt for testing"
+	p := &countingProvider{
+		responses: []func(tools []schema.ToolDefinition) *schema.Message{
+			func(_ []schema.ToolDefinition) *schema.Message {
+				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
+			},
+		},
+	}
+	r := &staticRegistry{}
+	eng := NewAgentEngine(p, r, "/test", WithPromptBuilder(&mockPromptBuilder{content: customPrompt}))
+
+	_ = eng.Run(context.Background(), "test")
+
+	if len(p.calls) == 0 {
+		t.Fatal("expected at least 1 Generate call")
+	}
+	systemMsg := p.calls[0].messages[0]
+	if systemMsg.Role != schema.RoleSystem {
+		t.Fatalf("first message should be system role, got %q", systemMsg.Role)
+	}
+	if systemMsg.Content != customPrompt {
+		t.Errorf("system prompt: got %q, want %q", systemMsg.Content, customPrompt)
+	}
+}
+
+// TestWithPromptBuilder_FallbackDefault 验证未设置 PromptBuilder 时使用内置默认文案。
+func TestWithPromptBuilder_FallbackDefault(t *testing.T) {
+	p := &countingProvider{
+		responses: []func(tools []schema.ToolDefinition) *schema.Message{
+			func(_ []schema.ToolDefinition) *schema.Message {
+				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
+			},
+		},
+	}
+	r := &staticRegistry{}
+	eng := NewAgentEngine(p, r, "/fallback/path")
+
+	_ = eng.Run(context.Background(), "test")
+
+	systemMsg := p.calls[0].messages[0]
+	if !strings.Contains(systemMsg.Content, "/fallback/path") {
+		t.Errorf("default prompt should contain workDir, got: %s", systemMsg.Content)
+	}
+	if !strings.Contains(systemMsg.Content, "harness9") {
+		t.Errorf("default prompt should contain 'harness9', got: %s", systemMsg.Content)
+	}
+}

--- a/internal/skills/index.go
+++ b/internal/skills/index.go
@@ -1,0 +1,54 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Index 是所有已加载 skills 的集合，提供索引摘要和按需全文读取能力。
+type Index struct {
+	skills []Skill
+}
+
+// IsEmpty 报告 Index 中是否不包含任何 skill。
+func (idx *Index) IsEmpty() bool {
+	return len(idx.skills) == 0
+}
+
+// Summary 返回 skills 索引的纯文本摘要，格式为每行 "- name: description\n"。
+// 供 PromptBuilder 注入到 System Prompt，实现 Progressive Disclosure。
+func (idx *Index) Summary() string {
+	if idx.IsEmpty() {
+		return ""
+	}
+	var sb strings.Builder
+	for _, s := range idx.skills {
+		fmt.Fprintf(&sb, "- %s: %s\n", s.Name, s.Description)
+	}
+	return sb.String()
+}
+
+// GetFullContent 按名称懒加载指定 skill 的全文内容（frontmatter 之后的 body）。
+// skill 不存在时返回包含可用名称列表的可读错误信息，供 LLM 自愈。
+func (idx *Index) GetFullContent(name string) (string, error) {
+	for _, s := range idx.skills {
+		if s.Name == name {
+			data, err := os.ReadFile(s.filePath)
+			if err != nil {
+				return "", fmt.Errorf("读取 skill %q 失败: %w", name, err)
+			}
+			_, _, _, body := parseFrontmatter(string(data))
+			return strings.TrimSpace(body), nil
+		}
+	}
+	return "", fmt.Errorf("skill %q 不存在，可用技能: %s", name, idx.availableNames())
+}
+
+func (idx *Index) availableNames() string {
+	names := make([]string, len(idx.skills))
+	for i, s := range idx.skills {
+		names[i] = s.Name
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -1,0 +1,47 @@
+package skills
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadSkills 扫描 skillsDir 目录下所有 .md 文件并解析 frontmatter 构建 Index。
+// 目录不存在时返回空 Index（不报错），保证零配置可运行。
+// frontmatter 缺少必填字段（name 或 description）的文件被跳过并记录警告日志。
+func LoadSkills(skillsDir string) (*Index, error) {
+	entries, err := os.ReadDir(skillsDir)
+	if os.IsNotExist(err) {
+		return &Index{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("读取 skills 目录失败: %w", err)
+	}
+
+	var loaded []Skill
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		filePath := filepath.Join(skillsDir, entry.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			log.Printf("[skills] 跳过 %s: 读取失败: %v", entry.Name(), err)
+			continue
+		}
+		name, desc, trigger, _ := parseFrontmatter(string(data))
+		if name == "" || desc == "" {
+			log.Printf("[skills] 跳过 %s: frontmatter 缺少 name 或 description", entry.Name())
+			continue
+		}
+		loaded = append(loaded, Skill{
+			Name:        name,
+			Description: desc,
+			Trigger:     trigger,
+			filePath:    filePath,
+		})
+	}
+	return &Index{skills: loaded}, nil
+}

--- a/internal/skills/skill.go
+++ b/internal/skills/skill.go
@@ -1,0 +1,54 @@
+// Package skills 实现 harness9 的 Agent Skills 解析与加载系统。
+//
+// Skills 遵循 Progressive Disclosure 原则：System Prompt 只注入技能索引摘要，
+// LLM 通过调用 use_skill 工具按需加载特定技能的全文内容，避免上下文窗口膨胀。
+package skills
+
+import "strings"
+
+// Skill 表示一个已解析的 skill。frontmatter 字段在加载时解析，
+// 全文内容（body）通过 filePath 懒加载，不在启动时读入内存。
+type Skill struct {
+	Name        string
+	Description string
+	Trigger     string
+	filePath    string
+}
+
+// parseFrontmatter 解析 Markdown 文件开头的 YAML frontmatter 块。
+// 返回 name、description、trigger 和 frontmatter 之后的 body。
+// 文件不以 "---\n" 开头或缺少闭合分隔符时，视为无 frontmatter，body 为全文。
+func parseFrontmatter(content string) (name, description, trigger, body string) {
+	const delim = "---\n"
+	if !strings.HasPrefix(content, delim) {
+		return "", "", "", content
+	}
+	rest := content[len(delim):]
+	idx := strings.Index(rest, "\n---\n")
+	if idx == -1 {
+		return "", "", "", content
+	}
+	fm := rest[:idx]
+	body = strings.TrimPrefix(rest[idx+len("\n---\n"):], "\n")
+
+	for _, line := range strings.Split(fm, "\n") {
+		k, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if len(v) >= 2 && ((v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'')) {
+			v = v[1 : len(v)-1]
+		}
+		switch k {
+		case "name":
+			name = v
+		case "description":
+			description = v
+		case "trigger":
+			trigger = v
+		}
+	}
+	return
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -148,3 +148,96 @@ func TestIndex_GetFullContent_Found(t *testing.T) {
 		t.Errorf("body: got %q, want %q", body, "Skill body content.")
 	}
 }
+
+// --- LoadSkills tests ---
+
+// writeSkillFile 在指定路径写入 skill 文件内容的测试辅助函数。
+func writeSkillFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadSkills_NonExistentDir(t *testing.T) {
+	idx, err := LoadSkills("/nonexistent/path/to/skills")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !idx.IsEmpty() {
+		t.Error("expected empty index for nonexistent directory")
+	}
+}
+
+func TestLoadSkills_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := LoadSkills(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !idx.IsEmpty() {
+		t.Error("expected empty index for empty directory")
+	}
+}
+
+func TestLoadSkills_ValidSkills(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, filepath.Join(dir, "skill-a.md"),
+		"---\nname: skill-a\ndescription: Skill A desc\n---\n\nBody A")
+	writeSkillFile(t, filepath.Join(dir, "skill-b.md"),
+		"---\nname: skill-b\ndescription: Skill B desc\n---\n\nBody B")
+
+	idx, err := LoadSkills(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.IsEmpty() {
+		t.Fatal("expected non-empty index")
+	}
+	summary := idx.Summary()
+	if !strings.Contains(summary, "skill-a: Skill A desc") {
+		t.Errorf("summary missing skill-a: %q", summary)
+	}
+	if !strings.Contains(summary, "skill-b: Skill B desc") {
+		t.Errorf("summary missing skill-b: %q", summary)
+	}
+}
+
+func TestLoadSkills_SkipsInvalidFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, filepath.Join(dir, "no-desc.md"),
+		"---\nname: missing-desc\n---\n\nBody")
+	writeSkillFile(t, filepath.Join(dir, "valid.md"),
+		"---\nname: valid-skill\ndescription: Valid skill\n---\n\nBody")
+
+	idx, err := LoadSkills(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	summary := idx.Summary()
+	if strings.Contains(summary, "missing-desc") {
+		t.Error("skill missing description should be skipped")
+	}
+	if !strings.Contains(summary, "valid-skill") {
+		t.Error("valid skill should be loaded")
+	}
+}
+
+func TestLoadSkills_SkipsNonMdFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeSkillFile(t, filepath.Join(dir, "not-skill.txt"),
+		"---\nname: txt-skill\ndescription: Text file\n---\n\nBody")
+	writeSkillFile(t, filepath.Join(dir, "real.md"),
+		"---\nname: real-skill\ndescription: Real skill\n---\n\nBody")
+
+	idx, err := LoadSkills(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(idx.Summary(), "txt-skill") {
+		t.Error("non-.md files should be skipped")
+	}
+	if !strings.Contains(idx.Summary(), "real-skill") {
+		t.Error(".md skill should be loaded")
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -241,3 +241,61 @@ func TestLoadSkills_SkipsNonMdFiles(t *testing.T) {
 		t.Error(".md skill should be loaded")
 	}
 }
+
+// --- UseSkillTool tests ---
+
+func TestUseSkillTool_Name(t *testing.T) {
+	tool := NewUseSkillTool(&Index{})
+	if tool.Name() != "use_skill" {
+		t.Errorf("Name(): got %q, want %q", tool.Name(), "use_skill")
+	}
+}
+
+func TestUseSkillTool_Execute_InvalidArgs(t *testing.T) {
+	tool := NewUseSkillTool(&Index{})
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{invalid json`))
+	if err == nil {
+		t.Error("expected error for invalid JSON args")
+	}
+}
+
+func TestUseSkillTool_Execute_EmptyName(t *testing.T) {
+	tool := NewUseSkillTool(&Index{})
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"skill_name":""}`))
+	if err == nil {
+		t.Error("expected error for empty skill_name")
+	}
+}
+
+func TestUseSkillTool_Execute_NotFound(t *testing.T) {
+	tool := NewUseSkillTool(&Index{})
+	_, err := tool.Execute(context.Background(), json.RawMessage(`{"skill_name":"missing"}`))
+	if err == nil {
+		t.Error("expected error for missing skill")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Errorf("error should mention skill name: %v", err)
+	}
+}
+
+func TestUseSkillTool_Execute_Found(t *testing.T) {
+	f, err := os.CreateTemp("", "skill-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("---\nname: test\ndescription: Test\n---\n\nSkill body content."); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	idx := &Index{skills: []Skill{{Name: "test", Description: "Test", filePath: f.Name()}}}
+	tool := NewUseSkillTool(idx)
+	body, err := tool.Execute(context.Background(), json.RawMessage(`{"skill_name":"test"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body != "Skill body content." {
+		t.Errorf("body: got %q, want %q", body, "Skill body content.")
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,84 @@
+package skills
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseFrontmatter_Valid(t *testing.T) {
+	content := "---\nname: my-skill\ndescription: A test skill\ntrigger: refactor\n---\n\nBody here."
+	name, desc, trig, body := parseFrontmatter(content)
+	if name != "my-skill" {
+		t.Errorf("name: got %q, want %q", name, "my-skill")
+	}
+	if desc != "A test skill" {
+		t.Errorf("description: got %q, want %q", desc, "A test skill")
+	}
+	if trig != "refactor" {
+		t.Errorf("trigger: got %q, want %q", trig, "refactor")
+	}
+	if body != "Body here." {
+		t.Errorf("body: got %q, want %q", body, "Body here.")
+	}
+}
+
+func TestParseFrontmatter_QuotedValues(t *testing.T) {
+	content := "---\nname: \"quoted-skill\"\ndescription: \"Quoted description\"\n---\n\nBody"
+	name, desc, _, body := parseFrontmatter(content)
+	if name != "quoted-skill" {
+		t.Errorf("name: got %q, want %q", name, "quoted-skill")
+	}
+	if desc != "Quoted description" {
+		t.Errorf("description: got %q, want %q", desc, "Quoted description")
+	}
+	if body != "Body" {
+		t.Errorf("body: got %q, want %q", body, "Body")
+	}
+}
+
+func TestParseFrontmatter_NoFrontmatter(t *testing.T) {
+	content := "Just a plain body"
+	name, desc, trig, body := parseFrontmatter(content)
+	if name != "" || desc != "" || trig != "" {
+		t.Error("expected empty name/desc/trig for content without frontmatter")
+	}
+	if body != content {
+		t.Errorf("body should equal full content: got %q", body)
+	}
+}
+
+func TestParseFrontmatter_MissingClosingDelimiter(t *testing.T) {
+	content := "---\nname: my-skill\n\nNo closing delimiter"
+	name, _, _, body := parseFrontmatter(content)
+	if name != "" {
+		t.Errorf("name: got %q, want empty when closing delimiter missing", name)
+	}
+	if body != content {
+		t.Errorf("body should equal full content: got %q", body)
+	}
+}
+
+func TestParseFrontmatter_NoTrigger(t *testing.T) {
+	content := "---\nname: my-skill\ndescription: A skill\n---\n\nBody"
+	name, desc, trig, body := parseFrontmatter(content)
+	if name != "my-skill" || desc != "A skill" {
+		t.Error("expected name and description to parse")
+	}
+	if trig != "" {
+		t.Errorf("trigger: got %q, want empty string", trig)
+	}
+	if body != "Body" {
+		t.Errorf("body: got %q, want %q", body, "Body")
+	}
+}
+
+// 以下变量仅为让编译器不报错（后续任务会用到这些导入）
+var _ = context.Background
+var _ = json.RawMessage(nil)
+var _ = os.TempDir
+var _ = filepath.Join
+var _ = strings.Contains

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -82,3 +82,69 @@ var _ = json.RawMessage(nil)
 var _ = os.TempDir
 var _ = filepath.Join
 var _ = strings.Contains
+
+// --- Index tests ---
+
+func TestIndex_IsEmpty(t *testing.T) {
+	empty := &Index{}
+	if !empty.IsEmpty() {
+		t.Error("new Index should be empty")
+	}
+	nonEmpty := &Index{skills: []Skill{{Name: "a", Description: "A"}}}
+	if nonEmpty.IsEmpty() {
+		t.Error("Index with skills should not be empty")
+	}
+}
+
+func TestIndex_Summary_Empty(t *testing.T) {
+	idx := &Index{}
+	if idx.Summary() != "" {
+		t.Error("empty index Summary() should return empty string")
+	}
+}
+
+func TestIndex_Summary_WithSkills(t *testing.T) {
+	idx := &Index{skills: []Skill{
+		{Name: "skill-a", Description: "Desc A"},
+		{Name: "skill-b", Description: "Desc B"},
+	}}
+	got := idx.Summary()
+	if !strings.Contains(got, "skill-a: Desc A") {
+		t.Errorf("summary missing skill-a entry: %q", got)
+	}
+	if !strings.Contains(got, "skill-b: Desc B") {
+		t.Errorf("summary missing skill-b entry: %q", got)
+	}
+}
+
+func TestIndex_GetFullContent_NotFound(t *testing.T) {
+	idx := &Index{}
+	_, err := idx.GetFullContent("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent skill")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should mention skill name: %v", err)
+	}
+}
+
+func TestIndex_GetFullContent_Found(t *testing.T) {
+	f, err := os.CreateTemp("", "skill-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString("---\nname: test-skill\ndescription: Test\n---\n\nSkill body content."); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	idx := &Index{skills: []Skill{{Name: "test-skill", Description: "Test", filePath: f.Name()}}}
+	body, err := idx.GetFullContent("test-skill")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body != "Skill body content." {
+		t.Errorf("body: got %q, want %q", body, "Skill body content.")
+	}
+}

--- a/internal/skills/use_skill_tool.go
+++ b/internal/skills/use_skill_tool.go
@@ -1,0 +1,57 @@
+package skills
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/harness9/internal/schema"
+)
+
+// UseSkillTool 使 LLM 能够按需加载指定 skill 的全文内容（Progressive Disclosure 执行层）。
+// 通过 Go 结构类型（Structural Typing）隐式满足 tools.BaseTool 接口，无需 import tools 包。
+type UseSkillTool struct {
+	index *Index
+}
+
+// NewUseSkillTool 创建绑定到指定 Index 的 use_skill 工具。
+func NewUseSkillTool(index *Index) *UseSkillTool {
+	return &UseSkillTool{index: index}
+}
+
+// Name 返回工具标识符 "use_skill"。
+func (t *UseSkillTool) Name() string { return "use_skill" }
+
+// Definition 返回工具元信息，包含描述和参数 JSON Schema。
+func (t *UseSkillTool) Definition() schema.ToolDefinition {
+	return schema.ToolDefinition{
+		Name:        "use_skill",
+		Description: "加载指定技能的完整内容。当需要执行特定领域任务时，先调用此工具获取对应技能的完整指导内容。",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"skill_name": map[string]interface{}{
+					"type":        "string",
+					"description": "要加载的技能名称（来自 System Prompt 技能索引中的 name 字段）",
+				},
+			},
+			"required": []string{"skill_name"},
+		},
+	}
+}
+
+type useSkillArgs struct {
+	SkillName string `json:"skill_name"`
+}
+
+// Execute 加载并返回指定 skill 的全文内容。
+func (t *UseSkillTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var a useSkillArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("参数解析失败: %w", err)
+	}
+	if a.SkillName == "" {
+		return "", fmt.Errorf("skill_name 不能为空")
+	}
+	return t.index.GetFullContent(a.SkillName)
+}

--- a/skills/architecture-overview.md
+++ b/skills/architecture-overview.md
@@ -1,0 +1,130 @@
+---
+name: architecture-overview
+description: Use when asked about harness9 architecture, module design, or how components interact — explains the system design
+trigger: architecture, design, how does, module, component, structure
+---
+
+# harness9 架构概览
+
+## 核心设计原则
+
+| 原则 | 说明 |
+|------|------|
+| **简洁** | 最小化抽象层，极少的直接依赖 |
+| **完备** | 覆盖 Agent 运行所需的全部核心模块 |
+| **生产可用** | 错误恢复、超时控制、路径沙箱、并发安全 |
+
+## 标准 ReAct 循环
+
+```
+Turn N:
+  LLM(messages + tools) → 推理 + 工具调用决策
+  → 并发执行所有工具调用 → Observation 注入 context
+  → Turn N+1
+
+自然终止：模型不再发起工具调用 → 输出最终回复
+```
+
+三重终止保障：
+1. **自然终止**：`len(responseMsg.ToolCalls) == 0`
+2. **MaxTurns**：默认 50，可通过 `WithMaxTurns` 配置
+3. **Context 取消**：外部 `cancel()` 或超时
+
+## 模块依赖关系
+
+```
+cmd/harness9 (入口)
+    ├── internal/context (System Prompt 组装)
+    │       └── internal/skills (Skills 解析 + 索引)
+    ├── internal/engine (ReAct 主循环)
+    │       ├── internal/provider (LLM 调用)
+    │       ├── internal/tools (工具注册 + 执行)
+    │       └── internal/schema (数据类型)
+    ├── internal/imchannel/feishu (飞书 Bot，--feishu 模式)
+    └── internal/env (配置加载)
+```
+
+**关键设计决策：接口定义在使用者侧**
+
+- `tools.Registry` 接口定义在 `tools` 包，`engine` 包依赖它
+- `engine.PromptBuilder` 接口定义在 `engine` 包，`context` 包实现它
+- `skills.UseSkillTool` 通过 Go 结构类型满足 `tools.BaseTool` 接口，不需要 import `tools` 包（避免循环依赖）
+
+## 关键数据流
+
+### CLI 模式
+
+```
+用户输入 → RunCLI → eng.Run(ctx, prompt)
+    → runLoop → LLM Generate
+    → ToolCalls → 并发执行 → ToolResults → 继续循环
+    → 最终回复打印到 stdout
+```
+
+### 飞书 Bot 模式
+
+```
+飞书消息 → WebSocket → Server.handleMessage
+    → eng.RunStream → engine.Event stream
+    → EventActionDelta → 累积回复文本
+    → EventToolStart/Result → 进度消息推送
+    → EventDone → SendReply(最终回复)
+```
+
+## System Prompt 组装
+
+`DefaultPromptBuilder.Build()` 按顺序组装：
+
+1. **基础 Prompt**：角色定义 + workDir
+2. **AGENTS.md**：项目级规范（文件不存在时跳过）
+3. **Skills 索引**：`- name: description` 列表（为空时跳过）
+
+完整内容示例：
+```
+You are harness9, an expert coding assistant...
+
+## Project Guidelines (AGENTS.md)
+{AGENTS.md 全文}
+
+## Available Skills
+Use the `use_skill` tool to load full content of any skill when needed.
+- go-coding-standards: Use when writing or reviewing Go code...
+- debugging-guide: Use when debugging Go errors...
+```
+
+## Provider 抽象
+
+```go
+type LLMProvider interface {
+    Generate(ctx, messages, tools) (Message, error)
+    GenerateStream(ctx, messages, tools) (<-chan StreamChunk, error)
+}
+```
+
+当前实现：
+- `OpenAIProvider`：兼容所有 OpenAI Chat Completions API（包括 OpenRouter、Azure）
+- `AnthropicProvider`：Anthropic Messages API
+
+**Anthropic 约束**：user/assistant 消息必须严格交替，禁止连续 assistant 消息。
+
+## 工具系统
+
+```go
+type BaseTool interface {
+    Name() string
+    Definition() schema.ToolDefinition  // JSON Schema，传给 LLM
+    Execute(ctx context.Context, args json.RawMessage) (string, error)
+}
+```
+
+内置工具：
+
+| 工具 | 说明 |
+|------|------|
+| `bash` | Shell 命令执行，workDir 为 CWD |
+| `read_file` | 文件读取，4096 字节截断 |
+| `write_file` | 文件写入，自动 mkdir |
+| `edit_file` | 字符串替换编辑，多级模糊匹配 |
+| `use_skill` | 按需加载 Skill 全文 |
+
+所有文件工具通过 `safePath()` 校验路径，防止 Path Traversal 攻击。

--- a/skills/debugging-guide.md
+++ b/skills/debugging-guide.md
@@ -1,0 +1,111 @@
+---
+name: debugging-guide
+description: Use when debugging Go errors, test failures, or unexpected behavior — step-by-step diagnosis approach
+trigger: debug, error, fail, crash, panic, fix, wrong
+---
+
+# harness9 调试指南
+
+## 诊断顺序
+
+遇到问题时，按以下顺序排查：
+
+### 1. 编译错误
+
+```bash
+go build ./...
+```
+
+常见原因：
+- 未使用的 import → 删除或添加 `_` blank import
+- 类型不匹配 → 检查接口实现是否完整
+- 循环依赖 → 将接口定义移到使用者侧包中
+
+### 2. 测试失败
+
+```bash
+# 详细输出
+go test -v ./internal/engine/
+
+# 单个测试
+go test -v -run TestAgentLoop ./internal/engine/
+
+# 带 race detector
+go test -race ./...
+```
+
+### 3. 运行时 panic
+
+查看完整 goroutine stack：
+```bash
+go run ./cmd/harness9 2>&1 | head -100
+```
+
+nil pointer panic 通常来自：
+- 未初始化的 map（用 `make(map[K]V)` 初始化）
+- 接口值为 nil 但调用了方法
+
+### 4. Agent 行为异常
+
+**LLM 不调用工具：** 检查工具的 `Definition()` 描述是否清晰，JSON Schema 是否正确。
+
+**工具执行失败：** 查看 `ToolResult.IsError` 和 `Output` 字段，错误信息会回传给 LLM。
+
+**无限循环：** 检查 `WithMaxTurns` 配置，默认 50 Turn。
+
+## 常用调试技巧
+
+### 打印 System Prompt
+
+在 `internal/context/builder.go` 的 `Build()` 方法末尾临时添加：
+```go
+fmt.Fprintf(os.Stderr, "=== SYSTEM PROMPT ===\n%s\n===================\n", prompt)
+```
+
+### 检查工具注册
+
+在 `registry.Execute` 前打印可用工具列表：
+```go
+for _, def := range registry.GetAvailableTools() {
+    fmt.Fprintf(os.Stderr, "tool: %s\n", def.Name)
+}
+```
+
+### Provider 请求/响应
+
+如需查看实际 API 请求，在 `internal/provider/openai.go` 中打印消息列表。
+
+## harness9 特有问题
+
+### Anthropic Provider：user/assistant 必须严格交替
+
+症状：`400 Bad Request` 或 `invalid_request_error`
+
+原因：Anthropic Messages API 禁止连续 assistant 消息。
+
+修复：检查 `contextHistory` 的消息顺序，确保 system→user→assistant→user→assistant 交替。
+
+### 路径沙箱拒绝访问
+
+症状：工具返回 `路径超出工作区范围` 或类似错误
+
+原因：路径包含 `../` 或绝对路径指向 `WORK_DIR` 之外。
+
+修复：Agent 应使用相对于 `WORK_DIR` 的路径，如 `internal/engine/agent_loop.go` 而非 `/absolute/path/...`。
+
+### Skills 未加载
+
+症状：Agent 不知道有 Skills 可用
+
+检查：
+1. `skills/` 目录是否在 `WORK_DIR` 下（而非项目根目录的其他位置）
+2. Skill 文件是否有 `name` 和 `description` frontmatter 字段
+3. 启动日志中是否有 `warn` 输出
+
+## go vet 常见 warning
+
+| Warning | 含义 | 修复 |
+|---------|------|------|
+| `printf` 格式不匹配 | `%s` 传入了非 string 类型 | 修正格式或类型 |
+| `unreachable code` | return 后有代码 | 删除死代码 |
+| `loop variable captured` | goroutine 捕获了循环变量 | 传参而非捕获 |

--- a/skills/go-coding-standards.md
+++ b/skills/go-coding-standards.md
@@ -1,0 +1,136 @@
+---
+name: go-coding-standards
+description: Use when writing or reviewing Go code — explains harness9 project coding conventions and patterns
+trigger: write, review, refactor, add, implement
+---
+
+# harness9 Go 编码规范
+
+## 命名规范
+
+| 类别 | 规范 | 示例 |
+|------|------|------|
+| 包名 | 小写、单单词、无下划线 | `engine`、`provider`、`schema` |
+| 导出类型/函数 | PascalCase | `AgentEngine`、`NewRegistry` |
+| 未导出类型/函数 | camelCase | `mainLoop`、`runLoop` |
+| 接口名 | 以 `-er` 后缀为惯例 | `Provider`、`Registry`、`BaseTool` |
+| 常量 | PascalCase（导出）或 camelCase（未导出），**不使用全大写** | `RoleSystem`、`maxLogOutputLen` |
+| 配置选项函数 | `With` 前缀 | `WithMaxTurns`、`WithToolTimeout` |
+
+## 错误处理
+
+- 显式检查所有 `error` 返回值，**禁止 `_` 忽略**
+- 错误消息不以大写字母开头、不以句号结尾
+- 使用 `fmt.Errorf("context: %w", err)` 包装错误，保留错误链
+
+```go
+// ✅ 正确
+result, err := doSomething()
+if err != nil {
+    return fmt.Errorf("do something: %w", err)
+}
+
+// ❌ 错误
+result, _ := doSomething()
+```
+
+## 构造函数
+
+命名规范：`New` + 类型名
+
+```go
+func NewReadFileTool(workDir string) *ReadFileTool {
+    return &ReadFileTool{workDir: filepath.Clean(workDir)}
+}
+```
+
+## 接口定义原则
+
+**接口定义在使用者侧，而非实现者侧。**
+
+```go
+// ✅ 正确：Registry 接口定义在 tools 包（使用者侧）
+// internal/tools/registry.go
+type Registry interface {
+    Register(tool BaseTool) error
+    GetAvailableTools() []schema.ToolDefinition
+    Execute(ctx context.Context, call schema.ToolCall) schema.ToolResult
+}
+
+// ❌ 错误：不要在实现所在的包中定义接口
+```
+
+## 并发模式
+
+并发工具执行使用预分配切片 + 索引写入，确保结果顺序：
+
+```go
+// Go 1.22+ 中 for range 每次迭代已自动创建新绑定，无需手动传参捕获。
+// 本项目使用 Go 1.25，以下写法是正确的：
+results := make([]schema.ToolResult, len(toolCalls))
+var wg sync.WaitGroup
+for i, tc := range toolCalls {
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        toolCtx, cancel := context.WithTimeout(ctx, e.toolTimeout)
+        defer cancel()
+        results[i] = e.registry.Execute(toolCtx, tc)
+    }()
+}
+wg.Wait()
+```
+
+## 添加新工具的步骤
+
+1. 在 `internal/tools/` 下创建 `xxx.go`，实现 `BaseTool` 接口
+2. 使用 `safePath()` 校验所有文件路径参数
+3. 在 `internal/tools/xxx_test.go` 中添加表驱动测试
+4. 在 `cmd/harness9/main.go` 中注册工具
+
+```go
+type MyTool struct {
+    workDir string
+}
+
+func (t *MyTool) Name() string { return "my_tool" }
+func (t *MyTool) Definition() schema.ToolDefinition { /* JSON Schema */ }
+func (t *MyTool) Execute(ctx context.Context, args json.RawMessage) (string, error) { /* ... */ }
+```
+
+## 测试规范
+
+- 使用标准库 `testing` 包，不引入第三方断言库
+- 表驱动测试优先
+- 运行：`go test ./...`
+
+```go
+func TestXxx(t *testing.T) {
+    cases := []struct {
+        name  string
+        input string
+        want  string
+    }{
+        {"normal", "foo", "bar"},
+        {"empty", "", ""},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            got := Xxx(tc.input)
+            if got != tc.want {
+                t.Errorf("got %q, want %q", got, tc.want)
+            }
+        })
+    }
+}
+```
+
+## 代码检查
+
+提交前必须通过：
+
+```bash
+gofmt -l .        # 无输出表示格式正确
+go vet ./...      # 无 warning
+go test ./...     # 全部通过
+```


### PR DESCRIPTION
## Summary

- **Agent Skills 系统**：新增 `internal/skills/` 包，支持从 `workdir/skills/*.md` 加载领域知识；遵循 Progressive Disclosure 原则，System Prompt 仅注入索引，LLM 通过 `use_skill` 工具按需加载全文
- **Context Engineering**：新增 `internal/context/` 包，`DefaultPromptBuilder` 结构化组装 System Prompt（基础 Prompt + AGENTS.md + Skills 索引），通过 `engine.PromptBuilder` 接口与引擎解耦
- **交互式 CLI REPL**：`harness9` 默认以终端 Agent 模式运行，无需飞书配置；`--feishu` 标志启用飞书 Bot 模式
- **文档与示例**：新增 CLI 使用指南、Agent Skills 设计文档、3 个示例 Skill 文件；更新 README、agent-loop.md

## Test Plan

- [ ] `go test ./...` 全量测试通过（含 skills 包 20 个测试、context 包 4 个测试、engine 新增 2 个测试、cli 包 4 个测试）
- [ ] `go build ./...` 编译无报错
- [ ] `gofmt -l .` 无格式问题
- [ ] `go vet ./...` 无 warning
- [ ] CLI 模式：`go run ./cmd/harness9` 启动后可正常对话、exit/Ctrl-C 退出
- [ ] 飞书模式：`go run ./cmd/harness9 --feishu` 在未配置飞书环境变量时正确报错
- [ ] Skills 加载：在 `WORK_DIR/skills/` 放置 `.md` 文件后，Agent 能在 System Prompt 中感知到 Skills 索引