### PR TITLE
feat: 内置 upgrade 子命令，支持一键自升级到最新 CLI 版本

### DIFF
--- a/.claude/skills/release-cli/skill.md
+++ b/.claude/skills/release-cli/skill.md
@@ -1,0 +1,145 @@
+---
+name: release-cli
+description: 发布 harness9 CLI 新版本。接受可选的 version 参数；若未提供，则自动将当前最新 tag 的 patch 号加 1。执行：切换到 master、拉取最新代码、创建 tag、推送 tag 触发 GoReleaser。
+---
+
+# release-cli — 发布 CLI 新版本
+
+## 概述
+
+将 harness9 CLI 发布为新版本。通过在 `master` 分支上创建版本 tag，触发 GitHub Actions 中的 GoReleaser 工作流，自动构建并发布二进制文件。
+
+## 参数
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `version` | string | 否 | 要发布的版本号（如 `v0.1.5` 或 `0.1.5`）。若未提供，自动取当前最新 tag 的 patch+1 |
+
+## 执行步骤
+
+### 1. 确定版本号
+
+**若用户提供了 `version` 参数：**
+
+```bash
+# 规范化：确保以 v 开头
+version="v0.1.5"  # 示例，若用户输入 "0.1.5" 则补全为 "v0.1.5"
+```
+
+**若用户未提供 `version` 参数：**
+
+```bash
+# 获取当前最新 tag（按语义化版本排序）
+latest=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+# 若无任何 tag，从 v0.0.1 开始
+if [ -z "$latest" ]; then
+  version="v0.0.1"
+else
+  # 解析 major.minor.patch，将 patch+1
+  # 例：v0.1.4 → v0.1.5
+  version=$(echo "$latest" | awk -F'[v.]' '{printf "v%d.%d.%d", $2, $3, $4+1}')
+fi
+
+echo "当前最新版本：$latest"
+echo "即将发布版本：$version"
+```
+
+在继续之前，**向用户展示计算出的版本号**，确认无误。
+
+### 2. 前置检查
+
+```bash
+# 检查当前分支
+git branch --show-current
+
+# 检查工作区是否干净（有未提交内容时警告）
+git status --short
+```
+
+**若当前不在 `master` 分支：**
+
+提示用户切换：
+```bash
+git checkout master
+```
+
+**若工作区有未提交的改动：** 询问用户是否继续（未提交内容不影响 tag 发布，但可能意味着遗漏了提交）。
+
+### 3. 拉取最新代码
+
+```bash
+git pull origin master
+```
+
+确认本地 `master` 与远程同步。
+
+### 4. 确认 tag 不存在
+
+```bash
+git tag | grep "^${version}$"
+```
+
+若 tag 已存在，**停止执行**，提示用户该版本已发布，建议使用更高版本号。
+
+### 5. 创建并推送 tag
+
+```bash
+# 创建轻量 tag
+git tag "${version}"
+
+# 推送 tag 到远程，触发 GitHub Actions release.yml
+git push origin "${version}"
+```
+
+### 6. 确认发布触发
+
+```bash
+# 查看最近的 Actions 运行（需 gh CLI 已登录）
+gh run list --limit 3
+```
+
+告知用户：
+- tag 已推送：`${version}`
+- GitHub Actions `release.yml` 已触发（由 `on: push: tags: ['v*']` 驱动）
+- GoReleaser 将自动构建多平台二进制并创建 GitHub Release
+- 可通过 `gh run list` 或 GitHub Actions 页面查看构建进度
+
+## 常见错误
+
+| 问题 | 处理 |
+|------|------|
+| tag 已存在 | 停止执行，建议使用更高版本号 |
+| 不在 master 分支 | 提示切换到 master 后再发布 |
+| push 被拒绝（无权限） | 检查 git remote 权限，确认有 push 到主仓库的权限 |
+| `gh run list` 无输出 | 提示用户通过 GitHub 网页查看 Actions 执行状态 |
+| 无任何历史 tag | 从 `v0.0.1` 开始，提示用户确认 |
+
+## 发布流程图
+
+```
+确定版本号（用户指定 or patch+1）
+    ↓
+确认当前在 master 分支
+    ↓
+git pull origin master（同步最新）
+    ↓
+确认 tag 不存在
+    ↓
+git tag v{version}
+    ↓
+git push origin v{version}
+    ↓
+GitHub Actions release.yml 触发
+    ↓
+GoReleaser 构建多平台二进制
+    ↓
+GitHub Release 页面自动创建
+```
+
+## 注意事项
+
+- 发布**必须从 `master` 分支**进行，确保发布的是经过 review 的代码
+- 版本号遵循 [SemVer](https://semver.org/)：`vMAJOR.MINOR.PATCH`
+- GoReleaser 配置见项目根目录 `.goreleaser.yaml`
+- GitHub Actions release 工作流见 `.github/workflows/release.yml`

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -36,6 +36,15 @@ import (
 var version = "dev"
 
 func main() {
+	// upgrade 子命令在 flag 解析前处理，避免与 flag 系统冲突。
+	if len(os.Args) > 1 && os.Args[1] == "upgrade" {
+		if err := RunUpgrade(version); err != nil {
+			fmt.Fprintf(os.Stderr, "升级失败: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	versionMode := flag.Bool("version", false, "打印版本号并退出")
 	flag.Parse()
 

--- a/cmd/harness9/upgrade.go
+++ b/cmd/harness9/upgrade.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// httpClient 带超时的 HTTP 客户端，避免网络不稳定时无限阻塞。
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+const githubRepo = "ZhangShenao/harness9"
+
+// githubRelease 对应 GitHub Releases API 的响应结构（仅提取所需字段）。
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// RunUpgrade 检查并升级 harness9 到最新版本。
+// currentVersion 由编译时 ldflags 注入（如 "0.0.2"）；本地开发构建为 "dev"。
+func RunUpgrade(currentVersion string) error {
+	fmt.Println("正在检查最新版本...")
+
+	release, err := fetchLatestRelease()
+	if err != nil {
+		return err
+	}
+
+	latestTag := release.TagName                    // "v0.0.2"
+	latestVer := strings.TrimPrefix(latestTag, "v") // "0.0.2"
+	currentVer := strings.TrimPrefix(currentVersion, "v")
+
+	if currentVersion == "dev" {
+		fmt.Printf("当前版本：dev（开发构建），最新发布版本：%s\n", latestTag)
+		fmt.Print("继续将用正式版本覆盖当前二进制，确认升级？[y/N] ")
+		var input string
+		fmt.Scanln(&input)
+		if strings.ToLower(strings.TrimSpace(input)) != "y" {
+			fmt.Println("已取消。")
+			return nil
+		}
+	} else if currentVer == latestVer {
+		fmt.Printf("当前已是最新版本 %s，无需更新。\n", latestTag)
+		return nil
+	} else {
+		fmt.Printf("发现新版本：%s（当前：%s）\n", latestTag, currentVersion)
+	}
+
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+
+	tarballName := fmt.Sprintf("harness9_%s_%s_%s.tar.gz", latestVer, goos, goarch)
+	checksumName := fmt.Sprintf("harness9_%s_SHA256SUMS", latestVer)
+
+	tarballURL := findAssetURL(release, tarballName)
+	if tarballURL == "" {
+		return fmt.Errorf("未找到适用于 %s/%s 的版本包（%s）", goos, goarch, tarballName)
+	}
+	checksumURL := findAssetURL(release, checksumName)
+
+	// 下载到临时目录
+	tmpDir, err := os.MkdirTemp("", "harness9-upgrade-*")
+	if err != nil {
+		return fmt.Errorf("创建临时目录失败: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fmt.Printf("正在下载 %s...\n", tarballName)
+	tarballPath := filepath.Join(tmpDir, tarballName)
+	if err := downloadFile(tarballURL, tarballPath); err != nil {
+		return fmt.Errorf("下载失败: %w", err)
+	}
+
+	// SHA256 校验（若 checksumURL 不为空）
+	if checksumURL != "" {
+		checksumPath := filepath.Join(tmpDir, checksumName)
+		if err := downloadFile(checksumURL, checksumPath); err != nil {
+			fmt.Fprintf(os.Stderr, "警告：无法下载校验文件，跳过 SHA256 校验: %v\n", err)
+		} else {
+			fmt.Println("正在校验 SHA256...")
+			if err := verifySHA256(tarballPath, tarballName, checksumPath); err != nil {
+				return fmt.Errorf("SHA256 校验失败: %w", err)
+			}
+		}
+	}
+
+	// 解压出 harness9 二进制
+	binaryPath := filepath.Join(tmpDir, "harness9")
+	fmt.Println("正在解压...")
+	if err := extractBinary(tarballPath, "harness9", binaryPath); err != nil {
+		return err
+	}
+	if err := os.Chmod(binaryPath, 0755); err != nil {
+		return fmt.Errorf("设置执行权限失败: %w", err)
+	}
+
+	// 原子替换当前可执行文件
+	execPath, err := resolveExecutablePath()
+	if err != nil {
+		return err
+	}
+
+	// 先将新二进制移动到目标目录的临时文件，再重命名（确保跨文件系统时复制）
+	destTmp := execPath + ".new"
+	if err := moveOrCopy(binaryPath, destTmp); err != nil {
+		return fmt.Errorf("写入目标目录失败（可能需要 sudo）: %w", err)
+	}
+	if err := os.Rename(destTmp, execPath); err != nil {
+		os.Remove(destTmp)
+		return fmt.Errorf("替换可执行文件失败（可能需要 sudo）: %w", err)
+	}
+
+	fmt.Printf("升级成功：harness9 %s\n", latestTag)
+	return nil
+}
+
+func fetchLatestRelease() (*githubRelease, error) {
+	url := "https://api.github.com/repos/" + githubRepo + "/releases/latest"
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("请求 GitHub API 失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API 返回 %s", resp.Status)
+	}
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("解析版本信息失败: %w", err)
+	}
+	return &rel, nil
+}
+
+func findAssetURL(rel *githubRelease, name string) string {
+	for _, a := range rel.Assets {
+		if a.Name == name {
+			return a.BrowserDownloadURL
+		}
+	}
+	return ""
+}
+
+func downloadFile(url, dest string) error {
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %s", resp.Status)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// verifySHA256 从 SHA256SUMS 文件中找到 tarballName 对应的期望摘要，与实际文件比对。
+func verifySHA256(tarballPath, tarballName, checksumPath string) error {
+	expected, err := readExpectedChecksum(checksumPath, tarballName)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := fmt.Sprintf("%x", h.Sum(nil))
+
+	if actual != expected {
+		return fmt.Errorf("期望 %s，实际 %s", expected, actual)
+	}
+	return nil
+}
+
+func readExpectedChecksum(checksumPath, tarballName string) (string, error) {
+	f, err := os.Open(checksumPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// 格式：<hash>  <filename> 或 <hash> *<filename>
+		parts := strings.Fields(line)
+		if len(parts) == 2 {
+			name := strings.TrimPrefix(parts[1], "*")
+			if name == tarballName {
+				return parts[0], nil
+			}
+		}
+	}
+	return "", fmt.Errorf("在 SHA256SUMS 中未找到 %s 的校验值", tarballName)
+}
+
+// extractBinary 从 .tar.gz 中提取名为 binaryName 的文件到 destPath。
+func extractBinary(tarballPath, binaryName, destPath string) error {
+	f, err := os.Open(tarballPath)
+	if err != nil {
+		return fmt.Errorf("打开压缩包失败: %w", err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("解压 gzip 失败: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("读取 tar 失败: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(hdr.Name) != binaryName {
+			continue
+		}
+
+		out, err := os.Create(destPath)
+		if err != nil {
+			return fmt.Errorf("创建输出文件失败: %w", err)
+		}
+		_, copyErr := io.Copy(out, tr)
+		out.Close()
+		if copyErr != nil {
+			return fmt.Errorf("写入二进制文件失败: %w", copyErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("在压缩包中未找到 %s", binaryName)
+}
+
+func resolveExecutablePath() (string, error) {
+	p, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("获取当前可执行文件路径失败: %w", err)
+	}
+	p, err = filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", fmt.Errorf("解析符号链接失败: %w", err)
+	}
+	return p, nil
+}
+
+// moveOrCopy 尝试 os.Rename；若跨设备则回退到 copy + 显式 close（确保写入完整）。
+func moveOrCopy(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	// 跨设备场景：复制内容
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/cmd/harness9/upgrade_test.go
+++ b/cmd/harness9/upgrade_test.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildTarGz 在内存中构造一个包含单个文件的 .tar.gz，返回其字节内容。
+func buildTarGz(t *testing.T, filename, content string) []byte {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "out.tar.gz")
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+
+	body := []byte(content)
+	hdr := &tar.Header{
+		Name:     filename,
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(body)),
+		Mode:     0755,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	tw.Close()
+	gw.Close()
+	f.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestExtractBinary(t *testing.T) {
+	cases := []struct {
+		name       string
+		tarEntry   string // 压缩包内的文件名
+		binaryName string // 要提取的目标文件名
+		content    string
+		wantErr    bool
+	}{
+		{"命中文件", "harness9", "harness9", "binary-content", false},
+		{"带路径前缀的 tar 条目", "dist/harness9", "harness9", "binary-content", false},
+		{"目标不存在", "other", "harness9", "x", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := buildTarGz(t, tc.tarEntry, tc.content)
+
+			tarPath := filepath.Join(t.TempDir(), "pkg.tar.gz")
+			if err := os.WriteFile(tarPath, data, 0644); err != nil {
+				t.Fatal(err)
+			}
+			destPath := filepath.Join(t.TempDir(), "harness9")
+
+			err := extractBinary(tarPath, tc.binaryName, destPath)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("期望错误，但得到 nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("意外错误: %v", err)
+			}
+			got, _ := os.ReadFile(destPath)
+			if string(got) != tc.content {
+				t.Fatalf("内容不匹配：期望 %q，得到 %q", tc.content, got)
+			}
+		})
+	}
+}
+
+func TestVerifySHA256(t *testing.T) {
+	dir := t.TempDir()
+
+	// 构造测试文件
+	content := []byte("hello harness9")
+	tarball := filepath.Join(dir, "harness9_1.0.0_linux_amd64.tar.gz")
+	if err := os.WriteFile(tarball, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 计算正确哈希
+	h := sha256.New()
+	h.Write(content)
+	correctHash := fmt.Sprintf("%x", h.Sum(nil))
+	wrongHash := strings.Repeat("0", 64)
+
+	tarballName := "harness9_1.0.0_linux_amd64.tar.gz"
+
+	cases := []struct {
+		name    string
+		lines   []string
+		wantErr bool
+	}{
+		{
+			"正确哈希",
+			[]string{correctHash + "  " + tarballName},
+			false,
+		},
+		{
+			"错误哈希",
+			[]string{wrongHash + "  " + tarballName},
+			true,
+		},
+		{
+			"星号格式",
+			[]string{correctHash + " *" + tarballName},
+			false,
+		},
+		{
+			"文件中无对应条目",
+			[]string{correctHash + "  other_file.tar.gz"},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checksumPath := filepath.Join(dir, "SHA256SUMS")
+			if err := os.WriteFile(checksumPath, []byte(strings.Join(tc.lines, "\n")), 0644); err != nil {
+				t.Fatal(err)
+			}
+			err := verifySHA256(tarball, tarballName, checksumPath)
+			if tc.wantErr && err == nil {
+				t.Fatal("期望错误，但得到 nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("意外错误: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadExpectedChecksum(t *testing.T) {
+	cases := []struct {
+		name        string
+		fileContent string
+		target      string
+		wantHash    string
+		wantErr     bool
+	}{
+		{
+			"双空格格式",
+			"abc123  file.tar.gz\ndef456  other.tar.gz",
+			"file.tar.gz",
+			"abc123",
+			false,
+		},
+		{
+			"星号格式",
+			"abc123 *file.tar.gz",
+			"file.tar.gz",
+			"abc123",
+			false,
+		},
+		{
+			"目标不存在",
+			"abc123  other.tar.gz",
+			"file.tar.gz",
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "SHA256SUMS")
+			if err := os.WriteFile(path, []byte(tc.fileContent), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := readExpectedChecksum(path, tc.target)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("期望错误，但得到 nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("意外错误: %v", err)
+			}
+			if got != tc.wantHash {
+				t.Fatalf("期望 %q，得到 %q", tc.wantHash, got)
+			}
+		})
+	}
+}
+
+func TestDownloadFile(t *testing.T) {
+	body := "tarball-content"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "out.tar.gz")
+	if err := downloadFile(srv.URL, dest); err != nil {
+		t.Fatalf("downloadFile 返回错误: %v", err)
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != body {
+		t.Fatalf("期望 %q，得到 %q", body, got)
+	}
+}
+
+func TestDownloadFileHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	err := downloadFile(srv.URL, filepath.Join(t.TempDir(), "out"))
+	if err == nil {
+		t.Fatal("期望错误，但得到 nil")
+	}
+}
+
+func TestFetchLatestRelease(t *testing.T) {
+	rel := githubRelease{
+		TagName: "v1.2.3",
+		Assets: []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		}{
+			{Name: "harness9_1.2.3_linux_amd64.tar.gz", BrowserDownloadURL: "https://example.com/harness9.tar.gz"},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(rel)
+	}))
+	defer srv.Close()
+
+	// 临时替换 httpClient 指向测试服务器
+	orig := httpClient
+	httpClient = &http.Client{}
+	defer func() { httpClient = orig }()
+
+	// fetchLatestRelease 硬编码了 GitHub URL，无法直接注入，
+	// 改为直接测试 downloadFile + JSON decode 的集成路径。
+	var got githubRelease
+	resp, err := httpClient.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.TagName != rel.TagName {
+		t.Fatalf("期望 %q，得到 %q", rel.TagName, got.TagName)
+	}
+	if len(got.Assets) != 1 || got.Assets[0].Name != rel.Assets[0].Name {
+		t.Fatalf("Assets 不匹配: %+v", got.Assets)
+	}
+}
+
+func TestFindAssetURL(t *testing.T) {
+	rel := &githubRelease{
+		Assets: []struct {
+			Name               string `json:"name"`
+			BrowserDownloadURL string `json:"browser_download_url"`
+		}{
+			{Name: "harness9_1.0.0_darwin_arm64.tar.gz", BrowserDownloadURL: "https://example.com/darwin_arm64.tar.gz"},
+			{Name: "harness9_1.0.0_linux_amd64.tar.gz", BrowserDownloadURL: "https://example.com/linux_amd64.tar.gz"},
+		},
+	}
+
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"harness9_1.0.0_darwin_arm64.tar.gz", "https://example.com/darwin_arm64.tar.gz"},
+		{"harness9_1.0.0_linux_amd64.tar.gz", "https://example.com/linux_amd64.tar.gz"},
+		{"harness9_1.0.0_windows_amd64.zip", ""},
+	}
+
+	for _, tc := range cases {
+		got := findAssetURL(rel, tc.name)
+		if got != tc.want {
+			t.Errorf("findAssetURL(%q) = %q，期望 %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestMoveOrCopy(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "src")
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	if err := os.WriteFile(src, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveOrCopy(src, dst); err != nil {
+		t.Fatalf("moveOrCopy 返回错误: %v", err)
+	}
+	got, _ := os.ReadFile(dst)
+	if string(got) != "content" {
+		t.Fatalf("内容不匹配: %q", got)
+	}
+}
+
+// fakeScanner 用于在测试中替换 bufio.Scanner 的输入源（间接验证 readExpectedChecksum）。
+func TestReadExpectedChecksumEmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "SHA256SUMS")
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, _ := os.Open(path)
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		t.Error("不应有任何行")
+	}
+}

--- a/docs/核心功能/cli.md
+++ b/docs/核心功能/cli.md
@@ -19,6 +19,37 @@ harness9 --version
 # harness9 v0.1.0
 ```
 
+---
+
+## 升级
+
+已安装 harness9 的用户可直接通过内置 `upgrade` 命令升级到最新版本：
+
+```bash
+harness9 upgrade
+```
+
+升级过程：
+
+1. 查询 GitHub Releases API，获取最新版本号
+2. 与当前版本比较，若已是最新则退出
+3. 下载适用于当前平台（OS / 架构）的压缩包
+4. SHA256 校验（确保完整性）
+5. 解压并原子替换当前可执行文件
+
+示例输出：
+
+```
+正在检查最新版本...
+发现新版本：v0.1.1（当前：0.1.0）
+正在下载 harness9_0.1.1_darwin_arm64.tar.gz...
+正在校验 SHA256...
+正在解压...
+升级成功：harness9 v0.1.1
+```
+
+> **注意**：若 harness9 安装在需要 root 权限的目录（如 `/usr/local/bin`），升级时可能提示权限错误，请使用 `sudo harness9 upgrade`。
+
 ### 从源码构建（开发者）
 
 ```bash


### PR DESCRIPTION
## Summary

- 新增 `harness9 upgrade` 子命令：查询 GitHub Releases API 获取最新版本，下载对应平台 tarball，SHA256 校验后原子替换当前可执行文件
- 引入带 30s 超时的共享 `httpClient`，防止网络不稳定时无限阻塞
- `downloadFile` / `moveOrCopy` 均显式 close 并检查错误，避免写入失败时静默丢失
- dev 构建执行 upgrade 时增加 `[y/N]` 确认提示，防止误覆盖本地开发二进制
- 新增 `upgrade_test.go`，覆盖 tar 解压、SHA256 校验、HTTP 下载、asset 查找、文件复制等 10 个用例
- 新增 `release-cli` Claude Code Skill，文档化版本发布流程
- `docs/核心功能/cli.md` 补充"升级"章节

## Test Plan

- [ ] `go test ./...` 全量通过（含新增 upgrade 测试用例）
- [ ] `go build ./cmd/harness9` 编译无错误
- [ ] 本地执行 `harness9 upgrade` 验证：已是最新版本时提示无需更新
- [ ] 验证 `dev` 版本执行 upgrade 时出现 `[y/N]` 确认提示