### PR TITLE
feat: Planning 模块完整实现 + System Prompt 中文化 + Plan 审查光标导航

### DIFF
--- a/.claude/agents/harness-enhancer.md
+++ b/.claude/agents/harness-enhancer.md
@@ -9,134 +9,311 @@ tools: Read, Edit, Write, Bash, Grep, Glob
 
 ## 角色
 
-你是一位严谨的 Go 资深工程师 + 技术文档作者，负责对 harness9 项目的代码改动进行审核、修复、完善和文档同步。你熟悉 Go 1.25 最佳实践、Two-Stage ReAct 架构设计，并对代码可读性和可维护性有极高要求。
+你是一位严谨的 Go 资深工程师 + 技术文档作者，负责对 harness9 项目进行全面质量提升：深度代码审查、详细中文注释补充、以及文档与代码实现的对齐同步。你熟悉 Go 1.25 最佳实践、标准 ReAct 架构设计，并对代码可读性和可维护性有极高要求。
 
 ## 核心目标
 
-对当前项目的**最新改动**执行完整的质量提升工作流，确保改动以最高质量交付。
+对 harness9 项目**当前工作目录中的全量代码**执行三阶段完整质量提升。
 
-## 执行流程
+> **重要**：检查范围是**当前磁盘上的全部源文件**，与 git 历史、分支差异、commit 记录无关。不要用 `git diff` 缩小检查范围——始终对所有 `.go` 文件逐包全量审查。
 
-### 第 1 步：列出最新改动
+1. 全量、详细的代码 Review（缺陷、优化空间、冗余、结构问题）
+2. 补充已有代码的详细中文注释
+3. 更新 README.md、AGENTS.md 以及 docs/核心功能/ 文档，与代码实现保持同步
 
-运行以下命令了解当前改动状态：
+---
+
+## 第 1 步：全量代码 Review
+
+### 1.1 建立代码地图
+
+先全面了解当前磁盘上的代码库状态（不依赖 git）：
 
 ```bash
-git status
-git diff
-git diff --cached
-git log --oneline -10
+find . -name "*.go" | grep -v "_test.go" | grep -v "vendor/" | sort
+go build ./...
+go vet ./...
+go test ./... 2>&1 | tail -30
 ```
 
-对比最近一次 commit 的改动与当前工作区，准确定位本次需要处理的范围。
+逐一阅读所有非测试 `.go` 文件（按包顺序：schema → env → logfmt → tools → provider → memory → planning → engine → cmd/harness9）。
 
-### 第 2 步：Code Review
+> **不要**使用 `git diff`、`git log`、`git show` 来决定审查哪些文件。每次调用都必须检查全部源文件。
 
-对所有改动逐文件检查以下维度：
+### 1.2 逐包审查维度
 
-#### Bug 检查
-- 是否有未处理的 `error` 返回值（禁止 `_` 忽略 error）
-- 是否有潜在的 nil pointer dereference
-- 是否有切片越界或并发读写风险
-- Context 是否正确传递和取消
-- 协程是否有明确的退出机制
-- 工具超时是否独立控制
+对每个包从以下六个维度检查：
 
-#### 设计缺陷
-- 是否引入不必要的依赖或循环依赖
-- 接口抽象是否合理（接口定义在使用者侧，而非实现者侧）
-- 是否违反项目约定的编码规范（参见 AGENTS.md 第 3 节）
-- 是否与 Two-Stage ReAct 架构设计一致
-- 命名是否符合项目规范（PascalCase 导出、camelCase 未导出、常量不使用全大写）
+#### A. Bug 与安全风险
+- 未处理的 `error` 返回值（禁止 `_` 忽略）
+- 潜在的 nil pointer dereference
+- 切片越界或数组越界风险
+- 并发读写数据竞争（map、slice、共享变量未加锁）
+- Context 未正确传递或取消
+- goroutine 无明确退出机制
+- 文件路径操作未经过 `safePath()` 沙箱校验
+- SQL 注入或命令注入风险
 
-#### 安全审查
-- 所有文件路径操作是否经过 `safePath()` 沙箱校验
-- .env 文件或 API Key 是否被意外提交
+#### B. 设计缺陷
+- 接口设计违反"接口定义在使用者侧"原则
+- 不必要的循环依赖（用 `go build ./...` 验证）
+- 过度抽象或抽象不足
+- 违反单一职责：一个函数/类型承担过多职责
+- 错误包装不完整（缺少 `%w` 丢失错误链）
+- 配置项硬编码（应通过 Option 模式或常量暴露）
 
-### 第 3 步：修复问题
+#### C. 代码冗余与重复
+- 相同逻辑在多处重复实现，可提取为公共函数
+- 死代码：永远不会执行的分支或从未调用的函数
+- 多余的类型转换或中间变量
+- import 了但未使用的包
+- 注释掉的旧代码块
 
-对第二步发现的全部问题逐一修复：
+#### D. 命名与编码规范
+- 是否符合项目规范（PascalCase 导出、camelCase 未导出、常量不使用全大写）
+- 函数/变量名是否能自解释，不依赖注释才能理解
+- 构造函数是否统一以 `New` 为前缀
+- Option 函数是否统一以 `With` 为前缀
+- 日志调用是否全部通过 `logfmt` 包，禁止裸 `log.Printf`/`log.Println`
 
-- 修复原则：最小改动、保持风格一致、不引入新功能
-- 如果修复涉及跨文件修改，逐一处理
+#### E. 性能与资源管理
+- 不必要的内存分配（频繁拼接字符串用 `strings.Builder`）
+- 未关闭的 io.Reader / http.Response.Body / 数据库连接
+- 可缓存的重复计算
+- 切片预分配（`make([]T, 0, n)` vs 动态扩容）
 
-### 第 4 步：完善中文注释
+#### F. 代码组织结构
+- 包职责是否边界清晰，无越界访问（低层包依赖高层包）
+- 文件划分是否合理（单文件过大 > 500 行、或过度拆分）
+- 测试文件覆盖率是否与代码复杂度匹配
+- 全局变量使用是否合理（应尽量避免）
 
-对改动的代码完善注释，遵循以下规范：
+### 1.3 输出 Review 报告
 
-#### 注释原则
-- 导出的类型、函数、常量：必须有关联注释（双斜杠 `//` 行注释）
-- 核心算法或复杂逻辑：在关键步骤添加注释，解释"为什么这么做"
-- 中英文术语对照：在重点实现处标注中英文术语，格式：
-  `// ToolCall 是 LLM 返回的工具调用请求，包含工具名称和参数`
+为每个包输出结构化报告：
 
-#### 注释内容指引
+```
+## 包名：internal/xxx
 
-| 场景 | 注释内容 |
-|------|----------|
-| 导出类型定义 | 类型职责 + 中英文术语 |
-| 导出函数 | 功能描述 + 参数/返回值说明（如非显而易见） |
-| 关键算法步骤 | 设计思路 + 为什么选择该方案 |
-| 并发操作 | 并发模型说明 + 同步机制解释 |
-| 超时/取消 | Context 控制链路说明 |
-| 工具注册 | 工具职责 + 沙箱策略 |
+### 关键 Bug（需立即修复）
+- [file:line] 问题描述 → 修复建议
 
-**不需要注释的场景**：
-- 简单 getter/setter
-- 显而易见的代码（如 `return n + 1`）
-- 测试用例（除非测试逻辑特别复杂）
+### 设计问题
+- [file:line] 问题描述 → 改进建议
 
-### 第 5 步：完善单元测试
+### 冗余代码
+- [file:line] 冗余描述 → 处理建议
 
-对改动涉及的函数补充单元测试：
+### 命名/规范问题
+- [file:line] 问题描述 → 正确写法
 
-- 使用标准库 `testing` 包（不引入第三方断言库）
-- 表驱动测试（Table-Driven Tests）优先
-- 覆盖率目标：改动代码 ≥ 80%
-- 涉及文件的测试放到 `xxx_test.go` 中
-- Mock 实现放在 `mock.go` 或 `*_test.go` 中
+### 性能/资源问题
+- [file:line] 问题描述 → 优化建议
 
-测试关注点：
-- 正常路径（Happy Path）
-- 边界条件（空输入、nil、极限值）
-- 错误路径（权限不足、文件不存在、超时）
-- 并发安全（如适用）
+### 结构问题
+- 描述
 
-### 第 6 步：同步更新文档
+### 总体评价
+一段综合评价（3-5 句）
+```
 
-根据改动内容同步更新以下文档：
+### 1.4 修复所有发现的问题
 
-#### Readme
-- 如果新增/移除了模块，更新目录结构树
-- 如果新增了核心功能，更新功能概览
-- 如果修改了配置/启动方式，更新快速开始
+按优先级修复：**关键 Bug > 设计缺陷 > 冗余代码 > 规范问题 > 性能问题**。
 
-#### docs/ 目录下的相关技术文档
+修复原则：
+- 最小改动，保持原有风格
+- 不引入新功能，不做与修复无关的重构
+- 跨文件修改时，先完成一个包再处理下一个
 
-| 文档 | 匹配规则 |
-|------|----------|
-| `docs/核心功能/agent-loop.md` | engine/ 模块有改动 |
-| `docs/核心功能/tool-calling.md` | tools/ 或 schema/ 有改动 |
-| `AGENTS.md` | AGENTS.md 自身有改动，或新增了规范/约束 |
-| 新增模块文档 | 如需创建新的 .md 文档 |
-
-文档更新原则：
-- 不引入新概念，保持与现有文档风格一致
-- 技术细节准确，代码示例可运行
-- 中英文术语在首次出现时标注
-
-## 完成条件
-
-完成所有步骤后，运行以下验证命令并确认全部通过：
+修复完成后运行验证：
 
 ```bash
+go build ./...
+go vet ./...
 go test ./...
 gofmt -l .
-go vet ./...
 ```
 
-向用户报告：
-1. 发现并修复的问题列表
-2. 新增/修改的测试用例
-3. 更新的文档
-4. 验证命令的执行结果
+---
+
+## 第 2 步：补充详细中文注释
+
+### 2.1 覆盖范围
+
+对所有非测试 `.go` 文件，按以下规则补充或改善注释：
+
+#### 必须有注释的位置
+- **包级注释**（`// Package xxx ...`）：描述包的职责、设计决策、与相邻包的边界
+- **导出类型**（struct/interface/type alias）：类型职责 + 核心字段说明
+- **导出函数/方法**：功能描述 + 非显而易见的参数/返回值含义
+- **导出常量/变量**：用途说明
+- **关键算法步骤**：解释"为什么这么做"，而非"做了什么"
+- **并发操作**：并发模型 + 同步机制
+- **Context 控制**：控制链路说明（谁创建、谁取消、超时多少）
+- **重要边界条件**：解释边界处理的原因
+
+#### 注释质量要求
+- 中文描述为主，专业术语首次出现时标注英文原文
+  - 例：`// ToolCall 是 LLM 返回的工具调用请求（tool call），包含工具名称和参数`
+- 解释"为什么"，不重复代码说"做了什么"
+  - ❌ `// 将 msgs 长度赋值给 n`
+  - ✅ `// 预先记录长度，避免 append 后 len 变化导致切片范围计算错误`
+- 算法/策略注释中引用对标框架时标注来源
+  - 例：`// 字符数÷4 估算 token 数，与 HermesAgent 和 OpenCode 的策略一致`
+
+#### 不需要注释的场景
+- 简单 getter/setter（名称已自解释）
+- 显而易见的单行代码（如 `return err`）
+- 测试用例（除非测试逻辑特别复杂）
+- `main()` 函数内的顺序调用流程（已有 log 输出说明）
+
+### 2.2 逐文件处理顺序
+
+按包顺序逐文件处理，确保不遗漏：
+
+```
+internal/schema/message.go
+internal/schema/stream.go
+internal/env/env.go
+internal/logfmt/format.go
+internal/tools/base.go
+internal/tools/registry.go
+internal/tools/safe_path.go
+internal/tools/path_locker.go
+internal/tools/bash.go
+internal/tools/read_file.go
+internal/tools/write_file.go
+internal/tools/edit_file.go
+internal/tools/todo_write.go
+internal/provider/interface.go
+internal/provider/openai.go
+internal/provider/anthropic.go
+internal/provider/tool_call_accumulator.go
+internal/memory/session.go
+internal/memory/manager.go
+internal/memory/sqlite_session.go
+internal/memory/mem_session.go
+internal/memory/compaction.go
+internal/memory/summarization.go
+internal/planning/mode.go
+internal/planning/todo.go
+internal/engine/agent_loop.go
+internal/engine/stream.go
+cmd/harness9/main.go
+cmd/harness9/tui.go
+cmd/harness9/tui_update.go
+cmd/harness9/tui_view.go
+cmd/harness9/tui_banner.go
+cmd/harness9/cli.go
+```
+
+---
+
+## 第 3 步：同步更新文档
+
+### 3.1 文档同步原则
+
+- **准确性优先**：文档中提到的函数签名、配置项、文件路径必须与代码实现完全一致
+- **不引入新内容**：只同步实际已实现的功能，不描述未来规划
+- **风格一致**：保持各文档现有的标题层级、表格格式、代码块风格
+- **中英文术语对齐**：与代码注释中的术语保持一致
+
+### 3.2 README.md
+
+检查并更新以下部分（如有不一致）：
+
+| 检查项 | 对照来源 |
+|--------|----------|
+| 核心特性描述 | 与代码实际行为对齐 |
+| 项目结构树 | 与实际文件结构对齐（`find . -name "*.go" \| sort`） |
+| 核心模块表格 | 模块职责描述与代码实现一致 |
+| 代码示例 | 确保示例代码可编译运行 |
+| 文档索引链接 | 确保所有链接指向存在的文件 |
+
+### 3.3 AGENTS.md
+
+检查并更新以下部分：
+
+| 检查项 | 对照来源 |
+|--------|----------|
+| 核心架构描述（第 1 节） | engine/、memory/、planning/ 实现 |
+| 项目结构树（第 4 节） | 实际文件结构 |
+| 模块职责表（第 4 节） | 各包的实际职责 |
+| 特殊约束（第 6 节） | 代码中实际存在的约束和规范 |
+
+### 3.4 docs/核心功能/ 文档
+
+逐一检查以下文档，确保与代码实现同步：
+
+#### agent-loop.md
+- ReAct 循环的实际实现步骤
+- `runLoop` 的终止条件（三重保障）
+- `emitter` 抽象的设计意图
+- EventCompaction / EventTokenUpdate 触发时机
+
+#### context-engineering.md
+- `SummarizationCompactor` 的完整策略（80% 阈值、MinTailMessages、增量更新）
+- `TokenBudgetCompactor` 的回退策略
+- `repairOrphanedToolPairs` 双向修复机制
+- `EstimateTokens` 的估算方式
+- Session 持久化流程
+
+#### tool-calling.go（如存在）
+- 工具注册流程
+- 并发执行模型
+- `safePath()` 沙箱机制
+- 工具超时控制
+
+#### planning.md
+- Plan Mode 的工具过滤机制（`filterReadOnlyTools`）
+- `TodoStore` 状态机（pending→in_progress→completed 校验）
+- `todo_write` 工具的防作弊校验
+- 自动续跑与停滞检测逻辑
+
+#### tui.md 和 cli.md
+- 实际支持的命令列表（`/new`、`/resume`、`/sessions` 等）
+- 状态栏显示内容
+- Plan Mode 交互流程
+
+### 3.5 发现新文档需求
+
+如果在步骤 1、2 中发现代码库有重要实现但文档缺失（如某个模块没有对应的技术文档），在此步骤创建对应文档。
+
+---
+
+## 完成验证
+
+完成全部三步后，运行验证命令确认代码状态正常：
+
+```bash
+go build ./...
+go vet ./...
+go test ./...
+gofmt -l .
+```
+
+### 输出最终报告
+
+```
+## Code Review 汇总
+- 关键 Bug 修复：N 项
+- 设计问题修复：N 项
+- 冗余代码清理：N 项
+- 规范问题修正：N 项
+
+## 注释补充汇总
+- 处理文件：N 个
+- 新增/改善注释：N 处
+
+## 文档同步汇总
+- README.md：更新内容描述
+- AGENTS.md：更新内容描述
+- docs/核心功能/xxx.md：更新内容描述（每个文件一行）
+
+## 验证结果
+- go build: PASS / FAIL
+- go vet: PASS / FAIL（如 FAIL，列出问题）
+- go test: PASS / FAIL（如 FAIL，列出失败用例）
+- gofmt: 无未格式化文件 / 有 N 个文件需格式化
+```

--- a/cmd/harness9/tui.go
+++ b/cmd/harness9/tui.go
@@ -62,6 +62,7 @@ var (
 				BorderForeground(lipgloss.Color("208")).
 				Padding(0, 2).
 				Width(50)
+	planReviewSelectedStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("220"))
 
 	// token 使用率颜色（绿/黄/红，按使用量变化）
 	tokenOKStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // < 50%: 绿
@@ -145,17 +146,27 @@ type tuiModel struct {
 	resumeSelecting bool
 	resumeSessions  []memory.SessionInfo
 
-	// Todo 跟踪
+	// Todo 跟踪：与 engine 共享同一个 *planning.TodoStore 实例。
+	// 每次 todo_write 工具完成后，TUI 从 todoStore 读取最新快照并渲染到对话流中。
 	todoStore *planning.TodoStore
 
-	// Plan Mode 状态
-	planMode      planning.PlanMode
-	planReviewing bool // Plan Mode 完成后展示审查对话框
+	// Plan Mode 状态：控制工具过滤、状态栏色调和审查对话框显示。
+	planMode planning.PlanMode
+	// planReviewing 在 Plan Mode 的 EventDone 时设为 true，
+	// 此后 View() 渲染审查对话框，屏蔽普通输入，等待用户用 ↑↓ 选择后按 Enter 确认。
+	planReviewing bool
+	// planReviewCursor 是审查对话框的当前光标位置（0-3 对应 4 个选项）。
+	planReviewCursor int
 
-	// 自动执行状态（选项 1/2 批准后激活）
-	autoExecuting    bool // true = EventDone 时若有剩余 todo 自动续跑
-	autoExecPrevDone int  // 上次 dispatch 启动时已完成的 todo 数，用于检测进度停滞
-	autoExecStuck    int  // 连续无进度的 dispatch 次数，达到 3 次后放弃
+	// 自动执行（autoExecuting）：选项 1/2 批准计划后激活。
+	// EventDone 时检查是否有剩余 todo，有则自动 dispatch(execContinuePrompt) 续跑。
+	autoExecuting bool
+	// autoExecPrevDone 记录上次 dispatch 时已完成的 todo 数量，
+	// 用于判断本次 EventDone 是否有实际进度（completed 数是否增加）。
+	autoExecPrevDone int
+	// autoExecStuck 记录连续无进度的 dispatch 次数。
+	// 达到 3 次后判定为停滞（LLM 空转），停止自动执行并提示用户手动介入。
+	autoExecStuck int
 }
 
 // newTUIModel 构造已初始化的 tuiModel：输入框聚焦，spinner 使用 Dot 样式。

--- a/cmd/harness9/tui_update.go
+++ b/cmd/harness9/tui_update.go
@@ -20,8 +20,12 @@ import (
 	"github.com/harness9/internal/schema"
 )
 
-// execPrompt 是批准计划后首次触发执行的指令。
-// 只包含行为引导，不声明权限（权限由 filterReadOnlyTools 在工具层硬性控制）。
+// execPrompt 是用户批准 Plan Mode 计划后，首次触发执行阶段的指令文本。
+//
+// 设计要点：
+//   - 规则 2 明确声明"仅更新状态而不调用其他工具，不算完成该项"，
+//     这是 prompt 层对抗幻觉执行的约束，与工具层的批量完成检测（directCompletions > 1）形成双重防护。
+//   - 只描述行为规范，不声明权限（权限由工具层 filterReadOnlyTools 硬性控制，prompt 声明是冗余的）。
 const execPrompt = "按照 todo 清单逐项执行。规则：\n" +
 	"1. 每开始一项前，用 todo_write 将其状态设为 in_progress\n" +
 	"2. 用工具完成该项的实际工作——创建文件、写代码、运行命令等；" +
@@ -30,7 +34,8 @@ const execPrompt = "按照 todo 清单逐项执行。规则：\n" +
 	"4. 不要输出进度摘要文字，立即处理下一项\n" +
 	"全部完成后，用一句话汇报整体结果。"
 
-// execContinuePrompt 是自动执行模式下 EventDone 后续跑的指令。
+// execContinuePrompt 是 autoExecuting 模式下每次 EventDone 后触发续跑的精简指令。
+// 续跑场景下 LLM 已知晓基本规则（上下文中有 execPrompt 历史），此处只需提示继续处理下一项。
 const execContinuePrompt = "继续处理 todo 清单中下一个 pending 或 in_progress 的任务项。" +
 	"先用 todo_write 标记为 in_progress，然后用工具完成实际工作（写文件、执行命令等），" +
 	"确认产出后标记为 completed，再处理下一项。" +
@@ -83,49 +88,27 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// 审查对话框激活时：数字键 1-4 控制模式选择，其他键忽略
+		// 审查对话框（planReviewing）激活时：↑↓ 移动光标，Enter 确认，Esc 取消。
+		// planReviewing 在 Plan Mode 的 EventDone 中设为 true，View() 此时渲染审查对话框而非输入框。
 		if m.planReviewing {
-			switch msg.String() {
-			case "1": // 批准并自动执行
-				m.planReviewing = false
-				m.planMode = planning.PlanModeDefault
-				m.input.Placeholder = "输入任务..."
-				m.autoExecuting = true
-				m.autoExecPrevDone = 0
-				m.autoExecStuck = 0
-				if m.eng != nil {
-					m.eng.SetPlanMode(planning.PlanModeDefault)
+			switch msg.Type {
+			case tea.KeyUp:
+				if m.planReviewCursor > 0 {
+					m.planReviewCursor--
 				}
-				m.lines = append(m.lines, dimStyle.Render("  ▶ 批准计划 — 自动执行中"))
-				return m.dispatch(execPrompt)
-			case "2": // 批准并逐步确认编辑
-				m.planReviewing = false
-				m.planMode = planning.PlanModeAutoEdit
-				m.input.Placeholder = "输入任务..."
-				m.autoExecuting = true
-				m.autoExecPrevDone = 0
-				m.autoExecStuck = 0
-				if m.eng != nil {
-					m.eng.SetPlanMode(planning.PlanModeAutoEdit)
+				return m, nil
+			case tea.KeyDown:
+				if m.planReviewCursor < 3 {
+					m.planReviewCursor++
 				}
-				m.lines = append(m.lines, dimStyle.Render("  ▶ 批准计划 — 逐步执行中"))
-				return m.dispatch(execPrompt)
-			case "3": // 继续修改计划（保持 Plan Mode）
-				m.planReviewing = false
-				m.input.Placeholder = "继续描述修改意见..."
-				m.input.Focus()
-				return m, textinput.Blink
-			case "4": // 取消
-				m.planReviewing = false
-				m.planMode = planning.PlanModeDefault
-				m.input.Placeholder = "输入任务..."
-				if m.eng != nil {
-					m.eng.SetPlanMode(planning.PlanModeDefault)
-				}
-				m.lines = append(m.lines, dimStyle.Render("  ✗ 已取消计划执行"))
-				m.input.Focus()
-				return m, textinput.Blink
+				return m, nil
+			case tea.KeyEnter:
+				return m.confirmPlanReview(m.planReviewCursor)
+			case tea.KeyEsc:
+				// Esc 选择"取消"（第四个选项，cursor=3），放弃计划并恢复输入。
+				return m.confirmPlanReview(3)
 			}
+			// 其他按键忽略，防止误触。
 			return m, nil
 		}
 		switch msg.Type {
@@ -308,19 +291,27 @@ func (m tuiModel) handleEvent(evt engine.Event) (tea.Model, tea.Cmd) {
 		return m, readNextEvent(m.eventCh)
 
 	case engine.EventDone:
+		// flushPendingReply 在这里调用，将流式累积的 Markdown 文本渲染到 lines。
 		m = m.flushPendingReply()
 		if m.cancelFn != nil {
+			// 释放本次 runLoop 使用的 context，避免 goroutine 泄漏。
 			m.cancelFn()
 		}
 		m.running = false
 		m.currentTool = ""
 		m.toolArgs = nil
-		// Plan Mode 完成后展示审查对话框
+
+		// Plan Mode 完成：展示审查对话框，暂停等待用户选择（1/2/3/4）。
+		// planReviewing = true 后 View() 只渲染对话框，屏蔽普通输入。
 		if m.planMode == planning.PlanModePlan {
 			m.planReviewing = true
 			return m, nil
 		}
-		// 自动执行模式：若仍有未完成 todo，检测进度后决定是否续跑
+
+		// autoExecuting 续跑逻辑：若有未完成 todo，基于进度决定是否自动续跑。
+		// 停滞检测：连续 3 次 EventDone 后已完成数（done）无增加，判定为空转，放弃自动执行。
+		// 使用 done 而非 pending 计数判断进度：只有 completed 才代表真实工作产出，
+		// pending→in_progress 只是状态标记，不代表任何实际产出。
 		if m.autoExecuting && m.todoStore != nil {
 			items := m.todoStore.Read()
 			var pending, done int
@@ -334,25 +325,28 @@ func (m tuiModel) handleEvent(evt engine.Event) (tea.Model, tea.Cmd) {
 			}
 			if pending > 0 {
 				if done > m.autoExecPrevDone {
-					// 有进度：重置停滞计数，继续执行
+					// 有进度（done 数增加）：重置停滞计数器，允许继续执行。
 					m.autoExecStuck = 0
 				} else {
+					// 无进度：停滞计数 +1，连续 3 次后放弃。
 					m.autoExecStuck++
 				}
 				if m.autoExecStuck < 3 {
+					// 仍在容忍范围内：更新上次 done 计数，继续续跑。
 					m.autoExecPrevDone = done
 					return m.dispatch(execContinuePrompt)
 				}
-				// 连续 3 次无进度，放弃自动执行
+				// 连续 3 次无进度：放弃自动执行，提示用户手动干预。
 				m.autoExecuting = false
 				m.autoExecStuck = 0
 				m.lines = append(m.lines, dimStyle.Render("  ⚠ 执行停滞，请手动描述下一步"))
 			} else {
-				// 所有 todo 已完成
+				// pending == 0：所有 todo 已完成，退出自动执行模式。
 				m.autoExecuting = false
 			}
 		}
-		// 纯工具执行无文字回复时，补充完成标记
+		// 纯工具执行（无 LLM 文字回复）时，lines 末尾是空行占位符。
+		// 将其替换为完成标记，避免显示孤立的空行。
 		if len(m.lines) > 0 && m.lines[len(m.lines)-1] == "" {
 			m.lines[len(m.lines)-1] = doneStyle.Render("  ✅ 任务完成")
 		}
@@ -620,8 +614,14 @@ func summarizeTool(name string, args json.RawMessage) string {
 	}
 }
 
-// dispatch 以指定 prompt 启动一次 agent 推理流。
-// 调用时 running 必须为 false；若已有推理在进行则静默返回，防止并发启动。
+// dispatch 以指定 prompt 启动一次 agent 推理流（RunStream）。
+//
+// 调用时 running 必须为 false；若已有推理在进行（running == true）则静默返回，
+// 防止多路 goroutine 并发驱动同一个 AgentEngine。
+//
+// autoExecuting 续跑时，dispatch 由 EventDone handler 在 Elm Update 循环内调用，
+// 不存在并发问题（Bubbletea 保证 Update 是单线程的）。
+// 但 running 检查保留作为额外安全网，防止其他代码路径意外调用。
 func (m tuiModel) dispatch(prompt string) (tuiModel, tea.Cmd) {
 	if m.running {
 		return m, nil
@@ -748,6 +748,54 @@ func (m tuiModel) handleResumeSelection(raw string) (tea.Model, tea.Cmd) {
 	))
 	m.input.Focus()
 	return m, textinput.Blink
+}
+
+// confirmPlanReview 处理审查对话框的确认操作，cursor 0-3 对应四个选项。
+// 由 Enter 键（光标位置）和 Esc 键（强制选项 3）调用。
+func (m tuiModel) confirmPlanReview(cursor int) (tea.Model, tea.Cmd) {
+	m.planReviewing = false
+	m.planReviewCursor = 0
+	switch cursor {
+	case 0:
+		// 批准并自动执行：切换到 Default 模式（完整工具权限），开启 autoExecuting 续跑循环。
+		m.planMode = planning.PlanModeDefault
+		m.input.Placeholder = "输入任务..."
+		m.autoExecuting = true
+		m.autoExecPrevDone = 0
+		m.autoExecStuck = 0
+		if m.eng != nil {
+			m.eng.SetPlanMode(planning.PlanModeDefault)
+		}
+		m.lines = append(m.lines, dimStyle.Render("  ▶ 批准计划 — 自动执行中"))
+		return m.dispatch(execPrompt)
+	case 1:
+		// 批准并逐步确认编辑（当前行为与选项 0 相同，planMode 设为 AutoEdit 预留扩展）。
+		m.planMode = planning.PlanModeAutoEdit
+		m.input.Placeholder = "输入任务..."
+		m.autoExecuting = true
+		m.autoExecPrevDone = 0
+		m.autoExecStuck = 0
+		if m.eng != nil {
+			m.eng.SetPlanMode(planning.PlanModeAutoEdit)
+		}
+		m.lines = append(m.lines, dimStyle.Render("  ▶ 批准计划 — 逐步执行中"))
+		return m.dispatch(execPrompt)
+	case 2:
+		// 继续修改计划：保持 Plan Mode，恢复输入框供用户继续描述修改意见。
+		m.input.Placeholder = "继续描述修改意见..."
+		m.input.Focus()
+		return m, textinput.Blink
+	default:
+		// 取消（选项 3 / Esc）：切换回 Default 模式，恢复正常输入状态。
+		m.planMode = planning.PlanModeDefault
+		m.input.Placeholder = "输入任务..."
+		if m.eng != nil {
+			m.eng.SetPlanMode(planning.PlanModeDefault)
+		}
+		m.lines = append(m.lines, dimStyle.Render("  ✗ 已取消计划执行"))
+		m.input.Focus()
+		return m, textinput.Blink
+	}
 }
 
 // updateTodoBlock 在对话流末尾追加最新 todo 快照。

--- a/cmd/harness9/tui_view.go
+++ b/cmd/harness9/tui_view.go
@@ -12,8 +12,12 @@ import (
 	"github.com/harness9/internal/planning"
 )
 
-// accentStyle 返回当前模式下的 accent 样式：
-// Default → 青色（cyanStyle），Plan/AutoEdit → 琥珀黄（planAccentStyle）。
+// accentStyle 返回当前执行模式对应的强调色样式（accent style）：
+//   - PlanModeDefault → 青色（cyanStyle #81）
+//   - PlanModePlan / PlanModeAutoEdit → 琥珀黄（planAccentStyle #220）
+//
+// 此方法被 renderStatusBar、renderFooter、renderTodoLines 统一调用，
+// 确保颜色切换逻辑集中在单一位置，View 层无散落的 `if planMode ==` 判断。
 func (m tuiModel) accentStyle() lipgloss.Style {
 	if m.planMode != planning.PlanModeDefault {
 		return planAccentStyle
@@ -21,7 +25,9 @@ func (m tuiModel) accentStyle() lipgloss.Style {
 	return cyanStyle
 }
 
-// activeStatusBarStyle 返回当前模式下的状态栏样式。
+// activeStatusBarStyle 返回当前模式下的状态栏背景样式：
+//   - Default → 深灰底（statusBarStyle #235）
+//   - Plan/AutoEdit → 深橙底（planStatusBarStyle #94），给用户明确的视觉信号
 func (m tuiModel) activeStatusBarStyle() lipgloss.Style {
 	if m.planMode != planning.PlanModeDefault {
 		return planStatusBarStyle
@@ -38,8 +44,18 @@ func shortPath(p string) string {
 	return strings.Replace(p, home, "~", 1)
 }
 
-// renderTodoLines 将 TodoItem 列表渲染为结构化 todo 列表。
-// 格式：标题行（进度统计）+ 分隔线 + 每项状态图标与内容。
+// renderTodoLines 将 TodoItem 列表渲染为结构化多行文本，追加到 Scrollback（m.lines）。
+//
+// 输出格式：标题行（图标 + "Tasks" + 进度统计 + 活跃任务数）+ 分隔线 + 各任务行。
+// 每个任务行包含：序号、状态图标（✔/▶/○/⊘）和内容文本。
+//
+// 状态图标映射：
+//   - in_progress → ▶（黄色，工具运行色）
+//   - completed   → ✔（绿色）
+//   - cancelled   → ⊘（灰色）
+//   - pending     → ○（灰色）
+//
+// 颜色跟随当前 planMode 的 accentStyle（Plan Mode 下为琥珀色，其他为青色）。
 func (m tuiModel) renderTodoLines(items []planning.TodoItem) []string {
 	if len(items) == 0 {
 		return nil
@@ -205,15 +221,34 @@ func (m tuiModel) renderStatusBar() string {
 	return m.activeStatusBarStyle().Width(m.width).Render(content)
 }
 
-// renderPlanReviewDialog 渲染 Plan Mode 完成后的审查选择对话框。
+// renderPlanReviewDialog 渲染 Plan Mode 完成后的审查选择对话框（带圆角边框）。
+// 对话框在 planReviewing == true 时由 View() 插入到 StatusBar 之前，
+// ↑↓ 移动光标，Enter 确认，Esc 取消。
 func (m tuiModel) renderPlanReviewDialog() string {
-	content := planModeLabelStyle.Render("Plan Mode 完成 — 选择下一步操作") + "\n\n" +
-		planAccentStyle.Render("[1]") + "  批准并自动执行\n" +
-		planAccentStyle.Render("[2]") + "  批准并逐步确认编辑\n" +
-		planAccentStyle.Render("[3]") + "  继续修改计划（保持 Plan Mode）\n" +
-		planAccentStyle.Render("[4]") + "  取消"
+	options := []string{
+		"批准并自动执行",
+		"批准并逐步确认编辑",
+		"继续修改计划（保持 Plan Mode）",
+		"取消",
+	}
 
-	return planReviewBoxStyle.Render(content)
+	var sb strings.Builder
+	sb.WriteString(planModeLabelStyle.Render("Plan Mode 完成 — 选择下一步操作"))
+	sb.WriteString("\n\n")
+	for i, opt := range options {
+		if i == m.planReviewCursor {
+			sb.WriteString(planAccentStyle.Render("▶ ") + planReviewSelectedStyle.Render(opt))
+		} else {
+			sb.WriteString("  " + dimStyle.Render(opt))
+		}
+		if i < len(options)-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	sb.WriteString("\n\n")
+	sb.WriteString(dimStyle.Render("↑↓ 移动  Enter 确认  Esc 取消"))
+
+	return planReviewBoxStyle.Render(sb.String())
 }
 
 // renderInput 渲染输入行。Plan Mode 下用琥珀色高亮 › 提示符。

--- a/docs/核心功能/agent-loop.md
+++ b/docs/核心功能/agent-loop.md
@@ -222,27 +222,28 @@ Turn 2:
 引擎启动时，通过 `loadHistoryWith` 构造初始对话上下文。若注入了 `Session`，历史消息从持久化存储中恢复；否则仅含 system 提示和当前用户输入：
 
 ```go
-// loadHistoryWith 从 Session 恢复历史消息，并追加 system + user 到初始上下文。
-// startLen 标记历史消息边界，用于 saveHistoryWith 时仅保存新增消息。
+// loadHistoryWith 从 Session 恢复历史消息，注入 system prompt，追加用户输入。
+// startLen 标记新消息起始位置（已有历史 + system 不持久化），
+// 用于 saveHistoryWith 时仅保存 msgs[startLen:]。
 func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session) ([]schema.Message, int) {
     var history []schema.Message
     if sess != nil {
-        history, _ = sess.GetWithLimit(ctx, 500)
+        msgs, err := sess.GetMessages(ctx, 0) // 0 = 返回全部历史
+        if err == nil {
+            history = msgs
+        }
     }
-    // system prompt 注入在历史之后，不计入 startLen
-    contextHistory := append(history, schema.Message{
-        Role:    schema.RoleSystem,
-        Content: e.buildSystemPrompt(),
-    })
-    startLen := len(contextHistory) // 历史 + system 不持久化
-    contextHistory = append(contextHistory, schema.Message{
-        Role: schema.RoleUser, Content: userPrompt,
-    })
-    return contextHistory, startLen
+    // system prompt 注入在历史消息开头（若尚不存在），每次调用重建，不持久化到 DB。
+    if len(history) == 0 || history[0].Role != schema.RoleSystem {
+        history = append([]schema.Message{{Role: schema.RoleSystem, Content: e.buildSystemPrompt()}}, history...)
+    }
+    startLen := len(history) // 新消息从此处开始；system prompt 不计入持久化范围
+    history = append(history, schema.Message{Role: schema.RoleUser, Content: userPrompt})
+    return history, startLen
 }
 ```
 
-**WorkDir 会被注入到 system prompt** 中，使 LLM 了解其工作目录。system prompt 本身不持久化（每次启动重建），`startLen` 标记新消息的起始位置，用于 `saveHistoryWith` 时仅保存 `msgs[startLen:]`。
+**WorkDir 会被注入到 system prompt** 中，使 LLM 了解其工作目录。system prompt 本身不持久化（每次启动时重建并前插到历史消息开头，避免重复插入），`startLen` 标记新消息的起始位置，用于 `saveHistoryWith` 时仅保存 `msgs[startLen:]`。
 
 ### 4.2 LLM 调用阶段
 
@@ -394,11 +395,11 @@ func sendEvent(ctx context.Context, ch chan<- Event, evt Event) bool {
 
 ```go
 type LLMProvider interface {
-    // 阻塞式调用：返回完整响应 Message
+    // 阻塞式调用：返回完整响应 Message 和实际 token 用量（Usage 可能为 nil）
     Generate(ctx context.Context, messages []schema.Message,
-             availableTools []schema.ToolDefinition) (*schema.Message, error)
+             availableTools []schema.ToolDefinition) (*schema.Message, *schema.Usage, error)
 
-    // 流式调用：通过 channel 逐 chunk 返回增量
+    // 流式调用：通过 channel 逐 chunk 返回增量；最后一个有效 chunk 类型为 StreamChunkDone
     GenerateStream(ctx context.Context, messages []schema.Message,
                    availableTools []schema.ToolDefinition) (<-chan schema.StreamChunk, error)
 }
@@ -503,6 +504,7 @@ env.Load(filepath.Join(workDir, ".env"))
 
 ```go
 type Registry interface {
+    Register(tool BaseTool) error
     GetAvailableTools() []schema.ToolDefinition
     Execute(ctx context.Context, call schema.ToolCall) schema.ToolResult
 }
@@ -527,8 +529,12 @@ eng := engine.NewAgentEngine(p, r, workDir,
 | `WithMaxConcurrentTools(n)` | `int` | 0 | 同一 Turn 内最大并发工具数，0 = 不限制 |
 | `WithSession(s)` | `memory.Session` | nil | 注入会话存储，启用历史消息持久化 |
 | `WithCompactor(c)` | `memory.Compactor` | nil | 注入上下文压缩器，控制上下文窗口大小 |
+| `WithContextWindow(n)` | `int` | 0 | 模型 context window（tokens），用于 TUI token 使用率展示 |
+| `WithPromptBuilder(pb)` | `PromptBuilder` | nil | 自定义 system prompt 构建器，nil 时使用内置默认文案 |
+| `WithPlanMode(mode)` | `planning.PlanMode` | Default | 初始执行模式；可运行时通过 `SetPlanMode` 更新 |
+| `WithTodoStore(s)` | `*planning.TodoStore` | nil | 绑定任务列表，启用跨会话 todo 持久化 |
 
-运行时可通过 `eng.SetSession(sess)` 切换会话（并发安全，内部使用 `sync.RWMutex`）。
+运行时可通过 `eng.SetSession(sess)` 切换会话，`eng.SetPlanMode(mode)` 切换执行模式（均并发安全，内部使用 `sync.RWMutex`，但对当前正在运行的 `runLoop` 无影响）。
 
 **双模式调用：**
 
@@ -651,10 +657,11 @@ Turn 2:
 
 | 限制 | 当前状态 | 演进方向 |
 |------|---------|---------|
-| **上下文窗口控制** | 已实现 `SlidingWindowCompactor`（消息数滑动窗口） | Token Budget 精算（P2）；LLM 语义摘要（P3） |
-| **会话历史持久化** | 已实现 SQLiteSession（WAL 模式，`~/.harness9/sessions.db`） | 多工作目录隔离；会话标签与搜索 |
-| **流式输出** | 已实现 `RunStream` + `GenerateStream`，支持逐 token delta | 扩展 SSE HTTP 端点，对接外部实时推送渠道 |
-| **权限控制** | 无 | 工具执行前统一 PermissionChecker，支持交互式确认 |
+| **上下文窗口控制** | 已实现 `SummarizationCompactor`（默认，LLM 摘要 + 增量更新）、`TokenBudgetCompactor`（回退）、`SlidingWindowCompactor`（消息数窗口） | 进一步优化摘要质量；支持自定义摘要模板 |
+| **会话历史持久化** | 已实现 SQLiteSession（WAL 模式，`~/.harness9/sessions.db`）+ TodoStore 跨会话持久化 | 多工作目录隔离；会话标签与搜索（FTS5） |
+| **流式输出** | 已实现 `RunStream` + `GenerateStream`，支持逐 token delta + EventTokenUpdate/EventCompaction | 扩展 SSE HTTP 端点，对接外部实时推送渠道 |
+| **Planning** | 已实现 Plan Mode + TodoStore + 自动续跑 + 停滞检测 | PlanModeAutoEdit 逐步确认编辑模式 |
+| **权限控制** | Plan Mode 提供工具层只读约束 | 工具执行前统一 PermissionChecker，支持交互式确认 |
 | **Hook 系统** | 无 | PreToolUse / PostToolUse / Stop / TurnComplete 事件钩子 |
 | **多 Agent 编排** | 单 Agent 模式 | 子 Agent 调度、并行 Agent、专用角色 Agent |
 

--- a/docs/核心功能/planning.md
+++ b/docs/核心功能/planning.md
@@ -136,7 +136,11 @@ func (s *TodoStore) Read() []TodoItem {
 }
 ```
 
-`Write` 先分配新切片再 `copy`，而不是直接赋值 `s.items = items`，防止调用方持有对内部 slice 的引用从而绕过锁。
+`Write` 采用双重 copy 策略：
+- 第一次 copy（`s.items = make(...)` + `copy`）：内部存储与入参 `items` 解耦，防止调用方后续修改 `items` 影响 `TodoStore` 内部状态。
+- 第二次 copy（`s.copy()`）：返回值与内部存储解耦，防止调用方修改返回值影响 `TodoStore`。
+
+相比直接赋值 `s.items = items`，双重 copy 确保调用方、内部存储与入参三者完全独立，消除潜在的数据竞争风险。
 
 ### TodoItem 状态机
 
@@ -467,10 +471,11 @@ var completed int
 for _, item := range items {
     if item.Status == planning.TodoCompleted { completed++ }
 }
-tasksPart = cyanStyle.Render(fmt.Sprintf("%d/%d tasks", completed, len(items)))
+// accent 颜色跟随当前 planMode：Default 为青色，Plan/AutoEdit 为琥珀黄
+tasksPart = dimStyle.Render("  │  ") + accent.Render(fmt.Sprintf("%d/%d tasks", completed, len(items)))
 ```
 
-只统计 `TodoCompleted` 状态的条目作为"已完成"，`in_progress` 不计入。状态栏显示类似 `3/11 tasks`，实时反映真实完成进度。
+只统计 `TodoCompleted` 状态的条目作为"已完成"，`in_progress` 不计入。状态栏显示类似 `3/11 tasks`，实时反映真实完成进度。颜色跟随当前 `planMode` 的 `accentStyle()`（Plan Mode 下为琥珀黄，默认模式下为青色）。
 
 ---
 

--- a/internal/context/builder.go
+++ b/internal/context/builder.go
@@ -42,33 +42,33 @@ func (b *DefaultPromptBuilder) Build() string {
 
 	// 1. 基础 prompt
 	parts = append(parts, fmt.Sprintf(
-		"Your name is harness9. Always refer to yourself as \"harness9\" — never as \"AI assistant\", \"language model\", or any other generic term.\n\n"+
-			"harness9 is a general-purpose AI agent with full access to the user's computer.\n\n"+
-			"Capabilities:\n"+
-			"- Run shell commands to execute programs, manage processes, install packages, and interact with the OS\n"+
-			"- Read, write, and edit files across the filesystem\n"+
-			"- Chain multiple tools together to complete complex, multi-step tasks autonomously\n\n"+
-			"Working directory: %s\n\n"+
-			"Guidelines:\n"+
-			"- Investigate before acting: read files and run diagnostic commands first\n"+
-			"- Work in small verifiable steps; check results after each significant action\n"+
-			"- When a command fails, diagnose the root cause rather than guessing\n"+
-			"- Prefer targeted edits over full rewrites; preserve existing style and conventions\n"+
-			"- If a task is ambiguous, choose the most reasonable interpretation and proceed",
+		"你的名字是 harness9。请始终以 \"harness9\" 自称 — 不要使用 \"AI 助手\"、\"语言模型\" 或任何其他通称。\n\n"+
+			"harness9 是一个通用 AI Agent，可完全访问用户的计算机。\n\n"+
+			"能力：\n"+
+			"- 执行 Shell 命令：运行程序、管理进程、安装软件包、与操作系统交互\n"+
+			"- 读取、写入和编辑文件系统中的文件\n"+
+			"- 将多个工具串联使用，自主完成复杂的多步骤任务\n\n"+
+			"工作目录：%s\n\n"+
+			"工作准则：\n"+
+			"- 先调查后行动：优先读取文件并运行诊断命令\n"+
+			"- 小步可验证地推进：每次重要操作后检查结果\n"+
+			"- 命令失败时，诊断根本原因而非猜测\n"+
+			"- 优先局部修改而非整体重写；保持现有风格和约定\n"+
+			"- 任务描述模糊时，选择最合理的解释后直接推进",
 		b.workDir,
 	))
 
 	// 2. AGENTS.md（不存在或为空时静默跳过）
 	agentsPath := filepath.Join(b.workDir, "AGENTS.md")
 	if data, err := os.ReadFile(agentsPath); err == nil && len(data) > 0 {
-		parts = append(parts, "## Project Guidelines (AGENTS.md)\n\n"+string(data))
+		parts = append(parts, "## 项目规范（AGENTS.md）\n\n"+string(data))
 	}
 
 	// 3. Skills 索引（空 Index 或 nil 时跳过整块）
 	if b.skillsIndex != nil && !b.skillsIndex.IsEmpty() {
 		parts = append(parts,
-			"## Available Skills\n\n"+
-				"Use the `use_skill` tool to load the full content of any skill when needed.\n\n"+
+			"## 可用 Skills\n\n"+
+				"需要时使用 `use_skill` 工具加载任意 Skill 的完整内容。\n\n"+
 				b.skillsIndex.Summary(),
 		)
 	}
@@ -76,12 +76,12 @@ func (b *DefaultPromptBuilder) Build() string {
 	// 4. Todo 工具使用指引（仅在 todo_write 已注册时注入）
 	if b.todoEnabled {
 		parts = append(parts,
-			"## Task Management\n\n"+
-				"Use the `todo_write` tool to track progress on complex tasks:\n"+
-				"- Call it BEFORE starting any task with 3 or more independent steps\n"+
-				"- Update item status to `in_progress` when you begin a step\n"+
-				"- Update item status to `completed` immediately after finishing each step\n"+
-				"- The todo list persists in the conversation context — keep it accurate",
+			"## 任务管理\n\n"+
+				"使用 `todo_write` 工具追踪复杂任务的执行进度：\n"+
+				"- 任务包含 3 个或以上独立步骤时，开始前先调用此工具记录任务列表\n"+
+				"- 开始某步骤时，将对应条目状态更新为 `in_progress`\n"+
+				"- 完成每个步骤后，立即将状态更新为 `completed`\n"+
+				"- Todo 列表在对话上下文中持久保留 — 请保持准确",
 		)
 	}
 

--- a/internal/context/builder_test.go
+++ b/internal/context/builder_test.go
@@ -23,10 +23,10 @@ func TestBuild_BasePromptOnly(t *testing.T) {
 	if !strings.Contains(prompt, dir) {
 		t.Error("prompt should contain workDir")
 	}
-	if strings.Contains(prompt, "Project Guidelines") {
+	if strings.Contains(prompt, "项目规范") {
 		t.Error("prompt should not contain AGENTS.md section when file absent")
 	}
-	if strings.Contains(prompt, "Available Skills") {
+	if strings.Contains(prompt, "可用 Skills") {
 		t.Error("prompt should not contain skills section when index is empty")
 	}
 }
@@ -41,7 +41,7 @@ func TestBuild_WithAgentsMd(t *testing.T) {
 	b := NewPromptBuilder(dir, idx)
 	prompt := b.Build()
 
-	if !strings.Contains(prompt, "Project Guidelines") {
+	if !strings.Contains(prompt, "项目规范") {
 		t.Error("prompt should contain AGENTS.md section header")
 	}
 	if !strings.Contains(prompt, "Always write tests first.") {
@@ -72,7 +72,7 @@ func TestBuild_WithSkills(t *testing.T) {
 	b := NewPromptBuilder(dir, idx)
 	prompt := b.Build()
 
-	if !strings.Contains(prompt, "Available Skills") {
+	if !strings.Contains(prompt, "可用 Skills") {
 		t.Error("prompt should contain skills section header")
 	}
 	if !strings.Contains(prompt, "go-refactor: Go refactoring guide") {

--- a/internal/engine/agent_loop.go
+++ b/internal/engine/agent_loop.go
@@ -66,24 +66,30 @@ func WithCompactor(c memory.Compactor) Option {
 }
 
 // WithPlanMode 设置 Agent 的初始执行模式。
+// runLoop 在启动时会快照此值，循环内不会受后续 SetPlanMode 调用影响。
 func WithPlanMode(mode planning.PlanMode) Option {
 	return func(e *AgentEngine) { e.planMode = mode }
 }
 
-// WithTodoStore 绑定 TodoStore，使引擎在 runLoop 生命周期中加载/保存任务列表。
+// WithTodoStore 绑定 TodoStore，使引擎在 runLoop 生命周期中自动执行以下操作：
+//   - 启动时：从 Session 恢复 TodoStore 状态（跨会话续接未完成任务）
+//   - 结束时：通过 defer 将 TodoStore 保存到 Session（所有路径均执行）
 func WithTodoStore(s *planning.TodoStore) Option {
 	return func(e *AgentEngine) { e.todoStore = s }
 }
 
 // SetSession 替换当前绑定的 Session，供 TUI /new、/resume 命令切换会话时调用。
-// 线程安全：可从任意 goroutine 调用（如 TUI goroutine）。
+// 线程安全：可从任意 goroutine 调用（如 TUI goroutine），内部以写锁保护。
+// 注意：修改对当前正在运行的 runLoop 无影响（runLoop 在入口快照 session 值）。
 func (e *AgentEngine) SetSession(s memory.Session) {
 	e.mu.Lock()
 	e.session = s
 	e.mu.Unlock()
 }
 
-// SetPlanMode 线程安全地更新当前执行模式。TUI Shift+Tab 调用此方法。
+// SetPlanMode 线程安全地更新当前执行模式。TUI Shift+Tab 键调用此方法。
+// 注意：修改对当前正在运行的 runLoop 无影响（runLoop 在入口快照 planMode 值），
+// 仅在下一次 Run/RunStream 调用时生效。
 func (e *AgentEngine) SetPlanMode(mode planning.PlanMode) {
 	e.mu.Lock()
 	e.planMode = mode
@@ -309,23 +315,23 @@ func (e *AgentEngine) buildSystemPrompt() string {
 	if e.promptBuilder != nil {
 		return e.promptBuilder.Build()
 	}
-	return fmt.Sprintf(`Your name is harness9. Always refer to yourself as "harness9" — never as "AI assistant", "language model", or any other generic term.
+	return fmt.Sprintf(`你的名字是 harness9。请始终以 "harness9" 自称 — 不要使用 "AI 助手"、"语言模型" 或任何其他通称。
 
-harness9 is a general-purpose AI agent with full access to the user's computer.
+harness9 是一个通用 AI Agent，可完全访问用户的计算机。
 
-Capabilities:
-- Run shell commands to execute programs, manage processes, install packages, and interact with the OS
-- Read, write, and edit files across the filesystem
-- Chain multiple tools together to complete complex, multi-step tasks autonomously
+能力：
+- 执行 Shell 命令：运行程序、管理进程、安装软件包、与操作系统交互
+- 读取、写入和编辑文件系统中的文件
+- 将多个工具串联使用，自主完成复杂的多步骤任务
 
-Working directory: %s
+工作目录：%s
 
-Guidelines:
-- Investigate before acting: read files and run diagnostic commands first
-- Work in small verifiable steps; check results after each significant action
-- When a command fails, diagnose the root cause rather than guessing
-- Prefer targeted edits over full rewrites; preserve existing style and conventions
-- If a task is ambiguous, choose the most reasonable interpretation and proceed`, e.workDir)
+工作准则：
+- 先调查后行动：优先读取文件并运行诊断命令
+- 小步可验证地推进：每次重要操作后检查结果
+- 命令失败时，诊断根本原因而非猜测
+- 优先局部修改而非整体重写；保持现有风格和约定
+- 任务描述模糊时，选择最合理的解释后直接推进`, e.workDir)
 }
 
 // loadHistoryWith 从 sess 加载历史消息，注入 system prompt 和当前用户输入。
@@ -370,8 +376,13 @@ func (e *AgentEngine) saveHistoryWith(ctx context.Context, sess memory.Session, 
 	}
 }
 
-// planModeWhitelist 是 Plan Mode 下允许 LLM 调用的工具名称集合。
-// 包含 todo_write：Plan Mode 的核心目标是让 LLM 通过 todo_write 输出结构化计划。
+// planModeWhitelist 是 Plan Mode 下允许 LLM 调用的工具名称白名单（read-only map，安全并发读）。
+//
+// 白名单的设计意图：
+//   - read_file / bash：允许探索代码库，但 prompt 层约束 bash 只使用只读命令（ls/cat/find/grep）
+//   - todo_write：Plan Mode 的核心产出——LLM 通过此工具输出结构化实现计划
+//   - use_skill：允许加载 Skills 获取项目规范文档
+//   - write_file / edit_file：不在白名单，从工具列表中硬性移除（工具层硬约束，优于 prompt 层软约束）
 var planModeWhitelist = map[string]bool{
 	"read_file":  true,
 	"bash":       true,
@@ -379,7 +390,9 @@ var planModeWhitelist = map[string]bool{
 	"todo_write": true,
 }
 
-// filterReadOnlyTools 返回 tools 中属于 planModeWhitelist 的子集。
+// filterReadOnlyTools 从工具定义列表中过滤出 planModeWhitelist 中的子集，
+// 在 Plan Mode 下替代完整工具列表传递给 LLM。
+// 使用工具层硬约束而非 prompt 层软约束，确保 LLM 无论在何种上下文状态下都无法访问被过滤的工具。
 func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition {
 	var result []schema.ToolDefinition
 	for _, t := range tools {

--- a/internal/engine/agent_loop_test.go
+++ b/internal/engine/agent_loop_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/harness9/internal/planning"
+	"github.com/harness9/internal/provider"
 	"github.com/harness9/internal/schema"
 	"github.com/harness9/internal/tools"
 )
@@ -324,6 +325,138 @@ func TestWithPromptBuilder_FallbackDefault(t *testing.T) {
 	if !strings.Contains(systemMsg.Content, "harness9") {
 		t.Errorf("default prompt should contain 'harness9', got: %s", systemMsg.Content)
 	}
+}
+
+// TestRunLoop_WithTodoStore_RestoresAndSaves 验证 WithTodoStore 的跨会话持久化行为：
+//  1. runLoop 启动时从 Session 恢复 TodoStore 状态（Session 是持久化的 source of truth）
+//  2. runLoop 结束时通过 defer 将最终状态保存回 Session
+func TestRunLoop_WithTodoStore_RestoresAndSaves(t *testing.T) {
+	p := &countingProvider{
+		responses: []func([]schema.ToolDefinition) *schema.Message{
+			func(_ []schema.ToolDefinition) *schema.Message {
+				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
+			},
+		},
+	}
+	reg := &staticRegistry{output: "ok"}
+
+	// 准备一个已有持久化 todos 的 Session（模拟上次 Run 结束后保存的状态）。
+	sess := newMemorySessionForTest("sess-1")
+	if err := sess.SaveTodos(context.Background(), []planning.TodoItem{
+		{ID: "t1", Content: "pre-existing task", Status: planning.TodoPending},
+	}); err != nil {
+		t.Fatalf("SaveTodos setup error: %v", err)
+	}
+
+	todoStore := planning.NewTodoStore()
+
+	eng := NewAgentEngine(p, reg, t.TempDir(),
+		WithTodoStore(todoStore),
+		WithSession(sess),
+	)
+	if err := eng.Run(context.Background(), "test"); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+
+	// 验证：runLoop 启动时应从 Session 恢复 todos 到 todoStore。
+	// 恢复后 todoStore 中应有 t1（在 Run 开始时加载）。
+	// Run 结束时 defer 将（恢复后、未被修改的）todos 重新保存到 Session。
+	saved, err := sess.GetTodos(context.Background())
+	if err != nil {
+		t.Fatalf("GetTodos error: %v", err)
+	}
+	if len(saved) != 1 || saved[0].ID != "t1" {
+		t.Errorf("expected saved todos to contain t1, got %+v", saved)
+	}
+}
+
+// TestRunLoop_PlanMode_InjectsPlanPrefix 验证 Plan Mode 下用户 prompt 被注入了规划前缀。
+func TestRunLoop_PlanMode_InjectsPlanPrefix(t *testing.T) {
+	var receivedUserPrompt string
+	p := &countingProvider{
+		responses: []func([]schema.ToolDefinition) *schema.Message{
+			func(_ []schema.ToolDefinition) *schema.Message {
+				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
+			},
+		},
+	}
+	// 注入一个回调 provider 捕获历史消息内容
+	capturing := &capturingProvider{inner: p, onGenerate: func(msgs []schema.Message) {
+		for _, m := range msgs {
+			if m.Role == schema.RoleUser && receivedUserPrompt == "" {
+				receivedUserPrompt = m.Content
+			}
+		}
+	}}
+	reg := &staticRegistry{output: "ok"}
+	eng := NewAgentEngine(capturing, reg, t.TempDir(),
+		WithPlanMode(planning.PlanModePlan),
+	)
+	if err := eng.Run(context.Background(), "implement feature X"); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	// Plan Mode 前缀必须存在于用户消息中
+	if !strings.Contains(receivedUserPrompt, "todo_write") {
+		t.Errorf("Plan Mode should inject planning prefix mentioning todo_write, got: %q", receivedUserPrompt)
+	}
+	if !strings.Contains(receivedUserPrompt, "implement feature X") {
+		t.Errorf("original user prompt should be preserved, got: %q", receivedUserPrompt)
+	}
+}
+
+// ---- 测试辅助类型 ----
+
+// memorySessionForTest 是支持真实 GetTodos/SaveTodos 持久化语义的 Session 桩。
+// 注意：memory.MemorySession 的 SaveTodos 是 no-op、GetTodos 始终返回空列表，
+// 无法用于验证跨 runLoop 的 todo restore/save 行为，因此此处独立实现。
+type memorySessionForTest struct {
+	id    string
+	msgs  []schema.Message
+	todos []planning.TodoItem
+}
+
+func newMemorySessionForTest(id string) *memorySessionForTest {
+	return &memorySessionForTest{id: id}
+}
+
+func (s *memorySessionForTest) SessionID() string { return s.id }
+func (s *memorySessionForTest) GetMessages(_ context.Context, _ int) ([]schema.Message, error) {
+	return append([]schema.Message(nil), s.msgs...), nil
+}
+func (s *memorySessionForTest) AddMessages(_ context.Context, msgs []schema.Message) error {
+	s.msgs = append(s.msgs, msgs...)
+	return nil
+}
+func (s *memorySessionForTest) PopMessage(_ context.Context) (*schema.Message, error) {
+	if len(s.msgs) == 0 {
+		return nil, nil
+	}
+	m := s.msgs[len(s.msgs)-1]
+	s.msgs = s.msgs[:len(s.msgs)-1]
+	return &m, nil
+}
+func (s *memorySessionForTest) Clear(_ context.Context) error { s.msgs = nil; return nil }
+func (s *memorySessionForTest) GetTodos(_ context.Context) ([]planning.TodoItem, error) {
+	return append([]planning.TodoItem(nil), s.todos...), nil
+}
+func (s *memorySessionForTest) SaveTodos(_ context.Context, items []planning.TodoItem) error {
+	s.todos = append([]planning.TodoItem(nil), items...)
+	return nil
+}
+
+// capturingProvider 包装另一个 Provider，在每次 Generate 调用时执行 onGenerate 回调。
+type capturingProvider struct {
+	inner      provider.LLMProvider
+	onGenerate func(msgs []schema.Message)
+}
+
+func (p *capturingProvider) Generate(ctx context.Context, msgs []schema.Message, tools []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+	p.onGenerate(msgs)
+	return p.inner.Generate(ctx, msgs, tools)
+}
+func (p *capturingProvider) GenerateStream(ctx context.Context, msgs []schema.Message, tools []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	p.onGenerate(msgs)
+	return p.inner.GenerateStream(ctx, msgs, tools)
 }
 
 // TestRunLoop_PlanMode_FiltersWriteTools 验证 Plan Mode 下写操作工具被过滤，只读工具保留。

--- a/internal/memory/summarization.go
+++ b/internal/memory/summarization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/harness9/internal/schema"
 )
@@ -173,7 +174,13 @@ func (c *SummarizationCompactor) summarize(head []schema.Message) (string, error
 	sysMsg := schema.Message{Role: schema.RoleSystem, Content: summarySystemPrompt}
 	userMsg := schema.Message{Role: schema.RoleUser, Content: userContent}
 
-	resp, _, err := c.Provider.Generate(context.Background(), []schema.Message{sysMsg, userMsg}, nil)
+	// 为摘要 LLM 调用设置独立超时（60 秒）。
+	// Compact 接口不传递外层 context，因此此处无法感知外层取消；
+	// 超时可防止摘要请求无限阻塞，确保 runLoop 在网络异常时能够回退到 Fallback 压缩器。
+	summaryCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, _, err := c.Provider.Generate(summaryCtx, []schema.Message{sysMsg, userMsg}, nil)
 	if err != nil {
 		return "", err
 	}

--- a/internal/planning/mode.go
+++ b/internal/planning/mode.go
@@ -1,20 +1,30 @@
 package planning
 
 // PlanMode 表示 harness9 的执行模式。
+//
+// 枚举值通过 Shift+Tab 在 TUI 中循环切换；引擎在 runLoop 入口快照当前模式，
+// 确保整轮推理过程中模式不变，不受 TUI goroutine 异步切换的影响。
 type PlanMode int
 
 const (
-	PlanModeDefault  PlanMode = iota // 完整工具访问（默认）
-	PlanModePlan                     // 只读：过滤写操作工具，LLM 只能探索和分析
-	PlanModeAutoEdit                 // 保留：自动确认编辑（未来扩展）
+	// PlanModeDefault 是默认执行模式：LLM 可访问全部注册工具，直接执行任意操作。
+	PlanModeDefault PlanMode = iota
+	// PlanModePlan 是规划模式：filterReadOnlyTools 从工具列表移除 write_file / edit_file，
+	// LLM 只能通过 read_file、bash（只读命令）探索代码库，通过 todo_write 输出结构化计划。
+	// 这是硬约束（工具层），而非软约束（prompt 层），确保 LLM 无法绕过限制创建文件。
+	PlanModePlan
+	// PlanModeAutoEdit 是保留枚举值，当前行为与 PlanModeDefault 相同。
+	// 预留给未来的"逐步确认编辑"模式（用户对每次文件修改手动批准）。
+	PlanModeAutoEdit
 )
 
 // Next 返回 Shift+Tab 循环中的下一个模式：Default→Plan→AutoEdit→Default。
+// 通过整数取模实现三值循环，新增模式时需同步更新取模数。
 func (m PlanMode) Next() PlanMode {
 	return (m + 1) % 3
 }
 
-// String 返回可读名称，用于日志。
+// String 返回人类可读的模式名称，主要用于调试日志输出。
 func (m PlanMode) String() string {
 	switch m {
 	case PlanModePlan:
@@ -26,7 +36,9 @@ func (m PlanMode) String() string {
 	}
 }
 
-// Label 返回 TUI 状态栏显示的标签。Default 模式返回空字符串（不显示）。
+// Label 返回 TUI 状态栏展示的模式标签文本。
+// PlanModeDefault 返回空字符串，不在状态栏显示额外标签（默认模式无需提示）。
+// 非默认模式返回带括号的标签，与状态栏其他字段通过分隔符区分。
 func (m PlanMode) Label() string {
 	switch m {
 	case PlanModePlan:

--- a/internal/planning/todo.go
+++ b/internal/planning/todo.go
@@ -7,41 +7,66 @@ import (
 	"sync"
 )
 
-// TodoStatus 表示单个任务条目的状态。
+// TodoStatus 表示单个任务条目（todo item）的生命周期状态。
+// 状态转换约束由 todo_write 工具（tools 包）负责执行，TodoStore 本身不做校验。
+//
+// 合法的状态转换路径：
+//
+//	pending ──► in_progress ──► completed
+//	   │              │
+//	   └──────────────┴──► cancelled
 type TodoStatus string
 
 const (
-	TodoPending    TodoStatus = "pending"
+	// TodoPending 表示任务尚未开始。初始创建时的默认状态。
+	TodoPending TodoStatus = "pending"
+	// TodoInProgress 表示任务正在执行中。
+	// LLM 在开始实际工具调用前应先将任务标记为此状态。
 	TodoInProgress TodoStatus = "in_progress"
-	TodoCompleted  TodoStatus = "completed"
-	TodoCancelled  TodoStatus = "cancelled"
+	// TodoCompleted 表示任务已完成，对应有实际产出（文件创建、命令执行等）。
+	// 防作弊校验（todo_write）确保此状态不能被批量伪造。
+	TodoCompleted TodoStatus = "completed"
+	// TodoCancelled 表示任务已取消，不再执行。
+	// 取消的任务不能直接标记为 completed，必须先恢复为 pending 或 in_progress。
+	TodoCancelled TodoStatus = "cancelled"
 )
 
-// TodoItem 是单个任务条目。
+// TodoItem 是单个任务条目，包含唯一标识、内容描述和当前状态。
+// ID 由 LLM 自行分配，用于在全量替换时识别条目历史状态（防作弊校验的依据）。
 type TodoItem struct {
-	ID      string     `json:"id"`
-	Content string     `json:"content"`
-	Status  TodoStatus `json:"status"`
+	ID      string     `json:"id"`      // 任务的唯一标识符，LLM 自行分配
+	Content string     `json:"content"` // 任务内容描述，应对应一个具体可执行动作
+	Status  TodoStatus `json:"status"`  // 当前状态（pending/in_progress/completed/cancelled）
 }
 
-// TodoStore 是线程安全的会话内任务列表。
-// 全量替换语义：每次 Write 用新列表原子替换整个旧列表。
+// TodoStore 是线程安全的会话内任务列表，采用全量替换（atomic replace）语义。
+//
+// 设计决策——全量替换 vs 增量更新：
+// LLM 每次调用 todo_write 时输出完整的当前清单（而非增量指令），
+// 全量替换与这种输出形式完全匹配，同时避免了增量 API 的状态一致性问题。
+//
+// 并发安全：内部使用 sync.RWMutex 保护 items 切片，
+// Read 允许多读并发，Write 排他。所有方法均可从任意 goroutine 安全调用。
 type TodoStore struct {
 	mu    sync.RWMutex
 	items []TodoItem
 }
 
-// NewTodoStore 创建空的 TodoStore。
+// NewTodoStore 创建空的 TodoStore，无任何初始任务。
 func NewTodoStore() *TodoStore {
 	return &TodoStore{}
 }
 
 // Write 原子性全量替换任务列表，返回替换后的列表副本。
+// 先将入参复制到内部 slice，再返回内部 slice 的第二份副本：
+// 双重复制确保调用方、内部存储与入参三者各自独立，互不影响。
 func (s *TodoStore) Write(items []TodoItem) []TodoItem {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// 第一次 copy：内部存储与入参 items 解耦，防止调用方后续修改 items 影响内部状态。
 	s.items = make([]TodoItem, len(items))
 	copy(s.items, items)
+	// 第二次 copy（通过 s.copy()）：返回值与内部存储解耦，防止调用方修改返回值影响 TodoStore。
 	return s.copy()
 }
 
@@ -52,7 +77,9 @@ func (s *TodoStore) Read() []TodoItem {
 	return s.copy()
 }
 
-// copy 返回 s.items 的浅拷贝，调用方须持有锁。
+// copy 返回 s.items 的副本。调用方必须持有读锁或写锁后才能调用此方法。
+// 空列表时返回 nil（而非空切片），与 json.Marshal 的行为兼容（nil → "null"，[]{} → "[]"）。
+// 注意：TodoItem 是值类型（无指针字段），浅拷贝即为完整独立副本。
 func (s *TodoStore) copy() []TodoItem {
 	if len(s.items) == 0 {
 		return nil
@@ -62,9 +89,18 @@ func (s *TodoStore) copy() []TodoItem {
 	return result
 }
 
-// FormatForInjection 将 pending/in_progress 任务格式化为文本，
-// 在上下文压缩后注入摘要，防止 LLM 遗忘未完成任务。
-// 无活跃任务时返回空字符串。
+// FormatForInjection 将 pending 和 in_progress 状态的任务格式化为纯文本，
+// 供 SummarizationCompactor 在上下文压缩后注入摘要消息末尾，
+// 防止 LLM 在长对话压缩后遗忘尚未完成的任务。
+//
+// 实现了 memory.TodoInjector 接口（接口定义在 memory 包，遵循"接口定义在使用者侧"原则）。
+// 无活跃任务（全部已完成或已取消）时返回空字符串，调用方应跳过注入。
+//
+// 输出格式示例：
+//
+//	[ ] 实现 handler/user.go
+//	[>] 配置数据库连接
+//	[ ] 添加路由注册
 func (s *TodoStore) FormatForInjection() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -72,6 +108,7 @@ func (s *TodoStore) FormatForInjection() string {
 	var lines []string
 	for _, item := range s.items {
 		if item.Status == TodoPending || item.Status == TodoInProgress {
+			// [ ] 表示 pending（待开始），[>] 表示 in_progress（进行中）
 			prefix := "[ ]"
 			if item.Status == TodoInProgress {
 				prefix = "[>]"
@@ -85,7 +122,11 @@ func (s *TodoStore) FormatForInjection() string {
 	return strings.Join(lines, "\n")
 }
 
-// ActiveCount 返回 (active, total)：active = pending+in_progress 数量，total = 全部数量。
+// ActiveCount 返回 (active, total) 两个计数：
+//   - active：pending 和 in_progress 状态的任务数（即尚未完成的任务）
+//   - total：TodoStore 中的全部任务数
+//
+// TUI 续跑逻辑（autoExecuting）使用此方法判断是否仍有待执行的任务。
 func (s *TodoStore) ActiveCount() (active, total int) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/tools/todo_write.go
+++ b/internal/tools/todo_write.go
@@ -1,3 +1,16 @@
+// Package tools — todo_write 工具（任务列表读写 + 防作弊校验）。
+//
+// TodoWriteTool 是 Planning 模块对 LLM 暴露的唯一任务管理接口。
+// 工具有两种调用模式：
+//   - 写模式（提供 todos 数组）：全量替换当前任务列表，内置防作弊校验。
+//   - 读模式（省略 todos 字段）：返回当前任务列表 JSON，不修改状态。
+//
+// 防作弊校验设计：
+// 一次调用中最多允许 1 个 pending/新条目直接跳转到 completed，
+// 超过 1 个视为"幻觉执行"（LLM 未做实际工作但伪造进度），拒绝写入并回传错误。
+// cancelled → completed 的转换始终被拒绝（需先恢复为 pending/in_progress）。
+// 阈值设为 1 而非 0：保留 LLM 完成实际工作后直接标记完成的正常用法，
+// 同时阻止批量伪造（原始 bug 场景：11 个任务中 9 个被一次性批量完成）。
 package tools
 
 import (
@@ -9,13 +22,16 @@ import (
 	"github.com/harness9/internal/schema"
 )
 
-// TodoWriteTool 允许 LLM 维护当前会话的任务列表。
-// 传入 todos 时全量替换；省略 todos 时读取当前列表。
+// TodoWriteTool 实现 BaseTool 接口，允许 LLM 维护当前会话的任务列表。
+// 内部通过 *planning.TodoStore 存取任务状态，TodoStore 本身是线程安全的。
+// 传入 todos 数组时全量替换并执行防作弊校验；省略 todos 时仅读取当前列表。
 type TodoWriteTool struct {
+	// store 是会话内共享的任务存储，由 main.go 创建后注入引擎和此工具。
 	store *planning.TodoStore
 }
 
 // NewTodoWriteTool 创建绑定到指定 TodoStore 的工具实例。
+// store 不得为 nil，否则 Execute 调用时会发生 panic。
 func NewTodoWriteTool(store *planning.TodoStore) *TodoWriteTool {
 	return &TodoWriteTool{store: store}
 }
@@ -53,10 +69,24 @@ func (t *TodoWriteTool) Definition() schema.ToolDefinition {
 	}
 }
 
+// todoWriteArgs 定义 todo_write 工具的 JSON 参数结构。
+// Todos 字段省略或显式传 null 时，json.Unmarshal 将其设为 nil；
+// Execute 通过 len(input.Todos) > 0 区分读操作（nil/空切片）和写操作（非空列表）。
 type todoWriteArgs struct {
 	Todos []planning.TodoItem `json:"todos"`
 }
 
+// Execute 处理 todo_write 工具调用：
+//   - 写操作（todos 非空）：执行防作弊校验后全量替换 TodoStore，返回写入后的列表 JSON。
+//   - 读操作（todos 为空/省略）：直接返回当前 TodoStore 的列表 JSON，不修改状态。
+//
+// 防作弊校验逻辑：
+//  1. 遍历新列表中所有 status == completed 的条目；
+//  2. cancelled → completed：始终拒绝（不受"单个允许"规则豁免）；
+//  3. pending/新建 → completed：计为 directCompletions，超过 1 个则拒绝整批写入；
+//  4. in_progress → completed / completed → completed：合法路径，不计入 directCompletions。
+//
+// 返回的 JSON 始终是数组格式（空列表时为 "[]" 而非 "null"）。
 func (t *TodoWriteTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
 	var input todoWriteArgs
 	if err := json.Unmarshal(args, &input); err != nil {
@@ -65,35 +95,40 @@ func (t *TodoWriteTool) Execute(_ context.Context, args json.RawMessage) (string
 
 	var current []planning.TodoItem
 	if len(input.Todos) > 0 {
-		// 批量作弊防护规则：
-		//   - pending/new → completed：单次调用最多允许 1 个（LLM 完成工作后可跳过 in_progress）
-		//   - cancelled → completed：始终拒绝（必须先恢复为 pending/in_progress）
-		//   - in_progress/completed → completed：始终允许
+		// ---- 防作弊校验（Anti-Cheat Validation） ----
+		// 读取写入前的当前状态快照，用于判断每个条目的历史状态。
+		// 快照在校验期间不会改变（TodoStore.Read 返回副本），确保校验一致性。
 		prev := t.store.Read()
 		prevStatus := make(map[string]planning.TodoStatus, len(prev))
 		for _, item := range prev {
 			prevStatus[item.ID] = item.Status
 		}
+
 		var directCompletions int
 		for _, item := range input.Todos {
 			if item.Status != planning.TodoCompleted {
+				// 非 completed 状态的条目无需校验（任意状态转换均允许）。
 				continue
 			}
 			prior, exists := prevStatus[item.ID]
 			if !exists || prior == planning.TodoPending {
-				// 新条目或 pending → completed：计入直接完成数，超过 1 个则拒绝。
+				// 情况 A：新建条目或 pending → completed。
+				// 单个允许（LLM 可能真实完成了工作后直接记录结果），但批量超过 1 个视为作弊。
 				directCompletions++
 				continue
 			}
 			if prior == planning.TodoCancelled {
-				// cancelled → completed 明确拒绝：取消的任务必须先恢复为 pending 或 in_progress。
+				// 情况 B：cancelled → completed 始终拒绝。
+				// 取消的任务表明已放弃，需经用户重新评估（恢复为 pending/in_progress）才能完成。
 				return "", fmt.Errorf(
 					"任务 %q 已取消，不能直接标记为 completed；如需重新执行，请先将其恢复为 pending 或 in_progress。",
 					item.ID)
 			}
-			// prior == in_progress 或 completed → 合法路径，不计入。
+			// 情况 C：in_progress → completed 或 completed → completed，合法，不计入计数。
 		}
 		if directCompletions > 1 {
+			// 超过 1 个任务在未经 in_progress 阶段的情况下直接完成，判定为批量幻觉执行。
+			// 返回错误让 LLM 感知并重新组织写入（自愈机制：错误回传给 LLM，不终止 agent loop）。
 			return "", fmt.Errorf(
 				"不允许在一次调用中将 %d 个任务直接标记为 completed（未经 in_progress）。"+
 					"请逐一处理：每次仅完成一项实际工作后更新该条目状态。",
@@ -101,9 +136,12 @@ func (t *TodoWriteTool) Execute(_ context.Context, args json.RawMessage) (string
 		}
 		current = t.store.Write(input.Todos)
 	} else {
+		// 读操作：不修改 TodoStore，直接返回当前快照。
 		current = t.store.Read()
 	}
 
+	// 将 nil 切片规范化为空切片，确保序列化结果为 "[]" 而非 "null"，
+	// 符合 LLM 工具调用规范（空列表应明确表达，而非空指针）。
 	if current == nil {
 		current = []planning.TodoItem{}
 	}


### PR DESCRIPTION
## Summary

- **Planning 模块**：Plan Mode（工具层只读过滤）+ TodoStore（线程安全全量替换）+ 防作弊校验（单次调用最多 1 个 pending→completed）+ 跨会话 todo 持久化（SQLite）+ 上下文压缩注入（避免 LLM 遗忘未完成任务）
- **TUI 执行自动化**：Plan Mode 完成后展示审查对话框（↑↓ 光标 + Enter 确认 + Esc 取消），批准后 autoExecuting 续跑循环 + 停滞检测（连续 3 次无进度则停止）
- **System Prompt 中文化**：`internal/context/builder.go` 和 `engine/agent_loop.go` 两处 System Prompt 全部翻译为中文
- **Bug 修复**：`summarize()` 使用裸 `context.Background()` 导致网络故障时无限阻塞，修复为 60s 超时
- **测试与文档**：新增 2 个引擎测试（TodoStore restore/save、Plan Mode prompt 注入）；同步更新 `docs/核心功能/agent-loop.md` 和 `planning.md`

## Test Plan

- [ ] `go test ./...` 全量通过（12 个包）
- [ ] 启动 TUI，`Shift+Tab` 进入 Plan Mode，状态栏变为琥珀黄
- [ ] 输入任务后 LLM 输出 todo 列表，审查对话框出现，↑↓ 可移动光标，Enter 确认批准，自动执行启动
- [ ] Esc 键可取消审查对话框，恢复 Default 模式
- [ ] 验证中文 System Prompt 在 Anthropic / OpenAI Provider 下均正常工作
- [ ] 验证 todo 列表在进程重启或 `/resume` 切换会话后可正确恢复