### PR TITLE
fix: 移除 web_search.md 中指向未跟踪文件的死链（修复网站构建失败）

### DIFF
--- a/docs/核心功能/web_search.md
+++ b/docs/核心功能/web_search.md
@@ -304,4 +304,4 @@ Agent:
 | HermesAgent | 全功能 | 8 个后端，LLM 内容压缩管线（Gemini Flash，支持 2M 字符分块） |
 | Claude Agent SDK | 官方内置 | `WebSearch`/`WebFetch` 原生工具，research-agent 示例展示 Sub-Agent 并行研究模式 |
 
-详细调研见 [docs/技术调研/web-search-capability.md](../技术调研/web-search-capability.md)。
+详细调研见 `docs/技术调研/web-search-capability.md`（本地调研文档，不随仓库发布）。


### PR DESCRIPTION
## Summary

- `docs/核心功能/web_search.md` 末尾引用了 `../技术调研/web-search-capability.md`，该文件是本地调研文档，未纳入版本控制
- VitePress 构建时死链检查将其判为 dead link，导致 CI/CD 部署失败
- 将外部链接替换为纯文本引用，消除构建错误

## Test Plan

- [ ] 验证 VitePress 构建通过（无 dead link 报错）
- [ ] 确认页面内容表述准确