### PR TITLE
feat: 新增 TUI /compact 手动上下文压缩命令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ reports/
 # 本地临时目录
 tmp/
 
+# autodev：git worktree 临时工作区（/autodev 命令生成）
+.autodev/
+
 # VitePress 网站依赖与构建产物
 website/node_modules/
 website/.vitepress/dist/

--- a/cmd/harness9/tui.go
+++ b/cmd/harness9/tui.go
@@ -275,6 +275,10 @@ type tuiModel struct {
 	// dispatch() 在下次发送 prompt 前将其前置注入并清空（展示与注入分离，避免与 TaskTracker 双重消费）。
 	pendingSubAgentInject []string
 
+	// compacting 为 true 时表示 /compact 命令正在异步执行中。
+	// 此期间在输入框上方显示 spinner 进度条，完成后插入压缩通知并恢复为 false。
+	compacting bool
+
 	// shellMode 为 true 时表示输入框当前以 "!" 开头，处于 Shell 执行模式。
 	// 由 Update() 中的输入实时检测逻辑驱动（非 running 状态下每次按键后检测），
 	// View 层据此切换状态栏背景色（深绿）、输入区徽章（[SHELL]）、footer 提示文字。

--- a/cmd/harness9/tui_update.go
+++ b/cmd/harness9/tui_update.go
@@ -88,8 +88,19 @@ var builtinCmds = []struct {
 	{"new", "开启新会话"},
 	{"resume", "恢复历史会话"},
 	{"plan", "进入规划模式分析任务"},
+	{"compact", "手动压缩上下文"},
 	{"tasks", "查看后台子代理任务"},
 	{"exit", "退出 TUI"},
+}
+
+// compactDoneMsg 是 /compact 命令异步执行成功后投递的消息。
+type compactDoneMsg struct {
+	data engine.CompactionData
+}
+
+// compactErrMsg 是 /compact 命令异步执行失败后投递的消息。
+type compactErrMsg struct {
+	err error
 }
 
 // eventMsg 将 engine.Event 包装为 tea.Msg，供 Bubbletea 的 Update 分发。
@@ -297,6 +308,29 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 
+			// /compact 手动压缩上下文，不走 LLM 推理循环。
+			// 在 running 期间忽略（避免与正在进行的 runLoop 竞争 session 状态）。
+			if raw == "/compact" {
+				if m.running {
+					m.lines = append(m.lines, dimStyle.Render("  ⚠ /compact 不可在推理期间执行，请等待本次任务完成"))
+					m.input.Focus()
+					return m, textinput.Blink
+				}
+				m.lines = append(m.lines, dimStyle.Render("  ⟳ 正在压缩上下文…"))
+				m.compacting = true
+				eng := m.eng
+				return m, tea.Batch(
+					tea.Cmd(m.spinner.Tick),
+					func() tea.Msg {
+						data, err := eng.Compact(context.Background())
+						if err != nil {
+							return compactErrMsg{err: err}
+						}
+						return compactDoneMsg{data: data}
+					},
+				)
+			}
+
 			// Shell 模式: "!" 前缀直接执行 Bash 命令，绕过 LLM
 			// 不显示 "▶ You:" 行，改为 "$ cmd" 风格
 			if strings.HasPrefix(raw, "!") {
@@ -363,7 +397,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleEvent(engine.Event(msg))
 
 	case spinner.TickMsg:
-		if m.running && m.currentTool != "" {
+		if (m.running && m.currentTool != "") || m.compacting {
 			m.tickCount++
 			if m.tickCount%30 == 0 {
 				m.verbIdx = (m.verbIdx + 1) % len(spinnerVerbs)
@@ -373,6 +407,30 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		return m, nil
+
+	case compactDoneMsg:
+		m.compacting = false
+		data := msg.data
+		// 若 data 全为零值（无 compactor 或无 session），不追加通知。
+		if data.MsgsBefore > 0 {
+			line := dimStyle.Render(fmt.Sprintf(
+				"  ✦ Context compacted: %d → %d messages, %s → %s tokens",
+				data.MsgsBefore, data.MsgsAfter,
+				memory.FormatTokenCount(data.TokensBefore),
+				memory.FormatTokenCount(data.TokensAfter),
+			))
+			m.lines = append(m.lines, line)
+		} else {
+			m.lines = append(m.lines, dimStyle.Render("  ✦ /compact: 无可压缩内容（无 session 或无 compactor）"))
+		}
+		m.input.Focus()
+		return m, textinput.Blink
+
+	case compactErrMsg:
+		m.compacting = false
+		m.lines = append(m.lines, errorStyle.Render("  ✗ /compact 失败: "+msg.err.Error()))
+		m.input.Focus()
+		return m, textinput.Blink
 
 	case shellResultMsg:
 		// 展示侧（Scrollback）：UTF-8 安全截断至 maxShellDisplayLen，超出时追加截断提示。
@@ -743,6 +801,9 @@ func (m tuiModel) scrollHeight() int {
 	reserved := 3 // StatusBar + PromptInput + Footer
 	if m.running && m.currentTool != "" {
 		reserved++ // + ToolProgress
+	}
+	if m.compacting {
+		reserved++ // + CompactProgress
 	}
 	if n := len(m.subAgentLines); n > 0 {
 		reserved += n // + 子代理进度块（每行占一行）

--- a/cmd/harness9/tui_view.go
+++ b/cmd/harness9/tui_view.go
@@ -195,6 +195,14 @@ func (m tuiModel) renderToolProgress() string {
 		dimStyle.Render(fmt.Sprintf("  [%s]", elapsed))
 }
 
+// renderCompactProgress 渲染 /compact 命令执行期间的 spinner 进度行。
+// 与 renderToolProgress 风格一致：spinner + 动词 + 操作名称。
+func (m tuiModel) renderCompactProgress() string {
+	return "  " +
+		verbRunStyle.Render(m.spinner.View()+" 压缩中...") +
+		toolRunStyle.Render("  /compact")
+}
+
 // renderSubAgentProgress 渲染当前活跃子代理的流式进度块（暗青色缩进行）。
 // 仅在 len(m.subAgentLines) > 0 时由 View() 调用；每行已在 EventSubAgent 处理时带上 [agent] 前缀。
 func (m tuiModel) renderSubAgentProgress() string {
@@ -560,6 +568,10 @@ func (m tuiModel) View() string {
 		}
 		if m.running && m.currentTool != "" {
 			sb.WriteString(m.renderToolProgress())
+			sb.WriteByte('\n')
+		}
+		if m.compacting {
+			sb.WriteString(m.renderCompactProgress())
 			sb.WriteByte('\n')
 		}
 		if m.approvalPending {

--- a/internal/engine/compact.go
+++ b/internal/engine/compact.go
@@ -1,0 +1,77 @@
+// Package engine — 手动上下文压缩支持。
+//
+// Compact 方法允许调用方（如 TUI /compact 命令）在不触发 LLM 推理循环的情况下，
+// 对当前 session 的历史消息执行一次强制压缩，跳过常规的 80% 阈值检查。
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/harness9/internal/logfmt"
+	"github.com/harness9/internal/memory"
+)
+
+// Compact 对当前 session 的历史消息执行一次强制压缩，跳过 80% 阈值检查。
+//
+// 行为说明：
+//   - compactor 为 nil 时：立即返回零值 CompactionData 和 nil error（no-op）
+//   - session 为 nil 时：立即返回零值 CompactionData 和 nil error（no-op）
+//   - 否则：读取完整历史 → 调用 compactor.Compact → 将压缩结果写回 session
+//
+// 返回的 CompactionData 包含压缩前后的 token 数和消息条数，
+// 供 TUI 在对话流中展示压缩通知消息。
+//
+// 线程安全：通过读锁快照 session 和 compactor，与 TUI goroutine 并发安全。
+func (e *AgentEngine) Compact(ctx context.Context) (CompactionData, error) {
+	e.mu.RLock()
+	sess := e.session
+	comp := e.compactor
+	e.mu.RUnlock()
+
+	if comp == nil || sess == nil {
+		return CompactionData{}, nil
+	}
+
+	msgs, err := sess.GetMessages(ctx, 0)
+	if err != nil {
+		return CompactionData{}, fmt.Errorf("compact: load history: %w", err)
+	}
+
+	if len(msgs) == 0 {
+		return CompactionData{}, nil
+	}
+
+	tokensBefore := memory.EstimateTokens(msgs)
+	msgsBefore := len(msgs)
+
+	compacted := comp.Compact(msgs)
+
+	tokensAfter := memory.EstimateTokens(compacted)
+	msgsAfter := len(compacted)
+
+	// 将压缩后的历史写回 session：先清空再批量写入。
+	if err := sess.Clear(ctx); err != nil {
+		return CompactionData{}, fmt.Errorf("compact: clear session: %w", err)
+	}
+	if err := sess.AddMessages(ctx, compacted); err != nil {
+		return CompactionData{}, fmt.Errorf("compact: write compacted messages: %w", err)
+	}
+
+	data := CompactionData{
+		TokensBefore: tokensBefore,
+		TokensAfter:  tokensAfter,
+		MsgsBefore:   msgsBefore,
+		MsgsAfter:    msgsAfter,
+	}
+
+	log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
+		"manual compact: %s → %s tokens (%d → %d msgs)",
+		memory.FormatTokenCount(data.TokensBefore),
+		memory.FormatTokenCount(data.TokensAfter),
+		data.MsgsBefore, data.MsgsAfter,
+	)))
+
+	return data, nil
+}

--- a/internal/engine/compact_test.go
+++ b/internal/engine/compact_test.go
@@ -1,0 +1,158 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/provider/providertest"
+	"github.com/harness9/internal/schema"
+	"github.com/harness9/internal/tools"
+)
+
+// noopRegistry 是 tools.Registry 的空实现，仅用于测试。
+type noopRegistry struct{}
+
+func (noopRegistry) Register(_ tools.BaseTool) error            { return nil }
+func (noopRegistry) GetAvailableTools() []schema.ToolDefinition { return nil }
+func (noopRegistry) Execute(_ context.Context, _ schema.ToolCall) schema.ToolResult {
+	return schema.ToolResult{}
+}
+
+// fixedCompactor 是 memory.Compactor 的简单实现：始终只保留最后 N 条消息（含 system）。
+type fixedCompactor struct {
+	keep int // 保留最近 keep 条非 system 消息
+}
+
+func (c *fixedCompactor) Compact(msgs []schema.Message) []schema.Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	if c.keep <= 0 || len(msgs) <= c.keep+1 {
+		return msgs
+	}
+	// 保留 system 消息 + 最近 keep 条
+	result := make([]schema.Message, 0, c.keep+1)
+	result = append(result, msgs[0])
+	result = append(result, msgs[len(msgs)-c.keep:]...)
+	return result
+}
+
+func newTestEngine(opts ...Option) *AgentEngine {
+	return NewAgentEngine(providertest.NewMock(), noopRegistry{}, "/tmp", opts...)
+}
+
+// TestCompact_NilCompactor 验证 compactor 为 nil 时，Compact 返回零值 CompactionData 且不报错。
+func TestCompact_NilCompactor(t *testing.T) {
+	sess := memory.NewMemorySession("test-nil-compactor")
+	ctx := context.Background()
+
+	// 预填若干消息
+	msgs := []schema.Message{
+		{Role: schema.RoleSystem, Content: "system"},
+		{Role: schema.RoleUser, Content: "hello"},
+		{Role: schema.RoleAssistant, Content: "world"},
+	}
+	if err := sess.AddMessages(ctx, msgs); err != nil {
+		t.Fatalf("AddMessages: %v", err)
+	}
+
+	// compactor 为 nil（不调用 WithCompactor）
+	eng := newTestEngine(WithSession(sess))
+
+	data, err := eng.Compact(ctx)
+	if err != nil {
+		t.Fatalf("Compact returned unexpected error: %v", err)
+	}
+	// 零值 CompactionData
+	if data != (CompactionData{}) {
+		t.Errorf("expected zero CompactionData, got %+v", data)
+	}
+	// session 历史不变
+	got, err := sess.GetMessages(ctx, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(got) != len(msgs) {
+		t.Errorf("session messages changed: want %d, got %d", len(msgs), len(got))
+	}
+}
+
+// TestCompact_NilSession 验证 session 为 nil 时，Compact 返回零值 CompactionData 且不报错。
+func TestCompact_NilSession(t *testing.T) {
+	eng := newTestEngine(WithCompactor(&fixedCompactor{keep: 2}))
+
+	data, err := eng.Compact(context.Background())
+	if err != nil {
+		t.Fatalf("Compact returned unexpected error: %v", err)
+	}
+	if data != (CompactionData{}) {
+		t.Errorf("expected zero CompactionData, got %+v", data)
+	}
+}
+
+// TestCompact_Normal 验证正常执行：session 历史被替换为压缩后版本，CompactionData 字段正确。
+func TestCompact_Normal(t *testing.T) {
+	sess := memory.NewMemorySession("test-normal-compact")
+	ctx := context.Background()
+
+	// 预填 5 条消息（含 system）
+	msgs := []schema.Message{
+		{Role: schema.RoleSystem, Content: "system prompt"},
+		{Role: schema.RoleUser, Content: "msg1"},
+		{Role: schema.RoleAssistant, Content: "msg2"},
+		{Role: schema.RoleUser, Content: "msg3"},
+		{Role: schema.RoleAssistant, Content: "msg4"},
+	}
+	if err := sess.AddMessages(ctx, msgs); err != nil {
+		t.Fatalf("AddMessages: %v", err)
+	}
+
+	comp := &fixedCompactor{keep: 2} // 保留 system + 最近 2 条 = 3 条
+	eng := newTestEngine(WithSession(sess), WithCompactor(comp))
+
+	data, err := eng.Compact(ctx)
+	if err != nil {
+		t.Fatalf("Compact error: %v", err)
+	}
+
+	// 验证 MsgsBefore / MsgsAfter
+	if data.MsgsBefore != 5 {
+		t.Errorf("MsgsBefore: want 5, got %d", data.MsgsBefore)
+	}
+	if data.MsgsAfter != 3 {
+		t.Errorf("MsgsAfter: want 3, got %d", data.MsgsAfter)
+	}
+	// token 数应减少
+	if data.TokensAfter >= data.TokensBefore {
+		t.Errorf("expected TokensAfter < TokensBefore, got before=%d after=%d",
+			data.TokensBefore, data.TokensAfter)
+	}
+
+	// 验证 session 历史已被替换
+	got, err := sess.GetMessages(ctx, 0)
+	if err != nil {
+		t.Fatalf("GetMessages after compact: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("session messages after compact: want 3, got %d", len(got))
+	}
+	if len(got) > 0 && got[0].Role != schema.RoleSystem {
+		t.Errorf("first message should be system, got %v", got[0].Role)
+	}
+}
+
+// TestCompact_EmptySession 验证 session 无消息时，Compact 返回零值 CompactionData 且不报错。
+func TestCompact_EmptySession(t *testing.T) {
+	sess := memory.NewMemorySession("test-empty")
+	comp := &fixedCompactor{keep: 2}
+	eng := newTestEngine(WithSession(sess), WithCompactor(comp))
+
+	data, err := eng.Compact(context.Background())
+	if err != nil {
+		t.Fatalf("Compact error: %v", err)
+	}
+	if data != (CompactionData{}) {
+		t.Errorf("expected zero CompactionData for empty session, got %+v", data)
+	}
+}

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -51,7 +51,7 @@ trigger: /autodev, autodev
 - <明确列出不做的事>
 ```
 
-展示完成后，输出以下提示，然后**停止等待用户响应**：
+展示完成后，输出以下提示，**不要调用任何工具，直接结束本轮回复**（TUI 会自动等待用户输入）：
 
 > **请确认 spec（输入「确认」继续实现），或告知需要修改的地方。**
 
@@ -65,6 +65,11 @@ trigger: /autodev, autodev
 ### 3.1 前置检查
 
 依次用 bash 执行以下检查，任一失败则停下来告知用户并等待修复：
+
+```bash
+# 检查 Go 已安装（项目要求 1.25+）
+go version
+```
 
 ```bash
 # 检查 gh CLI 已安装并登录
@@ -85,7 +90,8 @@ echo "SANDBOX_IMAGE=${SANDBOX_IMAGE:-未设置}"
 
 ### 3.2 创建 git worktree
 
-从 spec 标题生成 slug（全小写，空格替换为 `-`，去掉特殊字符），然后执行：
+从 spec 标题生成 slug（全小写，空格替换为 `-`，去掉非 ASCII 字母数字字符），然后执行：
+示例：`"Add WebSocket 支持"` → `"add-websocket-"`（中文字符去掉）→ 可简化为 `"add-websocket-support"`
 
 ```bash
 git worktree add .autodev/<slug> -b feature/autodev-<slug>

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: autodev
+description: Feature auto-development — clarify requirements, generate spec, dispatch dev sub-agent to implement and create PR
+trigger: /autodev, autodev
+---
+
+# /autodev — Feature Auto-Development Workflow
+
+当用户输入 `/autodev <功能描述>` 时，你按以下三个阶段工作。
+
+---
+
+## Phase 1: 需求澄清
+
+首先用 `read_file` 读取 `AGENTS.md`，了解项目当前模块、架构和规范（重点：第 4 节项目结构、第 5 节开发流程）。
+
+然后向用户提 **2-3 个关键澄清问题，每次只问一个**：
+
+1. **功能边界**：明确实现什么、不实现什么
+2. **验收标准**：什么样的测试证明功能完成（单元测试？eval 用例？）
+3. **影响范围**：新增文件为主还是修改已有模块
+
+2-3 轮澄清后直接进入 Phase 2，不要过度追问。
+
+---
+
+## Phase 2: Spec 生成与确认
+
+以如下格式生成并展示 spec：
+
+```
+## Feature Spec: <标题>
+
+### 功能描述
+<简洁描述该功能做什么>
+
+### 实现范围
+新增文件：
+- internal/<pkg>/<file>.go
+- internal/<pkg>/<file>_test.go
+
+修改文件：
+- cmd/harness9/main.go（如需注册新工具）
+
+### 验收标准
+- [ ] go build ./... 通过
+- [ ] go test ./... 通过
+- [ ] （如涉及 Agent 行为）internal/evals/dataset/ 新增 eval 用例
+
+### 不在范围内
+- <明确列出不做的事>
+```
+
+展示完成后，输出以下提示，然后**停止等待用户响应**：
+
+> **请确认 spec（输入「确认」继续实现），或告知需要修改的地方。**
+
+如果用户要求修改，更新 spec 后重新展示，再次等待确认。
+只有用户明确输入「确认」后才进入 Phase 3。
+
+---
+
+## Phase 3: 前置检查 + 委派实现
+
+### 3.1 前置检查
+
+依次用 bash 执行以下检查，任一失败则停下来告知用户并等待修复：
+
+```bash
+# 检查 gh CLI 已安装并登录
+gh auth status
+```
+
+```bash
+# 检查 git 可用
+git --version
+```
+
+如果 `SANDBOX_ENABLED=true`，还需检查 Go 镜像是否配置：
+```bash
+echo "SANDBOX_IMAGE=${SANDBOX_IMAGE:-未设置}"
+# 若未设置或不含 golang，提示用户在 .env 中添加：
+# SANDBOX_IMAGE=golang:1.25-bookworm
+```
+
+### 3.2 创建 git worktree
+
+从 spec 标题生成 slug（全小写，空格替换为 `-`，去掉特殊字符），然后执行：
+
+```bash
+git worktree add .autodev/<slug> -b feature/autodev-<slug>
+```
+
+用 bash 获取绝对路径：
+```bash
+readlink -f .autodev/<slug>
+```
+
+### 3.3 委派 dev sub-agent
+
+调用 task 工具委派 dev sub-agent：
+
+```
+task("dev", "以下是需要实现的 Feature Spec：\n\n<spec 全文>\n\n工作目录（git worktree 绝对路径）：<worktreePath>")
+```
+
+### 3.4 处理结果
+
+**成功（sub-agent 返回 PR URL）：**
+1. 在 TUI 中展示：「✓ PR 已创建：<URL>」
+2. 清理 worktree：`git worktree remove .autodev/<slug>`
+
+**失败（sub-agent 报告无法通过测试）：**
+1. 展示错误摘要
+2. 保留 worktree 供排查：「worktree 保留在 .autodev/<slug>，可用 `cd .autodev/<slug>` 进入排查」
+3. 告知用户可手动删除：`git worktree remove .autodev/<slug> --force`


### PR DESCRIPTION
## 变更说明

新增 `/compact` TUI 内置命令，支持用户手动触发上下文压缩。

### 主要变更
- `internal/engine/compact.go`：新增 `AgentEngine.Compact()` 公开方法
- `cmd/harness9/tui_update.go`：识别并处理 `/compact` 命令
- `cmd/harness9/tui_view.go`：压缩期间展示 spinner 进度条

### 测试
- 新增 `internal/engine/compact_test.go`
- `go test ./...` 全部通过

---
🤖 Generated by harness9 /autodev