### PR TITLE
fix/feat: 修复 /compact 手动压缩 + autodev 改为合并分支 + 新增 cr/commit/pr skill

### DIFF
--- a/cmd/harness9/tui_update.go
+++ b/cmd/harness9/tui_update.go
@@ -411,8 +411,14 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case compactDoneMsg:
 		m.compacting = false
 		data := msg.data
-		// 若 data 全为零值（无 compactor 或无 session），不追加通知。
-		if data.MsgsBefore > 0 {
+		switch {
+		case data.MsgsBefore == 0:
+			// 全零值：无 compactor 或无 session
+			m.lines = append(m.lines, dimStyle.Render("  ✦ /compact: 无可压缩内容（无 session 或无 compactor）"))
+		case data.MsgsBefore == data.MsgsAfter && data.TokensBefore == data.TokensAfter:
+			// 压缩前后完全相同：消息数量不足（session 中至少需要 2 条消息才能产生可摘要的 head）
+			m.lines = append(m.lines, dimStyle.Render("  ✦ /compact: 消息数量不足，无法压缩（至少需要 2 条消息）"))
+		default:
 			line := dimStyle.Render(fmt.Sprintf(
 				"  ✦ Context compacted: %d → %d messages, %s → %s tokens",
 				data.MsgsBefore, data.MsgsAfter,
@@ -420,8 +426,6 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				memory.FormatTokenCount(data.TokensAfter),
 			))
 			m.lines = append(m.lines, line)
-		} else {
-			m.lines = append(m.lines, dimStyle.Render("  ✦ /compact: 无可压缩内容（无 session 或无 compactor）"))
 		}
 		m.input.Focus()
 		return m, textinput.Blink

--- a/internal/engine/compact.go
+++ b/internal/engine/compact.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/schema"
 )
 
 // Compact 对当前 session 的历史消息执行一次强制压缩，跳过 80% 阈值检查。
@@ -18,9 +19,13 @@ import (
 // 行为说明：
 //   - compactor 为 nil 时：立即返回零值 CompactionData 和 nil error（no-op）
 //   - session 为 nil 时：立即返回零值 CompactionData 和 nil error（no-op）
-//   - 否则：读取完整历史 → 调用 compactor.Compact → 将压缩结果写回 session
+//   - 否则：读取完整历史 → 注入 system prompt（与 runLoop 路径一致）→ 调用 ForceCompact →
+//     剥离 system prompt → 写回 session
 //
-// 返回的 CompactionData 包含压缩前后的 token 数和消息条数，
+// 注意：system prompt 不持久化到 DB（与 loadHistoryWith 一致），Compact 在调用
+// compactor 前注入 system prompt，写回时再剥离，保证 compactor 的 msgs[0].Role==System 前提。
+//
+// 返回的 CompactionData 包含压缩前后的 token 数和消息条数（不含 system prompt），
 // 供 TUI 在对话流中展示压缩通知消息。
 //
 // 线程安全：通过读锁快照 session 和 compactor，与 TUI goroutine 并发安全。
@@ -34,6 +39,7 @@ func (e *AgentEngine) Compact(ctx context.Context) (CompactionData, error) {
 		return CompactionData{}, nil
 	}
 
+	// 从 DB 加载历史（不含 system prompt）
 	msgs, err := sess.GetMessages(ctx, 0)
 	if err != nil {
 		return CompactionData{}, fmt.Errorf("compact: load history: %w", err)
@@ -46,7 +52,25 @@ func (e *AgentEngine) Compact(ctx context.Context) (CompactionData, error) {
 	tokensBefore := memory.EstimateTokens(msgs)
 	msgsBefore := len(msgs)
 
-	compacted := comp.Compact(msgs)
+	// system prompt 不存 DB，在调用 compactor 前动态注入（与 loadHistoryWith 一致），
+	// 确保 compactor 的前置条件 msgs[0].Role == RoleSystem 成立。
+	// 使用独立分配的切片，避免与 msgs 底层数组产生别名。
+	withSystem := make([]schema.Message, 0, len(msgs)+1)
+	withSystem = append(withSystem, schema.Message{Role: schema.RoleSystem, Content: e.buildSystemPrompt()})
+	withSystem = append(withSystem, msgs...)
+
+	var compactedWithSystem []schema.Message
+	if fc, ok := comp.(memory.ForceCompactor); ok {
+		compactedWithSystem = fc.CompactForce(withSystem)
+	} else {
+		compactedWithSystem = comp.Compact(withSystem)
+	}
+
+	// 剥离 system prompt（不持久化），得到写回 DB 的消息列表。
+	compacted := compactedWithSystem
+	if len(compacted) > 0 && compacted[0].Role == schema.RoleSystem {
+		compacted = compacted[1:]
+	}
 
 	tokensAfter := memory.EstimateTokens(compacted)
 	msgsAfter := len(compacted)

--- a/internal/engine/compact_test.go
+++ b/internal/engine/compact_test.go
@@ -47,9 +47,8 @@ func TestCompact_NilCompactor(t *testing.T) {
 	sess := memory.NewMemorySession("test-nil-compactor")
 	ctx := context.Background()
 
-	// 预填若干消息
+	// 预填若干消息（不含 system，与真实 session 不变式一致）
 	msgs := []schema.Message{
-		{Role: schema.RoleSystem, Content: "system"},
 		{Role: schema.RoleUser, Content: "hello"},
 		{Role: schema.RoleAssistant, Content: "world"},
 	}
@@ -92,13 +91,15 @@ func TestCompact_NilSession(t *testing.T) {
 }
 
 // TestCompact_Normal 验证正常执行：session 历史被替换为压缩后版本，CompactionData 字段正确。
+//
+// 与真实使用场景一致：system prompt 不持久化到 session DB，
+// Compact 内部动态注入 system prompt 后交给 compactor 处理，写回时剥离 system。
 func TestCompact_Normal(t *testing.T) {
 	sess := memory.NewMemorySession("test-normal-compact")
 	ctx := context.Background()
 
-	// 预填 5 条消息（含 system）
+	// 预填 4 条非 system 消息（真实场景中 session 不存储 system prompt）
 	msgs := []schema.Message{
-		{Role: schema.RoleSystem, Content: "system prompt"},
 		{Role: schema.RoleUser, Content: "msg1"},
 		{Role: schema.RoleAssistant, Content: "msg2"},
 		{Role: schema.RoleUser, Content: "msg3"},
@@ -108,7 +109,7 @@ func TestCompact_Normal(t *testing.T) {
 		t.Fatalf("AddMessages: %v", err)
 	}
 
-	comp := &fixedCompactor{keep: 2} // 保留 system + 最近 2 条 = 3 条
+	comp := &fixedCompactor{keep: 2} // 保留 system + 最近 2 条；写回时 system 被剥离 → session 有 2 条
 	eng := newTestEngine(WithSession(sess), WithCompactor(comp))
 
 	data, err := eng.Compact(ctx)
@@ -116,12 +117,12 @@ func TestCompact_Normal(t *testing.T) {
 		t.Fatalf("Compact error: %v", err)
 	}
 
-	// 验证 MsgsBefore / MsgsAfter
-	if data.MsgsBefore != 5 {
-		t.Errorf("MsgsBefore: want 5, got %d", data.MsgsBefore)
+	// MsgsBefore/After 均不含 system（session 不存 system）
+	if data.MsgsBefore != 4 {
+		t.Errorf("MsgsBefore: want 4, got %d", data.MsgsBefore)
 	}
-	if data.MsgsAfter != 3 {
-		t.Errorf("MsgsAfter: want 3, got %d", data.MsgsAfter)
+	if data.MsgsAfter != 2 {
+		t.Errorf("MsgsAfter: want 2, got %d", data.MsgsAfter)
 	}
 	// token 数应减少
 	if data.TokensAfter >= data.TokensBefore {
@@ -129,16 +130,17 @@ func TestCompact_Normal(t *testing.T) {
 			data.TokensBefore, data.TokensAfter)
 	}
 
-	// 验证 session 历史已被替换
+	// session 写回的消息不含 system（system 由 engine 动态注入，不持久化）
 	got, err := sess.GetMessages(ctx, 0)
 	if err != nil {
 		t.Fatalf("GetMessages after compact: %v", err)
 	}
-	if len(got) != 3 {
-		t.Errorf("session messages after compact: want 3, got %d", len(got))
+	if len(got) != 2 {
+		t.Errorf("session messages after compact: want 2, got %d", len(got))
 	}
-	if len(got) > 0 && got[0].Role != schema.RoleSystem {
-		t.Errorf("first message should be system, got %v", got[0].Role)
+	// 第一条应为 user（msg3），而非 system
+	if len(got) > 0 && got[0].Role == schema.RoleSystem {
+		t.Errorf("session should not contain system message after compact")
 	}
 }
 

--- a/internal/memory/compaction.go
+++ b/internal/memory/compaction.go
@@ -11,6 +11,13 @@ type Compactor interface {
 	Compact(msgs []schema.Message) []schema.Message
 }
 
+// ForceCompactor 扩展 Compactor，提供跳过 token 阈值检查的强制压缩能力。
+// 由 engine.Compact（/compact 手动命令）使用，强制执行压缩而不受 80% 阈值约束。
+type ForceCompactor interface {
+	Compactor
+	CompactForce(msgs []schema.Message) []schema.Message
+}
+
 // SlidingWindowCompactor 保留最近 MaxMessages 条消息（System Prompt 固定在首位）。
 // MaxMessages 含 system 消息本身；0 或负数时使用默认值 100。
 type SlidingWindowCompactor struct {
@@ -111,6 +118,29 @@ func (c *TokenBudgetCompactor) Compact(msgs []schema.Message) []schema.Message {
 	}
 
 	// 头部完全移除：仅保留 system 消息 + 尾部最近消息。
+	result := make([]schema.Message, 0, 1+len(tail))
+	result = append(result, msgs[0])
+	result = append(result, tail...)
+	return repairOrphanedToolPairs(result)
+}
+
+// CompactForce 强制压缩，跳过 token 预算阈值检查，直接移除最旧的非 system 消息。
+// 用于手动触发的 /compact 命令：无论当前 token 用量多少，都执行一次结构裁剪。
+// 与 Compact 的区别：minTail 固定为 1，允许在消息数量很少时也能压缩。
+//
+// 注意：此方法不做 LLM 摘要，直接丢弃旧消息，仅保留 system + 最新 1 条；
+// 通常作为 SummarizationCompactor.CompactForce 摘要失败时的 fallback。
+func (c *TokenBudgetCompactor) CompactForce(msgs []schema.Message) []schema.Message {
+	if len(msgs) == 0 || msgs[0].Role != schema.RoleSystem {
+		return msgs
+	}
+	const forceMinTail = 1
+	rest := msgs[1:]
+	if len(rest) <= forceMinTail {
+		return msgs // 只有 system + 1 条消息，无可裁剪的头部
+	}
+	// 直接移除中间最旧的非 system 消息，只保留 system + 最近 1 条。
+	tail := rest[len(rest)-forceMinTail:]
 	result := make([]schema.Message, 0, 1+len(tail))
 	result = append(result, msgs[0])
 	result = append(result, tail...)

--- a/internal/memory/summarization.go
+++ b/internal/memory/summarization.go
@@ -134,6 +134,41 @@ func (c *SummarizationCompactor) Compact(msgs []schema.Message) []schema.Message
 		return c.fallback().Compact(msgs)
 	}
 
+	return c.buildCompactedResult(msgs[0], summary, tail)
+}
+
+// CompactForce 强制压缩，跳过 token 预算阈值检查，总是尝试 LLM 摘要。
+// 用于手动触发的 /compact 命令：无论当前 token 用量多少，都执行摘要压缩。
+// 与 Compact 的区别：minTail 固定为 1，允许在消息数量很少时也能压缩（只保留最新 1 条）。
+func (c *SummarizationCompactor) CompactForce(msgs []schema.Message) []schema.Message {
+	if len(msgs) == 0 || msgs[0].Role != schema.RoleSystem {
+		return msgs
+	}
+	const forceMinTail = 1 // 强制压缩时只保留最近 1 条消息作为 tail
+	rest := msgs[1:]
+	if len(rest) <= forceMinTail {
+		return msgs // 只有 system + 1 条消息，无可摘要的头部
+	}
+	headEnd := len(rest) - forceMinTail
+	head := rest[:headEnd]
+	tail := rest[headEnd:]
+	if c.extractor != nil {
+		c.extractor.Extract(head)
+	}
+	summary, err := c.summarize(head)
+	if err != nil {
+		// 摘要失败时回退到 TokenBudgetCompactor 的强制压缩
+		if fb, ok := c.fallback().(ForceCompactor); ok {
+			return fb.CompactForce(msgs)
+		}
+		return c.fallback().Compact(msgs)
+	}
+	return c.buildCompactedResult(msgs[0], summary, tail)
+}
+
+// buildCompactedResult 将 system 消息、LLM 摘要文本和尾部消息组合为压缩后的消息列表。
+// Compact 和 CompactForce 共用此方法，避免重复拼装逻辑。
+func (c *SummarizationCompactor) buildCompactedResult(systemMsg schema.Message, summary string, tail []schema.Message) []schema.Message {
 	summaryContent := summaryMarker + "\n" + summary
 	if c.TodoInjector != nil {
 		if todoText := c.TodoInjector.FormatForInjection(); todoText != "" {
@@ -144,12 +179,10 @@ func (c *SummarizationCompactor) Compact(msgs []schema.Message) []schema.Message
 		Role:    schema.RoleUser,
 		Content: summaryContent,
 	}
-
 	result := make([]schema.Message, 0, 2+len(tail))
-	result = append(result, msgs[0])    // system 始终保留
+	result = append(result, systemMsg)  // system 始终保留
 	result = append(result, summaryMsg) // LLM 生成的摘要
 	result = append(result, tail...)    // 最近消息原样保留
-
 	return repairOrphanedToolPairs(result)
 }
 

--- a/skills/autodev/SKILL.md
+++ b/skills/autodev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autodev
-description: Feature auto-development — clarify requirements, generate spec, dispatch dev sub-agent to implement and create PR
+description: Feature auto-development — clarify requirements, generate spec, dispatch dev sub-agent to implement and merge into current branch
 trigger: /autodev, autodev
 ---
 
@@ -72,11 +72,6 @@ go version
 ```
 
 ```bash
-# 检查 gh CLI 已安装并登录
-gh auth status
-```
-
-```bash
 # 检查 git 可用
 git --version
 ```
@@ -112,9 +107,23 @@ task("dev", "以下是需要实现的 Feature Spec：\n\n<spec 全文>\n\n工作
 
 ### 3.4 处理结果
 
-**成功（sub-agent 返回 PR URL）：**
-1. 在 TUI 中展示：「✓ PR 已创建：<URL>」
+**成功（sub-agent 返回 `AUTODEV_RESULT: SUCCESS`）：**
+
+从 sub-agent 返回结果中提取 `BRANCH: <branch-name>`，然后执行合并：
+
+```bash
+# 将 feature 分支合并到当前分支
+git merge feature/autodev-<slug>
+```
+
+若合并成功：
+1. 展示：「✓ 已合并到当前分支：feature/autodev-<slug>」
 2. 清理 worktree：`git worktree remove .autodev/<slug>`
+
+若合并产生冲突：
+1. 展示冲突文件列表
+2. 保留 worktree：「存在合并冲突，worktree 保留在 .autodev/<slug>，请手动解决冲突」
+3. 告知用户解决后执行：`git worktree remove .autodev/<slug> --force`
 
 **失败（sub-agent 报告无法通过测试）：**
 1. 展示错误摘要

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: commit
+description: Use when the user invokes /commit or asks to commit changes, after a code review has been completed and the changes are confirmed ready to stage and commit to git.
+---
+
+# commit — Stage & Commit
+
+## Overview
+
+在 Code Review 通过后，将有效的代码变更暂存并提交到本地 Git 仓库。
+
+## 前置条件检查
+
+1. 确认本次对话中已执行过 `/cr`（Code Review）
+2. 若 Review 报告存在 **Critical** 问题，**停止执行**，提示用户先修复
+3. 若未执行过 `/cr`，先调用 `cr` skill 完成 Review，再继续
+
+## 执行步骤
+
+### 1. 确认变更范围
+
+```bash
+git status
+git diff --stat
+git diff --cached --stat
+```
+
+### 2. 精确暂存文件
+
+**不使用 `git add -A` 或 `git add .`**，逐文件或逐目录添加：
+
+```bash
+git add <具体文件或目录>
+```
+
+排除规则：
+- `.env`、包含敏感信息的文件 → 不暂存，提示用户确认
+- 与本次功能无关的临时文件 → 不暂存
+
+### 3. 起草提交信息
+
+参考以下格式（优先遵循仓库现有风格，通过 `git log --oneline -10` 判断）：
+
+```
+<type>: <简明描述>（50 字符以内）
+
+<可选正文：说明 why，不是 what>
+```
+
+常用 `type`：`feat` / `fix` / `docs` / `refactor` / `test` / `chore`
+
+**禁止**在提交信息中添加任何 AI 工具相关的署名，例如 `Co-Authored-By: Claude` 或类似内容。
+
+### 4. 执行提交
+
+```bash
+git commit -m "$(cat <<'EOF'
+<提交信息>
+EOF
+)"
+```
+
+### 5. 确认结果
+
+```bash
+git log --oneline -3   # 确认提交已记录
+git status             # 确认工作区干净
+```
+
+输出提交的 hash 与摘要，告知用户提交成功。
+
+## 常见错误
+
+| 问题 | 处理 |
+|------|------|
+| pre-commit hook 失败 | 修复 hook 报告的问题，重新 `git add` 后创建**新** commit，不使用 `--amend` |
+| 暂存了不该提交的文件 | `git restore --staged <file>` 取消暂存，重新操作 |
+| 工作区已无变更 | 告知用户没有可提交的内容 |

--- a/skills/cr/SKILL.md
+++ b/skills/cr/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: cr
+description: Use when the user invokes /cr, requests a code review, or before committing to verify correctness, security, and quality of new or modified code in the working tree.
+---
+
+# cr — Code Review
+
+## Overview
+
+对当前工作区所有新增或修改的代码执行详细的 Code Review，按严重级别输出问题，不做任何修改。
+
+## 执行步骤
+
+### 1. 收集变更范围
+
+```bash
+git status          # 查看新增 / 修改 / 删除的文件列表
+git diff            # 未暂存的改动
+git diff --cached   # 已暂存的改动
+```
+
+将两者合并视为本次 Review 的完整范围。
+
+### 2. 逐文件审查
+
+对每个变更文件，依次检查：
+
+| 维度 | 检查点 |
+|------|--------|
+| **正确性** | 逻辑错误、边界条件、空值/类型异常 |
+| **安全性** | SQL 注入、XSS、命令注入、敏感信息硬编码、不安全的默认值 |
+| **可维护性** | 函数/类职责单一、命名清晰、不必要的复杂度 |
+| **性能** | N+1 查询、不必要的循环、大对象复制 |
+| **测试覆盖** | 关键路径是否有对应测试，新代码是否破坏现有测试 |
+| **依赖安全** | 新引入的第三方包是否合理，版本是否锁定 |
+
+### 3. 检查敏感文件
+
+若 `git status` 中出现以下类型的文件，**单独标注**，不得进入后续提交：
+
+- `.env`、`*.pem`、`*credentials*`、`*secret*`
+- 包含明文密码、API Key 的配置文件
+
+### 4. 输出 Review 报告
+
+按以下格式输出，无问题的级别可省略：
+
+```
+## Code Review 报告
+
+### 🔴 Critical（必须修复，阻断提交）
+- `文件路径:行号` — 问题描述
+
+### 🟡 Warning（建议修复）
+- `文件路径:行号` — 问题描述
+
+### 🔵 Suggestion（可选优化）
+- `文件路径:行号` — 建议描述
+
+### ✅ 总结
+- 变更文件数：N
+- 通过提交：是 / 否（存在 Critical 问题时为否）
+```
+
+## 注意事项
+
+- 只审查，不修改代码
+- Critical 问题存在时，明确说明**不建议提交**，等待用户确认修复
+- 若变更集为空（`git status` 无输出），告知用户当前无需 Review

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: pr
+description: Use when the user invokes /pr or asks to push changes and open a pull request, after commits are ready to be pushed to a remote branch and merged into the main branch.
+---
+
+# pr — Push & Pull Request
+
+## Overview
+
+将本地提交推送到远程分支，并使用 `gh` CLI 创建 Pull Request，目标为仓库主分支。
+
+> **默认行为**：所有 PR 均以 **Draft** 模式创建（`--draft`），避免误操作导致未经审查的代码被直接 merge。需要正式发起 Review 时，由用户在 GitHub 上手动将 Draft 转为 Ready for Review。
+
+## 前置条件检查
+
+1. 确认本次对话中已执行过 `/commit`，且有新提交未推送
+2. 确认当前分支**不是** `main` / `master`（若在主分支，停止并提示用户切换到功能分支）
+3. 确认 `gh` CLI 已登录：`gh auth status`
+
+## 执行步骤
+
+### 1. 了解当前分支状态
+
+```bash
+git branch --show-current          # 当前分支名
+git log --oneline origin/HEAD..HEAD  # 待推送的提交列表
+git diff origin/HEAD...HEAD --stat   # 本次 PR 涉及的文件变更
+```
+
+### 2. 确定目标分支
+
+按以下顺序判断：
+
+1. 仓库默认分支（`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`）
+2. 若无法获取，依次尝试 `main` → `master`
+3. 仍不确定时，询问用户
+
+### 3. 推送到远程
+
+```bash
+git push -u origin <当前分支名>
+```
+
+若远程已有同名分支且有分歧，**不使用 `--force`**，先告知用户手动处理冲突。
+
+### 4. 起草 PR 内容
+
+根据 `git log` 和 `git diff` 的输出，整理：
+
+- **标题**：70 字符以内，描述本次变更的核心目的
+- **正文**：包含变更摘要（2-4 条要点）和测试计划
+
+### 5. 创建 Pull Request
+
+**始终使用 `--draft` 标志**，避免误操作导致 PR 被直接 merge。
+
+```bash
+gh pr create \
+  --draft \
+  --base <目标分支> \
+  --title "<PR 标题>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <要点 1>
+- <要点 2>
+
+## Test Plan
+- [ ] <测试项 1>
+- [ ] <测试项 2>
+EOF
+)"
+```
+
+**禁止**在 PR 正文中添加任何 AI 工具相关的标注，例如 `🤖 Generated with Claude Code` 或类似内容。
+
+### 6. 输出结果
+
+返回 PR URL，告知用户 PR 已创建成功。
+
+## 常见错误
+
+| 问题 | 处理 |
+|------|------|
+| `gh` 未登录 | 提示用户执行 `! gh auth login` |
+| 当前分支无新提交 | 告知用户没有可推送的内容，建议先执行 `/commit` |
+| 该分支已存在 PR | 使用 `gh pr view` 查看现有 PR，提示用户是否需要更新 |
+| 推送被拒绝（non-fast-forward） | 不强制推送，提示用户检查远程分支状态 |


### PR DESCRIPTION
## Summary

- **fix /compact**：修复手动压缩完全无效的问题——根本原因是 session DB 不存储 system prompt，导致 compactor 前置检查 `msgs[0].Role != RoleSystem` 始终触发早返回。修复方案：在调用 compactor 前动态注入 system prompt（与 `loadHistoryWith` 路径一致），写回时再剥离；新增 `ForceCompactor` 接口跳过 80% 阈值检查；提取 `buildCompactedResult` 消除重复逻辑；修复 TUI 提示文案与 append 别名风险
- **autodev 改为合并**：dev sub-agent 完成后不再推送远端和创建 PR，而是提交到 `feature/autodev-<slug>` 后由主 agent 执行 `git merge`，合并到当前分支并清理 worktree；移除 `gh` CLI 前置依赖检查
- **新增 skill**：将用户 scope 的 `cr`、`commit`、`pr` skill 转换为 harness9 格式，放入 `skills/` 目录

## Test Plan

- [ ] `go test ./internal/memory/... ./internal/engine/...` 全部通过
- [ ] 启动 harness9，手动执行 `/compact`，验证压缩实际发生（token 数减少，消息数减少）
- [ ] 消息数量不足时（< 2 条），验证显示"消息数量不足，无法压缩（至少需要 2 条消息）"而非错误的"2 → 2"
- [ ] `/cr`、`/commit`、`/pr` skill 可通过 Tab 补全并加载