### PR TITLE
fix: 框架鲁棒性与正确性优化（SWE-bench 轨迹分析驱动）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,20 @@ LLM_MODEL=openai/gpt-4o-mini
 ANTHROPIC_API_KEY=your-anthropic-api-key
 ANTHROPIC_BASE_URL=https://api.anthropic.com
 
+# ---- LLM 请求韧性（OpenAI/Anthropic 共用）----
+# 单次请求超时（秒），防止卡死的连接吞掉整体预算。默认 600。
+# LLM_REQUEST_TIMEOUT_SECS=600
+# SDK 内置重试次数（覆盖 429/5xx/连接错误，首字节前）。默认 5（高于 SDK 默认 2）。
+# 流式中途断连由引擎层应用重试兜底（WithGenerateRetry）。
+# LLM_MAX_RETRIES=5
+
 # ---- Sandbox 系统 ----
 # Docker Sandbox 默认开启（需本地安装并运行 Docker）。
 # 如需关闭，取消下行注释：
 # SANDBOX_ENABLED=false
+# SANDBOX_IMAGE 指定容器镜像（默认 ubuntu:22.04；SWE-bench runner 默认 python:3.11-slim）。
+# SANDBOX_IMAGE=python:3.11-slim
+# 容器就绪后、Agent 开始前执行一次的初始化命令（独立超时预算，不受单条 bash 30s/120s 约束）。
+# 用于为仓库安装依赖或激活预置环境，是接入官方 SWE-bench 每实例镜像的关键接缝。
+# SANDBOX_BOOTSTRAP_CMD=pip install -e . -q
+# SANDBOX_BOOTSTRAP_TIMEOUT_SECS=600

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ logs/
 
 # SWE-bench 数据集文件（体积大，不纳入版本控制）
 swe-bench-lite.jsonl
+
+# SWE-bench 运行产物（predictions / trajectory 日志 / run_summary / 官方评分 JSON），均为生成物
+swebench-results/
+*.harness9-lite-*.json

--- a/cmd/swebench/main.go
+++ b/cmd/swebench/main.go
@@ -49,9 +49,10 @@ func main() {
 	flag.StringVar(&cfg.OutputDir, "output", "./swebench-results", "输出目录")
 	flag.IntVar(&cfg.MaxTurns, "max-turns", 0, "每个 instance 最大 LLM Turn 数（0 = 沿用引擎默认值 500）")
 	flag.IntVar(&cfg.Parallel, "parallel", 1, "并发 instance 数")
-	flag.BoolVar(&cfg.Resume, "resume", false, "跳过已有结果的 instance（断点续跑）")
-	flag.IntVar(&cfg.TimeoutMins, "timeout", 10, "单个 instance 超时（分钟）")
+	flag.BoolVar(&cfg.Resume, "resume", false, "跳过已有非空结果的 instance（断点续跑）")
+	flag.IntVar(&cfg.TimeoutMins, "timeout", 30, "单个 instance 超时（分钟）")
 	flag.StringVar(&cfg.Model, "model", "", "LLM 模型名称（默认使用 LLM_MODEL 环境变量）")
+	flag.Int64Var(&cfg.Seed, "seed", 1, "按 repo 采样的随机种子（固定默认值保证可复现；同 seed → 同实例集）")
 	flag.Parse()
 
 	if cfg.DatasetPath == "" {
@@ -90,9 +91,9 @@ func main() {
 	modelName := resolveModelName(cfg.Model)
 	fmt.Fprintf(os.Stderr, "使用模型: %s\n", modelName)
 
-	// 按 repo 采样
-	instances := sampleByRepo(allInstances, cfg.SampleN, time.Now().UnixNano())
-	fmt.Fprintf(os.Stderr, "采样完成: %d 条（每 repo 最多 %d 条）\n", len(instances), cfg.SampleN)
+	// 按 repo 采样（固定 seed → 可复现；--resume 时同 seed 自然复现同一实例集）
+	instances := sampleByRepo(allInstances, cfg.SampleN, cfg.Seed)
+	fmt.Fprintf(os.Stderr, "采样完成: %d 条（每 repo 最多 %d 条，seed=%d）\n", len(instances), cfg.SampleN, cfg.Seed)
 
 	// 加载已有结果（--resume 模式）
 	predictionsPath := filepath.Join(cfg.OutputDir, "predictions.jsonl")
@@ -106,8 +107,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "断点续跑: 跳过 %d 个已有结果\n", len(skipIDs))
 	}
 
-	// 创建输出目录及 trajectory 日志子目录
-	if err := os.MkdirAll(filepath.Join(cfg.OutputDir, "logs"), 0755); err != nil {
+	// 为本次运行分配 RunID（时间戳），trajectory 日志写入 logs/<RunID>/，
+	// 避免多次运行的同名日志互相覆盖、污染后续分析。
+	cfg.RunID = time.Now().Format("20060102-150405")
+	fmt.Fprintf(os.Stderr, "本次运行 RunID: %s（日志目录 logs/%s/）\n", cfg.RunID, cfg.RunID)
+
+	// 创建输出目录及本次运行的 trajectory 日志子目录
+	if err := os.MkdirAll(filepath.Join(cfg.OutputDir, "logs", cfg.RunID), 0755); err != nil {
 		fmt.Fprintf(os.Stderr, "创建输出目录失败: %v\n", err)
 		os.Exit(1)
 	}
@@ -171,7 +177,7 @@ func main() {
 
 	// 写汇总
 	end := time.Now()
-	if err := writeSummary(cfg.OutputDir, results, start, end); err != nil {
+	if err := writeSummary(cfg, results, start, end); err != nil {
 		fmt.Fprintf(os.Stderr, "写入摘要失败: %v\n", err)
 	}
 

--- a/cmd/swebench/prompt.go
+++ b/cmd/swebench/prompt.go
@@ -4,92 +4,64 @@ import "strings"
 
 // sweBenchPromptTemplate 是 SWE-bench 专用的 agent 指令模板。
 //
-// 设计原则（基于两批次 benchmark trajectory 分析，2026-06-10/11）：
-//  1. 语言锁定：防止语言漂移（日语/韩语输出的偶发问题，语言约束加强至首尾双重声明）
-//  2. workDir 注入：消除 Agent 猜测 /repo 路径导致的 cd 失败（SWE-bench 官方 Docker 约定与
-//     harness9 sandbox 路径不同）
-//  3. bash 30s 超时约束：明确告知 Agent 不要尝试安装大型依赖包
-//  4. Python 分阶段检测策略：
-//     a. 解释器可用性（一条命令，单独执行，不与其他命令并发）
-//     b. 关键包导入可行性（追加一条命令，快速 fail-fast）
-//     c. 熔断规则：pip install 失败/超时一次后立即停止，转静态分析
-//  5. 并发工具调用引导：Step 2 探索阶段同时发起多个工具调用
-//  6. 先规划后编辑 + 禁止 bash sed 读文件：强制使用 read_file start_line/end_line
-//  7. edit_file diff 可信度声明：明确 diff 即为权威确认，无需额外验证
-//  8. 验证上限约束：至多 2 步，pip install 失败则立即转静态分析
-const sweBenchPromptTemplate = `**语言要求（贯穿全程）**：所有分析、推理和回复必须使用中文。代码标识符（函数名、类名、变量名）保持英文原名。此规则在任何情况下不得改变。
+// 设计原则（基于多批次 benchmark trajectory 分析，2026-06）：
+//  1. 相对路径强约束：read_file/write_file/edit_file 必须用相对路径——此前注入的绝对
+//     workDir 诱使 Agent 给文件工具传绝对路径，触发 safePath 路径翻倍 bug（10/12 实例命中）。
+//     该 bug 已在 safePath 修复，此处再以 prompt 双重保险并引导更简洁的相对路径。
+//  2. 行为验证而非语法验证：edit_file 的 diff 只确认"字节已写入"，不代表行为正确；
+//     旧 prompt 的"验证至多 1-2 步 / diff 即权威无需复验"直接导致大量 plausible-but-wrong
+//     的过度修复（如 sphinx-7738 整段删除）。改为鼓励运行真实测试 / 复现脚本，
+//     并明确禁止"把类/函数原样重抄到内联脚本里自测"这种假验证。
+//  3. 阅读现有测试：现有（非隐藏）测试编码了维护者期望的确切行为/输出字符串/边界条件，
+//     是对齐隐藏评分测试的最强信号；明确"可读取、绝不修改"。
+//  4. heredoc 跑复现：复现脚本一律用 `python3 - <<'PY'` 临时执行，绝不用 write_file 在
+//     仓库内新建 .py——否则会进入 git diff 污染最终 patch。
+//  5. 务实的依赖/超时说明：pip 可能不可用、慢命令可用 timeout_secs 放宽；能 import 就跑测试。
+//  6. 英文推理：英文更贴合英文代码/Issue/堆栈，代码匹配任务质量更优；单行防漂移约束，
+//     标识符保持原文。
+//  7. 并发探索 + 行号读取：Step 2 鼓励并行工具调用；read_file 行号模式便于精确 edit。
+const sweBenchPromptTemplate = `You are a senior software engineer fixing a real GitHub issue in the repository at the working directory below. Produce a clean, minimal patch that resolves the issue.
 
-你是一名资深软件工程师，正在处理一个真实的 GitHub Issue。
-你的目标是在当前代码仓库中找到并修复这个问题，生成一个干净、最小化的 patch。
+Reason and respond in English. Keep all code identifiers and string literals verbatim — never translate or rewrite them.
 
-## 环境信息
+## Environment
 
-- **当前工作目录**：` + "`{{WORK_DIR}}`" + `（这是实际路径，**不要使用 /repo 或其他假设路径**）
-- **bash 超时限制**：每条 bash 命令最多执行 30 秒，超时后被强制终止
-  - ⚠️ **pip install 大型包（numpy/scipy/matplotlib 等）通常超时被 killed**，不要尝试
-  - 如需安装，只尝试轻量小包（如 ` + "`pip install mpmath -q`" + `），且只试一次
+- **Working directory**: ` + "`{{WORK_DIR}}`" + ` — this is the real path; bash commands execute here.
+- **File paths**: read_file / write_file / edit_file MUST receive paths **relative to the working directory** (e.g. ` + "`src/flask/cli.py`" + `). NEVER pass an absolute path (one starting with ` + "`/`" + `) to these tools — it causes path errors. bash also runs inside the working directory, so use relative paths there too (e.g. ` + "`grep -rn foo src/`" + `).
+- **Isolated container**: you have an isolated environment. Each bash command has a timeout; for a slow test suite or install, pass ` + "`timeout_secs`" + ` to extend that single command.
+- **Dependencies**: project deps may or may not be pre-installed, and ` + "`pip`" + ` may be unavailable. If a quick ` + "`python3 -c \"import <pkg>\"`" + ` succeeds, prefer running real tests. If imports fail and a one-shot lightweight install is not possible, fall back to careful static analysis of the real source.
 
-## 工作流程
+## Workflow
 
-按以下步骤顺序执行：
+### Step 1 — Understand
+Read the issue carefully. Identify the core bug or missing behavior, the reproduction steps (if any), and expected vs. actual behavior.
 
-### Step 1 — 理解问题
-仔细阅读 Issue 描述，识别：
-- 核心 bug 或缺失行为是什么
-- 复现步骤（如有）
-- 预期行为 vs 实际行为
+### Step 2 — Explore
+Issue **multiple tool calls in parallel** when possible (grep several terms / read several files at once) to reduce round-trips.
+- ` + "`grep -rn \"<keyword>\" --include=\"*.py\" src/`" + ` to locate relevant code.
+- Read source with **read_file ` + "`start_line`" + `/` + "`end_line`" + `** (output is line-numbered for precise edits; do NOT include the line-number prefix in edit_file ` + "`source_text`" + `).
+- **Read — but never modify — the existing tests** near the buggy code (` + "`test_*.py`" + ` / ` + "`*_test.py`" + `). They reveal the maintainers' expected behavior, exact output strings, and edge cases, and are the strongest signal for matching the hidden grading test.
 
-### Step 2 — 探索仓库
-**尽量同时发起多个工具调用**（如同时 grep 多个关键词、同时读多个相关文件），减少往返次数：
-- ` + "`find . -type f -name \"*.py\" | grep -v __pycache__ | head -60`" + ` 了解项目结构
-- ` + "`grep -r \"<关键词>\" --include=\"*.py\" -l`" + ` 定位相关文件
-- 读取相关源文件时，使用 **` + "`read_file`" + ` 的 ` + "`start_line`" + `/` + "`end_line`" + ` 参数**按行号读取片段
-  - ✅ 正确：` + "`read_file(path=\"foo.py\", start_line=100, end_line=150)`" + `
-  - ❌ 禁止：` + "`bash: sed -n '100,150p' foo.py`" + `（绕过框架安全检查）
+### Step 3 — Reproduce (when feasible)
+If python is available and the package imports, write a **minimal reproduction** and confirm the bug exists.
+- ⚠️ Run reproductions via a bash heredoc: ` + "`python3 - <<'PY' ... PY`" + `. **NEVER use write_file to create scratch ` + "`.py`" + ` files in the repo** — they end up in ` + "`git diff`" + ` and corrupt the final patch.
+- If the package cannot be imported and no quick install works, skip to Step 4 and rely on static analysis.
 
-### Step 3 — 环境探测与复现（可选，两阶段）
+### Step 4 — Fix
+Before editing, pin down the exact location and surrounding code (` + "`grep -n \"target\" path`" + `, then read_file that region).
+- **Minimal change**: only touch the code causing the bug; no unrelated refactoring or style changes.
+- **Never modify test files** (` + "`test_*.py`" + ` / ` + "`*_test.py`" + `).
+- **No new dependencies** (don't edit requirements.txt / setup.py / pyproject.toml).
+- Provide enough surrounding context in edit_file ` + "`source_text`" + ` to match uniquely. If edit_file reports a fuzzy match, re-check the indentation it wrote (especially in Python).
 
-**阶段 A：单独执行解释器检测（不与任何其他命令并发）**
-` + "```" + `bash
-python3 -c "print('PYTHON_OK')" 2>/dev/null || echo "NO_PYTHON"
-` + "```" + `
-等待结果后再决定下一步：
-- 若输出 ` + "`NO_PYTHON`" + `：**立即跳过 Step 3 全部内容**，转静态分析，直接进入 Step 4
+### Step 5 — Verify (behavioral, not syntactic)
+edit_file's diff only confirms the **bytes were written** — it does NOT prove the behavior is correct. Whenever the environment allows, verify by exercising the **actual repository code**:
+- Run the relevant existing test: ` + "`python3 -m pytest path/to/test_x.py::TestClass -q`" + ` (use ` + "`timeout_secs`" + ` if slow), or re-run your reproduction against the real package and confirm the bug is gone.
+- ❌ NEVER "verify" by re-implementing the class/function inline in a script and testing the copy — that proves nothing about the real fix.
+- If the environment genuinely cannot run the code, say so explicitly and rely on a careful static review of the real code path you changed.
 
-**阶段 B：若 PYTHON_OK，追加仓库导入检测**
-包名通常与仓库目录同名（如 ` + "`django`" + `、` + "`flask`" + `、` + "`pytest`" + `、` + "`sympy`" + `）；scikit-learn 例外，包名为 ` + "`sklearn`" + `。
-` + "```" + `bash
-python3 -c "import <仓库主包名>" 2>&1 | head -3
-` + "```" + `
-- 若导入成功：写最简复现脚本验证 bug 存在，再进入 Step 4
-- 若导入失败（ModuleNotFoundError）：
-  - 可尝试 ` + "`pip install -e . -q`" + ` 一次（轻量包）
-  - 若安装超时或失败：**立即停止安装，不再重试**，转静态分析，直接进入 Step 4
-
-### Step 4 — 修复
-**在调用任何编辑工具之前**，先用 read_file 或 bash 明确以下信息：
-1. 精确的文件路径和行号：` + "`grep -n \"目标代码\" 文件路径`" + `
-2. 修复前后的完整代码片段（逐字确认）
-
-确认无误后，**一次完成修改**，不做试探性 edit。
-
-约束：
-- **最小化改动**：只修改导致 bug 的代码，不做无关重构或风格修改
-- **不修改测试文件**：绝不改动 test_*.py / *_test.py 文件
-- **不引入新依赖**：不修改 requirements.txt / setup.py / pyproject.toml
-
-### Step 5 — 验证
-edit_file 执行成功后会返回 ` + "`--- 改动上下文 ---`" + ` diff，**该 diff 即为权威确认，无需额外 grep/sed/read_file 重复验证**。
-
-如需额外确认，至多执行以下之一（选其一，不叠加）：
-- 若 Python 可用且仓库可 import：运行复现脚本确认 bug 已修复
-- 若 Python 不可用或 import 失败：` + "`grep -n`" + ` 确认改动存在（**一次即可**）
-
-## 完成条件
-改动已确认落地后**立即停止**。验证至多 1-2 步，不需要逐行重读已修改的代码。
-不要做额外的清理、注释或重构。
-
-**语言最终确认**：本回复及所有后续回复必须使用中文。
+## Done
+Stop once the fix is in place and you have verified the real behavior as far as the environment allows. Keep the change minimal — no extra cleanup, comments, or refactoring.
 
 ---
 

--- a/cmd/swebench/prompt_test.go
+++ b/cmd/swebench/prompt_test.go
@@ -13,59 +13,80 @@ func TestSwebenchPromptBuilder(t *testing.T) {
 	b := &swebenchPromptBuilder{instance: inst, workDir: "/tmp/swebench-test"}
 	prompt := b.Build()
 
+	// 占位符注入
 	if !strings.Contains(prompt, inst.ProblemStatement) {
 		t.Error("prompt should contain the problem statement")
 	}
 	if strings.Contains(prompt, "{{PROBLEM_STATEMENT}}") {
 		t.Error("prompt should not contain unreplaced placeholder")
 	}
-	if !strings.Contains(prompt, "Step 1") {
-		t.Error("prompt should contain structured workflow steps")
-	}
-	if !strings.Contains(prompt, "不修改测试文件") {
-		t.Error("prompt should contain constraint about not modifying test files")
-	}
-	// 语言锁定（P2：防止语言漂移）
-	if !strings.Contains(prompt, "语言要求") {
-		t.Error("prompt should contain language requirement")
-	}
-	// Python 快速放弃策略（P0：杜绝死循环搜索）
-	if !strings.Contains(prompt, "NO_PYTHON") {
-		t.Error("prompt should contain NO_PYTHON fast-detection pattern")
-	}
-	// 新版：立即跳过 Step 3 全部内容
-	if !strings.Contains(prompt, "立即跳过 Step 3 全部内容") {
-		t.Error("prompt should contain instruction to skip step 3 immediately")
-	}
-	// workDir 注入（P0：消除 /repo 路径假设）
 	if !strings.Contains(prompt, "/tmp/swebench-test") {
 		t.Error("prompt should contain the injected workDir")
 	}
 	if strings.Contains(prompt, "{{WORK_DIR}}") {
 		t.Error("prompt should not contain unreplaced WORK_DIR placeholder")
 	}
-	// bash 超时约束说明
-	if !strings.Contains(prompt, "30 秒") {
-		t.Error("prompt should mention 30s bash timeout")
+
+	// 结构化工作流
+	if !strings.Contains(prompt, "Step 1") || !strings.Contains(prompt, "Step 5") {
+		t.Error("prompt should contain structured workflow steps")
 	}
-	// 先规划后编辑（P1：减少 edit_file 反复撤回）
-	if !strings.Contains(prompt, "在调用任何编辑工具之前") {
-		t.Error("prompt should contain plan-before-edit instruction")
+
+	// 约束：不修改测试文件
+	if !strings.Contains(prompt, "Never modify test files") {
+		t.Error("prompt should contain constraint about not modifying test files")
 	}
-	// 验证上限（P2：杜绝过度验证）
-	if !strings.Contains(prompt, "验证至多 1-2 步") {
-		t.Error("prompt should contain max verification steps constraint")
+
+	// 英文推理 + 单行防漂移
+	if !strings.Contains(prompt, "Reason and respond in English") {
+		t.Error("prompt should mandate English reasoning with anti-drift line")
 	}
-	// edit_file diff 可信度声明
-	if !strings.Contains(prompt, "diff 即为权威确认") {
-		t.Error("prompt should declare diff as authoritative")
+
+	// 相对路径强约束（修复 safePath 路径翻倍的诱因）
+	if !strings.Contains(prompt, "relative to the working directory") {
+		t.Error("prompt should require relative paths for file tools")
 	}
-	// 禁止 sed 读文件，引导使用 read_file
+	if !strings.Contains(prompt, "NEVER pass an absolute path") {
+		t.Error("prompt should forbid absolute paths to file tools")
+	}
+
+	// 行为验证而非语法验证（核心修复：杜绝 plausible-but-wrong 过度修复）
+	if !strings.Contains(prompt, "does NOT prove the behavior is correct") {
+		t.Error("prompt should reframe verification as behavioral, not syntactic")
+	}
+	// 禁止内联重抄自测的假验证
+	if !strings.Contains(prompt, "re-implementing the class/function inline") {
+		t.Error("prompt should forbid fake verification via inline re-implementation")
+	}
+
+	// 阅读现有测试（最强行为信号）
+	if !strings.Contains(prompt, "never modify — the existing tests") {
+		t.Error("prompt should encourage reading existing tests")
+	}
+
+	// heredoc 跑复现，禁止在仓库内建临时文件污染 patch
+	if !strings.Contains(prompt, "heredoc") {
+		t.Error("prompt should instruct running repros via heredoc")
+	}
+	if !strings.Contains(prompt, "corrupt the final patch") {
+		t.Error("prompt should warn that scratch files corrupt the patch")
+	}
+
+	// read_file 行号模式 + 并发探索
 	if !strings.Contains(prompt, "start_line") {
 		t.Error("prompt should mention read_file start_line parameter")
 	}
-	// 并发工具调用引导（P3）
-	if !strings.Contains(prompt, "尽量同时发起多个工具调用") {
+	if !strings.Contains(prompt, "multiple tool calls in parallel") {
 		t.Error("prompt should encourage concurrent tool calls")
+	}
+
+	// timeout_secs 放宽慢命令
+	if !strings.Contains(prompt, "timeout_secs") {
+		t.Error("prompt should mention per-call timeout_secs for slow commands")
+	}
+
+	// 不应再保留旧的"放弃验证"反模式
+	if strings.Contains(prompt, "diff 即为权威确认") || strings.Contains(prompt, "验证至多 1-2 步") {
+		t.Error("prompt should no longer contain the discourage-verification anti-pattern")
 	}
 }

--- a/cmd/swebench/report.go
+++ b/cmd/swebench/report.go
@@ -12,8 +12,12 @@ import (
 	"time"
 )
 
-// loadExistingIDs 读取已有的 predictions.jsonl，返回已处理的 instance_id 集合。
+// loadExistingIDs 读取已有的 predictions.jsonl，返回"已成功产出非空 patch"的 instance_id 集合。
 // 文件不存在时返回空 map（不报错），支持首次运行。
+//
+// 仅当 model_patch 非空时才视为"已完成"并在 --resume 时跳过；空 patch（Agent 无改动、
+// 或瞬时错误/环境失败被记为空）不计入，从而在续跑时获得重试机会——修复了此前
+// "最该重跑的失败实例反被永久跳过"的问题。
 func loadExistingIDs(path string) (map[string]bool, error) {
 	ids := make(map[string]bool)
 	f, err := os.Open(path)
@@ -25,9 +29,11 @@ func loadExistingIDs(path string) (map[string]bool, error) {
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024) // patch 可能较大，扩大缓冲避免长行截断
 	for scanner.Scan() {
 		var p Prediction
-		if err := json.Unmarshal([]byte(scanner.Text()), &p); err == nil && p.InstanceID != "" {
+		if err := json.Unmarshal([]byte(scanner.Text()), &p); err == nil &&
+			p.InstanceID != "" && strings.TrimSpace(p.ModelPatch) != "" {
 			ids[p.InstanceID] = true
 		}
 	}
@@ -51,6 +57,8 @@ func appendPrediction(path string, p Prediction) error {
 
 const summaryTmpl = `# SWE-bench Lite Run Summary
 
+- RunID: {{.RunID}}
+- 采样 seed: {{.Seed}}（同 seed 可复现同一实例集）
 - 开始时间: {{.StartTime}}
 - 结束时间: {{.EndTime}}
 - 总实例数: {{.Total}}
@@ -87,6 +95,8 @@ type repoStats struct {
 }
 
 type summaryData struct {
+	RunID      string
+	Seed       int64
 	StartTime  string
 	EndTime    string
 	Total      int
@@ -96,10 +106,12 @@ type summaryData struct {
 	Repos      []repoStats
 }
 
-// writeSummary 将运行摘要写入 outputDir/run_summary.md。
-func writeSummary(outputDir string, results []RunResult, start, end time.Time) error {
+// writeSummary 将运行摘要写入 cfg.OutputDir/run_summary.md，记录 RunID 与 seed 以支持复现。
+func writeSummary(cfg Config, results []RunResult, start, end time.Time) error {
 	byRepo := make(map[string]*repoStats)
 	sd := summaryData{
+		RunID:     cfg.RunID,
+		Seed:      cfg.Seed,
 		StartTime: start.Format("2006-01-02 15:04:05"),
 		EndTime:   end.Format("2006-01-02 15:04:05"),
 		Total:     len(results),
@@ -135,5 +147,5 @@ func writeSummary(outputDir string, results []RunResult, start, end time.Time) e
 	if err := tmpl.Execute(&sb, sd); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(outputDir, "run_summary.md"), []byte(sb.String()), 0644)
+	return os.WriteFile(filepath.Join(cfg.OutputDir, "run_summary.md"), []byte(sb.String()), 0644)
 }

--- a/cmd/swebench/report_test.go
+++ b/cmd/swebench/report_test.go
@@ -20,9 +20,12 @@ func TestLoadExistingIDsEmpty(t *testing.T) {
 	}
 }
 
+// TestLoadExistingIDs 验证 --resume 跳过逻辑：仅"已产出非空 patch"的实例算完成并被跳过；
+// 空 patch（无改动 / 瞬时失败被记空）不计入，从而在续跑时获得重试机会。
 func TestLoadExistingIDs(t *testing.T) {
 	content := `{"instance_id":"django__django-1","model_patch":"diff ..."}
 {"instance_id":"astropy__astropy-2","model_patch":""}
+{"instance_id":"flask__flask-3","model_patch":"   "}
 `
 	tmp := filepath.Join(t.TempDir(), "predictions.jsonl")
 	if err := os.WriteFile(tmp, []byte(content), 0644); err != nil {
@@ -33,10 +36,14 @@ func TestLoadExistingIDs(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !ids["django__django-1"] {
-		t.Error("want django__django-1 in existing IDs")
+		t.Error("非空 patch 的实例应被视为已完成（跳过）")
 	}
-	if !ids["astropy__astropy-2"] {
-		t.Error("want astropy__astropy-2 in existing IDs")
+	// 空 / 纯空白 patch 不应被跳过——这些正是最该重跑的实例。
+	if ids["astropy__astropy-2"] {
+		t.Error("空 patch 实例不应被跳过，应在 --resume 时重试")
+	}
+	if ids["flask__flask-3"] {
+		t.Error("纯空白 patch 实例不应被跳过，应在 --resume 时重试")
 	}
 	if ids["unknown"] {
 		t.Error("want unknown NOT in existing IDs")
@@ -83,7 +90,8 @@ func TestWriteSummary(t *testing.T) {
 	}
 	start := time.Now().Add(-5 * time.Minute)
 	end := time.Now()
-	if err := writeSummary(outDir, results, start, end); err != nil {
+	cfg := Config{OutputDir: outDir, Seed: 7, RunID: "20260619-000000"}
+	if err := writeSummary(cfg, results, start, end); err != nil {
 		t.Fatalf("writeSummary error: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(outDir, "run_summary.md"))
@@ -96,5 +104,12 @@ func TestWriteSummary(t *testing.T) {
 	}
 	if !strings.Contains(content, "django/django") {
 		t.Error("summary should contain django/django repo")
+	}
+	// 记录 RunID 与 seed 以支持复现
+	if !strings.Contains(content, "20260619-000000") {
+		t.Error("summary should record RunID")
+	}
+	if !strings.Contains(content, "seed: 7") {
+		t.Error("summary should record sampling seed")
 	}
 }

--- a/cmd/swebench/runner.go
+++ b/cmd/swebench/runner.go
@@ -14,11 +14,16 @@ import (
 
 	"github.com/harness9/internal/engine"
 	"github.com/harness9/internal/hooks"
+	"github.com/harness9/internal/memory"
 	"github.com/harness9/internal/provider"
 	"github.com/harness9/internal/sandbox"
 	"github.com/harness9/internal/schema"
 	"github.com/harness9/internal/tools"
 )
+
+// benchmarkBashTimeout 是 SWE-bench 场景下单条 bash 命令的超时。
+// 远大于默认 120s，使 Agent 能运行较慢的测试套件 / 依赖安装（验证修复的关键路径）。
+const benchmarkBashTimeout = 300 * time.Second
 
 // Config 存储从 CLI flags 解析的运行配置。
 type Config struct {
@@ -31,6 +36,11 @@ type Config struct {
 	Resume      bool
 	TimeoutMins int
 	Model       string
+	// Seed 是按 repo 采样的随机种子。固定默认值保证基准可复现（同 seed → 同实例集），
+	// 修复了此前用 time.Now().UnixNano() 导致每次运行抽样不同、无法对比迭代效果的问题。
+	Seed int64
+	// RunID 标识本次运行，用于将 trajectory 日志写入 logs/<RunID>/，避免多次运行互相覆盖/污染。
+	RunID string
 }
 
 // resolveModelName 解析最终使用的模型名：cfg.Model > LLM_MODEL 环境变量 > 默认值。
@@ -110,7 +120,8 @@ func runInstance(ctx context.Context, inst Instance, cfg Config) RunResult {
 	// 4. 注册工具
 	registry := tools.NewRegistry()
 	toolList := []tools.BaseTool{
-		tools.NewBashTool(tmpDir, tools.WithEnvironment(env)),
+		// 放宽 bash 超时（默认 120s → 300s），让真实测试套件 / 依赖安装得以完成。
+		tools.NewBashTool(tmpDir, tools.WithEnvironment(env), tools.WithBashTimeout(benchmarkBashTimeout)),
 		tools.NewReadFileTool(tmpDir, tools.ReadFileWithEnvironment(env)),
 		tools.NewWriteFileTool(tmpDir, tools.WriteFileWithEnvironment(env)),
 		tools.NewEditFileTool(tmpDir, tools.EditFileWithEnvironment(env)),
@@ -128,11 +139,30 @@ func runInstance(ctx context.Context, inst Instance, cfg Config) RunResult {
 	if err != nil {
 		return RunResult{Instance: inst, Error: fmt.Errorf("创建 LLM provider 失败: %w", err), Duration: time.Since(start)}
 	}
+	// 上下文窗口与压缩器：此前 benchmark 未配置 compactor，长轨迹上下文无界增长，
+	// 触及模型窗口后 API 返回 400（prompt too long），在无重试时直接杀实例。
+	// 这里用无需 LLM、无需 session 的 TokenBudgetCompactor 做字符级裁剪；
+	// 预算取上下文窗口的 55%，为工具定义(~25K) + 输出预留 + chars/4 估算误差留足余量。
+	lim := provider.GetModelLimits(resolveModelName(cfg.Model))
+	compactor := &memory.TokenBudgetCompactor{
+		MaxTokens:       lim.ContextTokens * 55 / 100,
+		MinTailMessages: 8,
+	}
 	engOpts := []engine.Option{
 		engine.WithPromptBuilder(&swebenchPromptBuilder{instance: inst, workDir: tmpDir}),
+		engine.WithContextWindow(lim.ContextTokens),
+		engine.WithCompactor(compactor),
+		// 无人值守：显式短路审批，零延迟（不依赖是否注册了 hook）。
+		engine.WithPermissionMode(engine.PermissionModeBypassAll),
+		// 瞬时 LLM/流式错误的应用层重试：把"一次抖动杀实例"变为可恢复事件。
+		engine.WithGenerateRetry(4, 2*time.Second),
 	}
 	if cfg.MaxTurns > 0 {
 		engOpts = append(engOpts, engine.WithMaxTurns(cfg.MaxTurns))
+	} else {
+		// benchmark 默认上限 80 轮：足够 explore+fix+verify，又能截断失控循环
+		// （此前沿用引擎默认 500，配合每实例超时会在卡死实例上烧掉大量 token）。
+		engOpts = append(engOpts, engine.WithMaxTurns(80))
 	}
 	eng := engine.NewAgentEngine(llm, hookReg, tmpDir, engOpts...)
 
@@ -140,13 +170,18 @@ func runInstance(ctx context.Context, inst Instance, cfg Config) RunResult {
 	instanceCtx, instanceCancel := context.WithTimeout(ctx, time.Duration(cfg.TimeoutMins)*time.Minute)
 	defer instanceCancel()
 
-	// logs/ 目录由 main.go 在进入并发循环前统一创建（os.MkdirAll），此处无需再建。
-	logPath := filepath.Join(cfg.OutputDir, "logs", inst.InstanceID+".log")
+	// logs/<RunID>/ 目录由 main.go 在进入并发循环前统一创建（os.MkdirAll），此处无需再建。
+	// 按 RunID 命名空间隔离，避免不同运行的同名日志互相覆盖、污染分析。
+	logPath := filepath.Join(cfg.OutputDir, "logs", cfg.RunID, inst.InstanceID+".log")
 	runErr := runWithTrajectory(instanceCtx, eng, "请修复上述 Issue。", logPath, inst)
 
 	// 7. 收集 patch（无论 runErr 如何，MaxTurns 触发时也可能有部分 patch）
-	diffCtx, diffCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// 先 `git add -A -N`（intent-to-add）登记新建文件：纯 `git diff` 只输出已跟踪文件的改动，
+	// Agent 用 write_file 新建的修复文件不会出现在 diff 中而被静默丢弃。-N 使新文件以
+	// 新增 hunk 形式进入 `git diff`，从而被完整捕获进 model_patch。
+	diffCtx, diffCancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer diffCancel()
+	_ = exec.CommandContext(diffCtx, "git", "-C", tmpDir, "add", "-A", "-N").Run()
 	patchOut, _ := exec.CommandContext(diffCtx, "git", "-C", tmpDir, "diff").CombinedOutput()
 	patch := strings.TrimSpace(string(patchOut))
 

--- a/docs/核心功能/benchmark.md
+++ b/docs/核心功能/benchmark.md
@@ -170,10 +170,20 @@ runInstance(ctx, inst, cfg)
 |------|------|
 | git clone 在宿主机执行 | 容器内无 git credential，bind mount 后容器可见相同文件 |
 | bash 工具路由进容器 | Agent 执行的 Python 代码在隔离环境中运行，不污染宿主机 |
+| bash 超时放宽至 300s | 默认 120s 仍不足以跑完测试套件/装依赖；runner 通过 `WithBashTimeout` 提到 300s，模型亦可用 `timeout_secs` 临时放宽（验证修复的关键路径）|
+| 收集 patch 前先 `git add -A -N` | 纯 `git diff` 只输出已跟踪文件，Agent 用 write_file 新建的修复文件会被静默丢弃；intent-to-add 使新文件进入 diff |
 | git diff 用独立 context | Ctrl+C 取消主 context 后，仍能收集已修改的 patch，避免丢弃有效结果 |
-| MaxTurns 默认沿用引擎值（500） | SWE-bench 复杂任务不应被过早截断，使用 `--max-turns N` 显式限制 |
-| RunStream 替代 Run | 以事件流方式捕获完整 trajectory，写入 `logs/` 目录供后续分析 |
+| 显式接入 Compactor + ContextWindow | 此前未配置压缩器，长轨迹上下文无界增长触及窗口 → API 400 杀实例；runner 用无需 LLM/Session 的 `TokenBudgetCompactor`（预算取窗口 55%，为工具定义+输出+估算误差留余量）|
+| 引擎级生成重试 `WithGenerateRetry(4, 2s)` | SDK 重试只覆盖首字节前；流式中途断连/瞬时 429 会逃逸到引擎层杀实例。应用层有界退避重试把"一次抖动杀实例"变为可恢复事件 |
+| `WithPermissionMode(BypassAll)` | 无人值守显式短路审批，零延迟，不依赖是否注册 hook |
+| MaxTurns benchmark 默认 80 | 此前沿用引擎 500，卡死实例会在每实例超时内烧掉大量 token；80 足够 explore+fix+verify 又能截断失控循环（如观测到的 69 轮 runaway）。仍可用 `--max-turns N` 覆盖 |
+| 单实例超时默认 30 分钟 | 原 10 分钟需覆盖 clone+sandbox 启动+整段 agent loop，对大仓库偏紧 |
+| 采样种子固定（`--seed`，默认 1）| 原用 `time.Now().UnixNano()` 导致每次运行抽样不同、无法复现/对比；固定 seed → 同实例集，`--resume` 自然一致 |
+| 日志按 RunID 命名空间隔离 | `logs/<RunID>/<instance>.log`，避免多次运行同名日志互相覆盖、污染分析 |
+| `--resume` 仅跳过非空 patch | 原按 instance_id 跳过且接受空 patch，导致最该重跑的失败实例被永久跳过；改为仅跳过已产出非空 patch 的实例 |
+| RunStream 替代 Run | 以事件流方式捕获完整 trajectory，写入 `logs/<RunID>/` 目录供后续分析 |
 | predictions.jsonl 追加写 | 每条完成后立即 flush，配合 `--resume` 支持断点续跑 |
+| Sandbox 依赖 bootstrap 钩子（接缝）| `SANDBOX_BOOTSTRAP_CMD` 在容器就绪后、Agent 开始前执行一次（独立超时预算）；为接入官方 SWE-bench 每实例预装镜像（彻底打开"跑真实测试"验证能力）只差配置 |
 
 ### 3.3 采样策略
 
@@ -195,7 +205,7 @@ allInstances (300条)
 
 ### 3.4 专用 System Prompt 设计
 
-harness9 为 SWE-bench 设计了专用的 system prompt，策略为：
+harness9 为 SWE-bench 设计了专用的 system prompt（英文，提升英文代码任务质量），策略为：
 
 **结构化流程约束（5 步顺序）+ 每步内自由探索（不限制工具调用方式）**
 
@@ -204,22 +214,26 @@ Step 1 — 理解问题
   ↓ 识别 bug 核心、复现步骤、预期行为
 
 Step 2 — 探索仓库
-  ↓ find/grep 定位相关文件，阅读源码（不读测试文件）
+  ↓ grep 定位相关文件，read_file 行号读取；并行多工具调用
+  ↓ 阅读（绝不修改）相关现有测试——它们编码了维护者期望的行为/输出/边界
 
-Step 3 — 复现
-  ↓ 写最简复现脚本，用 bash 验证 bug 存在
+Step 3 — 复现（可行时）
+  ↓ python 可用且包可 import 时写最简复现；用 heredoc 执行，绝不在仓库内建临时 .py（污染 patch）
 
 Step 4 — 修复
-  ↓ 最小化改动，绝不修改测试文件，不引入新依赖
+  ↓ 最小化改动，绝不修改测试文件，不引入新依赖；编辑前 grep -n 定位精确行号
 
-Step 5 — 验证
-  ↓ 重跑复现脚本，确认 bug 消失
+Step 5 — 验证（行为而非语法）
+  ↓ edit_file 的 diff 只确认"字节已写入"，不代表行为正确
+  ↓ 尽量运行真实测试 / 复现脚本验证行为；绝不"把类/函数原样重抄到内联脚本里自测"
 ```
 
 **约束的设计原则**：
-- "不修改测试文件"是 SWE-bench 的硬约束，违反会导致评估结果无效
+- "不修改测试文件"是 SWE-bench 的硬约束，违反会导致评估结果无效；但**鼓励阅读**现有测试（最强行为信号）
 - "最小化改动"减少误改不相关代码引入回归的风险
-- 结构化步骤确保 Agent 不跳过复现步骤直接猜测修复，提升修复质量
+- **行为验证优先于语法验证**：早期 prompt 的"验证至多 1-2 步 / diff 即权威无需复验"会诱发 plausible-but-wrong 的过度修复（轨迹分析中多个失败由此而来），已改为鼓励运行真实测试、禁止内联重抄自测的假验证
+- **文件工具一律用相对路径**：注入的绝对工作目录曾诱使模型给 read_file/edit_file 传绝对路径，触发路径拼接错误（已在 `safePath` 修复，并以 prompt 双重保险）
+- 推理语言改为英文 + 单行防漂移约束（评测只看 patch，英文更贴合英文代码/Issue/堆栈）
 
 ### 3.5 并发控制与韧性
 
@@ -248,10 +262,11 @@ writeSummary(...)
 |------|---------|
 | git clone 失败 | 记录 Error，写空 patch，继续下一条 |
 | Docker 启动失败 | 同上 |
-| LLM API 超时/限流 | 同上；若有部分 patch 则保留 |
-| MaxTurns 触发 | 收集当前 git diff，不标记为错误 |
+| LLM API 瞬时错误/限流/流式断连 | 引擎级有界退避重试（`WithGenerateRetry`）+ SDK 内置重试；多数瞬时抖动可恢复，不再杀实例 |
+| 上下文逼近窗口 | `TokenBudgetCompactor` 在窗口 55% 处裁剪旧 Observation，规避 400 溢出 |
+| MaxTurns 触发（默认 80）| 收集当前 git diff（含 `git add -N` 的新文件），不标记为错误 |
 | 整体 Ctrl+C | 等待当前 instance 完成，收集 patch 后退出 |
-| `--resume` 重启 | 读取已有 predictions.jsonl，跳过已处理 instance_id |
+| `--resume` 重启 | 仅跳过**已产出非空 patch** 的 instance；空/出错实例会被重试 |
 
 ---
 
@@ -462,10 +477,11 @@ go run ./cmd/swebench --help
 | `--dataset` | string | **必填** | SWE-bench Lite JSONL 文件路径 |
 | `--sample` | int | 10 | 每个 repo 抽取的 instance 数量（≥1）|
 | `--output` | string | `./swebench-results` | 输出目录 |
-| `--max-turns` | int | 0 | 每个 instance 最大 Turn 数（0 = 引擎默认 500）|
+| `--max-turns` | int | 0 | 每个 instance 最大 Turn 数（0 = benchmark 默认 80；显式 N 覆盖）|
 | `--parallel` | int | 1 | 并发 instance 数（≥1）|
-| `--resume` | bool | false | 跳过已有结果（断点续跑）|
-| `--timeout` | int | 10 | 单个 instance 超时（分钟）|
+| `--resume` | bool | false | 跳过已产出非空 patch 的 instance（断点续跑）|
+| `--timeout` | int | 30 | 单个 instance 超时（分钟）|
+| `--seed` | int64 | 1 | 按 repo 采样的随机种子（固定默认值保证可复现；同 seed → 同实例集）|
 | `--model` | string | `""` | LLM 模型（空则读 `LLM_MODEL` 环境变量）|
 
 **环境变量**（可通过 `.env` 文件或系统环境变量提供，系统变量优先）：
@@ -475,8 +491,12 @@ go run ./cmd/swebench --help
 | `OPENAI_API_KEY` | LLM API Key（必填）| — |
 | `OPENAI_BASE_URL` | 自定义 API 地址（可选）| `https://openrouter.ai/api/v1` |
 | `LLM_MODEL` | 模型名称 | `openai/gpt-4o` |
+| `LLM_REQUEST_TIMEOUT_SECS` | 单次 LLM 请求超时（秒）| `600`（默认）|
+| `LLM_MAX_RETRIES` | SDK 内置重试次数（429/5xx）| `5`（默认）|
 | `SANDBOX_IMAGE` | Docker 镜像 | `python:3.11-slim` |
 | `SANDBOX_ENABLED` | 启用 Docker 隔离 | `true`（默认）|
+| `SANDBOX_BOOTSTRAP_CMD` | 容器就绪后执行一次的初始化命令（装依赖/激活环境）| 如 `pip install -e . -q` |
+| `SANDBOX_BOOTSTRAP_TIMEOUT_SECS` | bootstrap 命令超时（秒）| `600`（默认）|
 
 ---
 

--- a/internal/engine/agent_loop.go
+++ b/internal/engine/agent_loop.go
@@ -44,6 +44,21 @@ func WithContextWindow(tokens int) Option {
 	return func(e *AgentEngine) { e.contextWindow = tokens }
 }
 
+// WithGenerateRetry 配置 LLM 生成调用的应用层重试：最多尝试 attempts 次，
+// 首次重试退避 baseDelay，其后指数增长（上限 maxGenerateRetryDelay）。
+//
+// 这是对 SDK 内置重试的补充：SDK 的重试只覆盖"首字节到达前"的连接错误，
+// 而流式响应中途断连（mid-stream EOF / 代理超时 / 5xx after headers）会以
+// StreamChunkError 形式逃逸到引擎层，旧实现直接终止整个 agent loop（丢掉整条轨迹）。
+// 此重试在保持 context 取消语义的前提下，把"一次瞬时抖动杀实例"变为可恢复事件。
+// attempts<=1 时关闭重试（仅尝试一次）。
+func WithGenerateRetry(attempts int, baseDelay time.Duration) Option {
+	return func(e *AgentEngine) {
+		e.generateRetries = attempts
+		e.generateRetryBase = baseDelay
+	}
+}
+
 // WithMemoryNudge 配置长期记忆 nudge：每隔 interval 个 turn 在发送给 LLM 的历史中
 // 注入一行 text 提示（仅注入到临时副本，不持久化）。interval<=0 时关闭。
 func WithMemoryNudge(interval int, text string) Option {
@@ -131,21 +146,77 @@ type AgentEngine struct {
 	nudgeInterval      int                 // >0 时每隔该轮数注入一次记忆 nudge
 	nudgeText          string              // nudge 提示文本
 	observer           EngineObserver      // 可选，nil 时自动退化为 noopObserver
+	generateRetries    int                 // LLM 生成调用最大尝试次数（默认 3）
+	generateRetryBase  time.Duration       // 重试退避基准（默认 1s）
 }
 
-// NewAgentEngine 创建新的 AgentEngine。默认值：maxTurns=500, toolTimeout=60s。
+// maxGenerateRetryDelay 是生成重试指数退避的上限，避免退避时间吞掉整体预算。
+const maxGenerateRetryDelay = 30 * time.Second
+
+// NewAgentEngine 创建新的 AgentEngine。默认值：maxTurns=500, toolTimeout=60s,
+// generateRetries=3（base 1s）—— 对瞬时 LLM/流式错误具备基础韧性。
 func NewAgentEngine(p provider.LLMProvider, r tools.Registry, workDir string, opts ...Option) *AgentEngine {
 	e := &AgentEngine{
-		provider:    p,
-		registry:    r,
-		workDir:     workDir,
-		maxTurns:    500,
-		toolTimeout: 60 * time.Second,
+		provider:          p,
+		registry:          r,
+		workDir:           workDir,
+		maxTurns:          500,
+		toolTimeout:       60 * time.Second,
+		generateRetries:   3,
+		generateRetryBase: 1 * time.Second,
 	}
 	for _, opt := range opts {
 		opt(e)
 	}
 	return e
+}
+
+// generateWithRetry 在 em.generate 之上叠加有界指数退避重试。
+//
+// 重试策略：
+//   - 成功立即返回；
+//   - context 已取消/超时（ctx.Err()!=nil）不重试，原样返回（会话级终止信号）；
+//   - 其余错误视为可能瞬时，退避后重试，直到耗尽 attempts；
+//   - 退避期间感知 ctx 取消，避免无谓等待。
+func (e *AgentEngine) generateWithRetry(ctx context.Context, em emitter, turn int, history []schema.Message, toolDefs []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+	attempts := e.generateRetries
+	if attempts < 1 {
+		attempts = 1
+	}
+	base := e.generateRetryBase
+	if base <= 0 {
+		base = 1 * time.Second
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		msg, usage, err := em.generate(ctx, turn, history, toolDefs)
+		if err == nil {
+			return msg, usage, nil
+		}
+		lastErr = err
+		// context 取消/超时不重试。
+		if ctx.Err() != nil {
+			return nil, nil, err
+		}
+		if attempt < attempts {
+			delay := base << (attempt - 1)
+			if delay > maxGenerateRetryDelay {
+				delay = maxGenerateRetryDelay
+			}
+			log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
+				"LLM 生成失败 (turn %d, 尝试 %d/%d)，%s 后重试: %v", turn, attempt, attempts, delay, err)))
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+	return nil, nil, lastErr
 }
 
 // emitter 封装 Run 与 RunStream 在"输出侧"的差异：
@@ -324,7 +395,7 @@ func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix 
 		log.Print(logfmt.FormatTurnStart(logPrefix, turnCount, len(compactedHistory), len(availableTools)))
 
 		llmStart := time.Now()
-		responseMsg, usage, err := em.generate(turnCtx, turnCount, compactedHistory, availableTools)
+		responseMsg, usage, err := e.generateWithRetry(turnCtx, em, turnCount, compactedHistory, availableTools)
 		if err != nil {
 			interactionErr = err
 			return fmt.Errorf("模型生成失败 (turn %d): %w", turnCount, err)
@@ -349,10 +420,18 @@ func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix 
 		toolDuration := time.Since(toolStart)
 
 		for i, toolCall := range responseMsg.ToolCalls {
+			// 空输出兜底：部分 backend 拒绝空 content 的 tool_result（返回 400，
+			// 在无重试时直接杀实例），且空 Observation 无信息可供模型推理、浪费一轮。
+			content := results[i].Output
+			if content == "" {
+				content = "[工具执行完成，无输出]"
+			}
 			contextHistory = append(contextHistory, schema.Message{
 				Role:       schema.RoleUser,
-				Content:    results[i].Output,
+				Content:    content,
 				ToolCallID: toolCall.ID,
+				// 透传结构化错误信号，供 Provider 设置 tool_result.is_error，强化自愈。
+				IsError: results[i].IsError,
 			})
 		}
 

--- a/internal/engine/agent_loop_test.go
+++ b/internal/engine/agent_loop_test.go
@@ -13,6 +13,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -90,6 +91,84 @@ func (r *errorRegistry) Register(_ tools.BaseTool) error            { return nil
 func (r *errorRegistry) GetAvailableTools() []schema.ToolDefinition { return r.tools }
 func (r *errorRegistry) Execute(_ context.Context, call schema.ToolCall) schema.ToolResult {
 	return schema.ToolResult{ToolCallID: call.ID, Output: "command not found", IsError: true}
+}
+
+// flakyProvider 在前 failFirst 次调用返回错误，其后正常返回 done，用于验证引擎重试。
+type flakyProvider struct {
+	mu        sync.Mutex
+	calls     int
+	failFirst int
+	err       error
+}
+
+func (p *flakyProvider) Generate(_ context.Context, _ []schema.Message, _ []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.calls <= p.failFirst {
+		return nil, nil, p.err
+	}
+	return &schema.Message{Role: schema.RoleAssistant, Content: "done!"}, nil, nil
+}
+
+func (p *flakyProvider) GenerateStream(ctx context.Context, msgs []schema.Message, td []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	msg, _, err := p.Generate(ctx, msgs, td)
+	if err != nil {
+		return nil, err
+	}
+	ch := make(chan schema.StreamChunk, 2)
+	go func() {
+		defer close(ch)
+		ch <- schema.StreamChunk{Type: schema.StreamChunkDone, Message: msg}
+	}()
+	return ch, nil
+}
+
+// TestGenerateRetry_RecoversFromTransientError 验证：瞬时 LLM 错误经有界重试后恢复，
+// 整条轨迹不被一次抖动杀死。
+func TestGenerateRetry_RecoversFromTransientError(t *testing.T) {
+	p := &flakyProvider{failFirst: 2, err: fmt.Errorf("temporary stream reset")}
+	r := &staticRegistry{output: "ok"}
+	// 3 次尝试、极小退避（避免拖慢测试）。
+	eng := NewAgentEngine(p, r, "/test", WithGenerateRetry(3, time.Millisecond))
+
+	if err := eng.Run(context.Background(), "task"); err != nil {
+		t.Fatalf("应在重试后成功，got: %v", err)
+	}
+	if p.calls != 3 {
+		t.Errorf("应尝试 3 次（前 2 次失败 + 第 3 次成功），实际 %d", p.calls)
+	}
+}
+
+// TestGenerateRetry_ExhaustsThenFails 验证：持续失败时耗尽重试后返回错误（有界）。
+func TestGenerateRetry_ExhaustsThenFails(t *testing.T) {
+	p := &flakyProvider{failFirst: 100, err: fmt.Errorf("persistent failure")}
+	r := &staticRegistry{output: "ok"}
+	eng := NewAgentEngine(p, r, "/test", WithGenerateRetry(3, time.Millisecond))
+
+	err := eng.Run(context.Background(), "task")
+	if err == nil {
+		t.Fatal("持续失败应最终返回错误")
+	}
+	if p.calls != 3 {
+		t.Errorf("应恰好尝试 3 次后放弃，实际 %d", p.calls)
+	}
+}
+
+// TestGenerateRetry_DoesNotRetryOnContextCancel 验证：context 取消不触发重试。
+func TestGenerateRetry_DoesNotRetryOnContextCancel(t *testing.T) {
+	p := &flakyProvider{failFirst: 100, err: fmt.Errorf("should not be seen")}
+	r := &staticRegistry{output: "ok"}
+	eng := NewAgentEngine(p, r, "/test", WithGenerateRetry(5, time.Second))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = eng.Run(ctx, "task")
+	// ctx 已取消：要么在 turn 入口的 ctx.Done 检查就退出（calls==0），
+	// 要么首次 generate 后因 ctx.Err()!=nil 立即返回（calls<=1）。绝不应多次重试。
+	if p.calls > 1 {
+		t.Errorf("context 取消不应重试，calls=%d", p.calls)
+	}
 }
 
 // TestReact_BasicFlow 验证单阶段 ReAct 的完整流程：

--- a/internal/evals/dataset/tool_calling_test.go
+++ b/internal/evals/dataset/tool_calling_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/harness9/internal/schema"
 )
 
-// TestToolCalling 运行工具调用准确性评估（4 个黄金用例）。
+// TestToolCalling 运行工具调用准确性评估（5 个黄金用例）。
 func TestToolCalling(t *testing.T) {
 	evals.SetupHermeticEnv(t)
 
@@ -74,6 +74,38 @@ func TestToolCalling(t *testing.T) {
 			Assertions: []evals.Assertion{
 				&evals.ToolCalledAssertion{ToolName: "write_file"},
 				&evals.ToolCalledAssertion{ToolName: "read_file"},
+				&evals.NoErrorAssertion{},
+				&evals.MaxTurnsAssertion{Max: 4},
+			},
+		},
+		// 用例5：edit_file 模糊匹配（缩进不一致触发 L4）端到端不破坏循环。
+		// 先 write_file 写入带 4/8 空格缩进的 Python 方法；随后 edit_file 用 0/4 缩进的
+		// source_text（与文件缩进不一致 → 走 L4 逐行去缩进匹配 + 重缩进），验证编辑成功、
+		// 引擎不因模糊匹配/缩进重排而报错（覆盖 fuzzyReplaceWithLevel + reindentBlock 路径）。
+		{
+			ID:       "tool_calling/edit_file_fuzzy_indent",
+			Category: "tool_calling",
+			Prompt:   "把 mod.py 中 compute 方法的返回值从 1 改成 2。",
+			Provider: evals.NewScriptedProvider(
+				evals.ScriptedTurn{
+					ToolCalls: []schema.ToolCall{
+						evals.MakeToolCall("tc1", "write_file",
+							`{"path":"mod.py","content":"class A:\n    def compute(self):\n        return 1\n"}`),
+					},
+				},
+				evals.ScriptedTurn{
+					ToolCalls: []schema.ToolCall{
+						// source_text 缩进（0/4）与文件（4/8）不一致 → 强制 L4 模糊匹配
+						evals.MakeToolCall("tc2", "edit_file",
+							`{"path":"mod.py","source_text":"def compute(self):\n    return 1","target_text":"def compute(self):\n    return 2"}`),
+					},
+				},
+				evals.ScriptedTurn{Text: "已将 compute 的返回值改为 2。"},
+			),
+			Assertions: []evals.Assertion{
+				&evals.ToolCalledAssertion{ToolName: "write_file"},
+				&evals.ToolCalledAssertion{ToolName: "edit_file"},
+				// 模糊匹配编辑成功不应让引擎报错（self-healing/正确性）
 				&evals.NoErrorAssertion{},
 				&evals.MaxTurnsAssertion{Max: 4},
 			},

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -71,7 +71,12 @@ func NewAnthropicProvider(model string, maxTokens int64, opts ...AnthropicOption
 		maxTokens = 4096
 	}
 	p := &AnthropicProvider{
-		client:    anthropic.NewClient(option.WithAPIKey(apiKey), option.WithBaseURL(baseURL)),
+		client: anthropic.NewClient(
+			option.WithAPIKey(apiKey),
+			option.WithBaseURL(baseURL),
+			option.WithMaxRetries(providerMaxRetries()),
+			option.WithRequestTimeout(providerRequestTimeout()),
+		),
 		model:     model,
 		maxTokens: maxTokens,
 	}
@@ -271,8 +276,10 @@ func (p *AnthropicProvider) convertMessages(msgs []schema.Message) ([]anthropic.
 			systemPrompt = msg.Content
 		case schema.RoleUser:
 			if msg.ToolCallID != "" {
+				// 透传结构化错误标记：工具失败时 is_error=true，强化模型自愈，
+				// 而非硬编码 false 仅靠文本前缀让模型猜测。
 				anthropicMsgs = append(anthropicMsgs, anthropic.NewUserMessage(
-					anthropic.NewToolResultBlock(msg.ToolCallID, msg.Content, false),
+					anthropic.NewToolResultBlock(msg.ToolCallID, msg.Content, msg.IsError),
 				))
 			} else {
 				anthropicMsgs = append(anthropicMsgs, anthropic.NewUserMessage(

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/tidwall/gjson"
 
@@ -16,6 +18,30 @@ import (
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/shared"
 )
+
+// providerEnvInt 读取整型环境变量，缺省/非法时返回 def。
+func providerEnvInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return def
+}
+
+// providerRequestTimeout 返回单次 LLM 请求的超时（默认 600s）。
+// 用于防止"连接已建立但服务端中途挂起、字节不再流动"的请求吞掉整个实例预算；
+// 取值需远小于实例级超时、又足够长以容纳一次完整生成。env: LLM_REQUEST_TIMEOUT_SECS。
+func providerRequestTimeout() time.Duration {
+	return time.Duration(providerEnvInt("LLM_REQUEST_TIMEOUT_SECS", 600)) * time.Second
+}
+
+// providerMaxRetries 返回 SDK 内置重试次数（默认 5，高于 SDK 默认 2）。
+// 覆盖批量评测下常见的 429 限流；SDK 会自动遵循 Retry-After。env: LLM_MAX_RETRIES。
+// 注意：SDK 重试仅覆盖首字节到达前的错误，流式中途断连由引擎层 WithGenerateRetry 兜底。
+func providerMaxRetries() int {
+	return providerEnvInt("LLM_MAX_RETRIES", 5)
+}
 
 // OpenAIProvider 是 LLMProvider 的 OpenAI 兼容实现，支持所有遵循 OpenAI Chat Completion API
 // 规范的后端（包括 OpenAI 官方、Azure OpenAI、OpenRouter 等兼容端点）。
@@ -64,8 +90,13 @@ func NewOpenAIProvider(model string, opts ...OpenAIOption) (*OpenAIProvider, err
 	}
 
 	p := &OpenAIProvider{
-		client: openai.NewClient(option.WithAPIKey(apiKey), option.WithBaseURL(baseURL)),
-		model:  model,
+		client: openai.NewClient(
+			option.WithAPIKey(apiKey),
+			option.WithBaseURL(baseURL),
+			option.WithMaxRetries(providerMaxRetries()),
+			option.WithRequestTimeout(providerRequestTimeout()),
+		),
+		model: model,
 		// OpenRouter 需要 include_reasoning=true 才会在 delta.reasoning 中返回推理内容。
 		// 其他 OpenAI 兼容后端不含此参数时默认忽略，不产生副作用。
 		includeReasoning: strings.Contains(baseURL, "openrouter"),

--- a/internal/provider/tool_call_accumulator.go
+++ b/internal/provider/tool_call_accumulator.go
@@ -11,6 +11,7 @@
 package provider
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/harness9/internal/schema"
@@ -59,16 +60,25 @@ func (a toolCallAccumulators) appendArgs(idx int, partial string) {
 
 // finalize 按 Index 升序重组累积结果为 ToolCall 列表，供 StreamChunkDone 携带。
 // 返回 nil 表示流中没有工具调用（不应作为错误处理）。
+//
+// 关键修正：先收集实际存在的 key 再升序遍历，而非假设 key 从 0 连续。
+// Anthropic 流中 index 是 content-block 序号——开启 extended thinking 或有正文时，
+// thinking/text 块占据 index 0，tool_use 块从 1 起，key 集合形如 {1,2,3} 而非 {0,1,2}。
+// 旧实现 `for i:=0;i<len(a);i++` 会因 a[0] 不存在而漏掉末尾的工具调用，
+// 导致模型实际发出的工具调用被静默丢弃。
 func (a toolCallAccumulators) finalize() []schema.ToolCall {
 	if len(a) == 0 {
 		return nil
 	}
+	keys := make([]int, 0, len(a))
+	for k := range a {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+
 	result := make([]schema.ToolCall, 0, len(a))
-	for i := 0; i < len(a); i++ {
-		acc, ok := a[i]
-		if !ok {
-			continue
-		}
+	for _, k := range keys {
+		acc := a[k]
 		result = append(result, schema.ToolCall{
 			ID:        acc.id,
 			Name:      acc.name,

--- a/internal/provider/tool_call_accumulator_test.go
+++ b/internal/provider/tool_call_accumulator_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import "testing"
+
+// TestFinalize_ContiguousIndices 验证常规（OpenAI）密集 index 从 0 起的情形。
+func TestFinalize_ContiguousIndices(t *testing.T) {
+	a := newToolCallAccumulators()
+	a.start(0, "id0", "bash")
+	a.appendArgs(0, `{"command":"ls"}`)
+	a.start(1, "id1", "read_file")
+	a.appendArgs(1, `{"path":"x"}`)
+
+	got := a.finalize()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(got))
+	}
+	if got[0].ID != "id0" || got[1].ID != "id1" {
+		t.Errorf("顺序/ID 错误: %+v", got)
+	}
+}
+
+// TestFinalize_SparseIndices 是核心回归测试：当 index 不从 0 开始（Anthropic 在
+// thinking/text 块占据 index 0 时，tool_use 块从 index 1 起，key 集合形如 {1,2}），
+// 旧实现 `for i:=0;i<len(a);i++` 会漏掉末尾工具调用。这里验证全部被保留且按 index 升序。
+func TestFinalize_SparseIndices(t *testing.T) {
+	a := newToolCallAccumulators()
+	a.start(1, "id1", "bash")
+	a.appendArgs(1, `{"command":"a"}`)
+	a.start(2, "id2", "edit_file")
+	a.appendArgs(2, `{"path":"b"}`)
+
+	got := a.finalize()
+	if len(got) != 2 {
+		t.Fatalf("稀疏 index 时应保留全部 2 个工具调用，got %d（旧 bug 会漏掉）", len(got))
+	}
+	if got[0].ID != "id1" || got[1].ID != "id2" {
+		t.Errorf("应按 index 升序: %+v", got)
+	}
+}
+
+// TestFinalize_OutOfOrderArrival 验证乱序到达的 index 也按升序输出。
+func TestFinalize_OutOfOrderArrival(t *testing.T) {
+	a := newToolCallAccumulators()
+	a.start(3, "id3", "t3")
+	a.start(1, "id1", "t1")
+	a.start(2, "id2", "t2")
+
+	got := a.finalize()
+	if len(got) != 3 {
+		t.Fatalf("expected 3, got %d", len(got))
+	}
+	want := []string{"id1", "id2", "id3"}
+	for i, w := range want {
+		if got[i].ID != w {
+			t.Errorf("位置 %d: got %q, want %q", i, got[i].ID, w)
+		}
+	}
+}
+
+// TestFinalize_Empty 验证无工具调用时返回 nil。
+func TestFinalize_Empty(t *testing.T) {
+	a := newToolCallAccumulators()
+	if got := a.finalize(); got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}

--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -4,6 +4,7 @@ package sandbox
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -25,18 +26,27 @@ type SandboxConfig struct {
 	StartTimeout time.Duration
 	// StopTimeout docker stop 的宽限期，超时后 SIGKILL。
 	StopTimeout time.Duration
+	// BootstrapCmd 是容器就绪后、Agent 开始前执行一次的初始化命令（在独立的、较长的
+	// BootstrapTimeout 预算内运行，不受单条 bash 命令超时约束）。空字符串表示不执行。
+	// 典型用途：为 SWE-bench 仓库安装依赖（如 `pip install -e . -q`），或激活预置 conda 环境。
+	// 这是接入官方 SWE-bench 每实例镜像（仓库已预装）的关键接缝——届时只需配置镜像 + 此命令。
+	BootstrapCmd string
+	// BootstrapTimeout 是 BootstrapCmd 的超时（默认 600s）。
+	BootstrapTimeout time.Duration
 }
 
 // DefaultConfig 从环境变量读取配置，未设置时使用内置安全默认值。
 func DefaultConfig() SandboxConfig {
 	return SandboxConfig{
-		Enabled:      strings.ToLower(os.Getenv("SANDBOX_ENABLED")) != "false",
-		Image:        getenvOr("SANDBOX_IMAGE", "ubuntu:22.04"),
-		CPUs:         getenvOr("SANDBOX_CPUS", "1.0"),
-		Memory:       getenvOr("SANDBOX_MEMORY", "512m"),
-		PidsLimit:    256,
-		StartTimeout: 30 * time.Second,
-		StopTimeout:  10 * time.Second,
+		Enabled:          strings.ToLower(os.Getenv("SANDBOX_ENABLED")) != "false",
+		Image:            getenvOr("SANDBOX_IMAGE", "ubuntu:22.04"),
+		CPUs:             getenvOr("SANDBOX_CPUS", "1.0"),
+		Memory:           getenvOr("SANDBOX_MEMORY", "512m"),
+		PidsLimit:        256,
+		StartTimeout:     30 * time.Second,
+		StopTimeout:      10 * time.Second,
+		BootstrapCmd:     os.Getenv("SANDBOX_BOOTSTRAP_CMD"),
+		BootstrapTimeout: time.Duration(getenvIntOr("SANDBOX_BOOTSTRAP_TIMEOUT_SECS", 600)) * time.Second,
 	}
 }
 
@@ -44,6 +54,16 @@ func DefaultConfig() SandboxConfig {
 func getenvOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return fallback
+}
+
+// getenvIntOr 从环境变量读取整型 key，未设置/非法时返回 fallback。
+func getenvIntOr(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
 	}
 	return fallback
 }

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/harness9/internal/logfmt"
 )
@@ -62,12 +63,36 @@ func (m *Manager) Create(ctx context.Context, workDir string) (Environment, erro
 		return nil, fmt.Errorf("sandbox: 启动容器失败: %w", err)
 	}
 
+	env := newDockerEnvironment(c.DockerID(), id, workDir, run)
+
+	// 依赖 bootstrap：容器就绪后、Agent 开始前执行一次初始化命令（如安装项目依赖），
+	// 在独立的较长预算内运行，不受单条 bash 命令超时约束。fail-open：失败仅告警、不阻断创建
+	// （Agent 仍可静态分析；接入官方预装镜像后此步通常无需执行）。
+	if cmd := strings.TrimSpace(m.cfg.BootstrapCmd); cmd != "" {
+		m.runBootstrap(env, cmd, workDir)
+	}
+
 	m.mu.Lock()
 	m.containers[id] = c
 	m.mu.Unlock()
 
 	m.notify()
-	return newDockerEnvironment(c.DockerID(), id, workDir, run), nil
+	return env, nil
+}
+
+// runBootstrap 在独立的 BootstrapTimeout 预算内执行一次性初始化命令（fail-open）。
+func (m *Manager) runBootstrap(env Environment, cmd, workDir string) {
+	timeout := m.cfg.BootstrapTimeout
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	log.Print(logfmt.FormatMsg("sandbox", fmt.Sprintf("执行 bootstrap（超时 %s）: %s", timeout, cmd)))
+	bootCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	// DockerEnvironment.RunBash 始终返回 err==nil（错误转为输出字符串），故仅作记录。
+	if _, err := env.RunBash(bootCtx, cmd, workDir); err != nil {
+		log.Print(logfmt.FormatMsg("sandbox", fmt.Sprintf("bootstrap 出错（fail-open，继续）: %v", err)))
+	}
 }
 
 // Destroy 停止并移除指定 Sandbox。ID 不存在时静默返回 nil。

--- a/internal/sandbox/manager_test.go
+++ b/internal/sandbox/manager_test.go
@@ -3,9 +3,62 @@ package sandbox
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
+
+// TestManager_BootstrapCmd_Runs 验证：配置 BootstrapCmd 时，容器就绪后通过 docker exec
+// 执行一次该命令（接入官方预装镜像 / 依赖安装的关键接缝）。
+func TestManager_BootstrapCmd_Runs(t *testing.T) {
+	cfg := testCfg()
+	cfg.BootstrapCmd = "pip install -e . -q"
+	cfg.BootstrapTimeout = 5 * time.Second
+	mgr := NewManager(cfg)
+
+	var mock *mockCmdRunner
+	mgr.runnerFactory = func(id, workDir string, c SandboxConfig) cmdRunner {
+		mock = newMock(
+			id[:8], errNil(), // docker run
+			"true", errNil(), // docker inspect → running
+			"ok", errNil(), // bootstrap docker exec
+		)
+		return mock.run
+	}
+	if _, err := mgr.Create(context.Background(), t.TempDir()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	found := false
+	for _, call := range mock.Calls {
+		joined := strings.Join(call, " ")
+		if strings.Contains(joined, "exec") && strings.Contains(joined, "pip install -e . -q") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("bootstrap 命令应通过 docker exec 执行，Calls=%v", mock.Calls)
+	}
+}
+
+// TestManager_NoBootstrapByDefault 验证：默认（BootstrapCmd 为空）不触发任何 exec 调用。
+func TestManager_NoBootstrapByDefault(t *testing.T) {
+	mgr := newTestManager() // testCfg 不设 BootstrapCmd
+	var mock *mockCmdRunner
+	mgr.runnerFactory = func(id, workDir string, c SandboxConfig) cmdRunner {
+		mock = newMock(id[:8], errNil(), "true", errNil())
+		return mock.run
+	}
+	if _, err := mgr.Create(context.Background(), t.TempDir()); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	for _, call := range mock.Calls {
+		if len(call) > 0 && call[0] == "exec" {
+			t.Errorf("未配置 BootstrapCmd 时不应有 exec 调用，Calls=%v", mock.Calls)
+		}
+	}
+}
 
 // newTestManager 创建使用 mock runner 的 Manager，不真实启动 Docker。
 func newTestManager() *Manager {

--- a/internal/schema/message.go
+++ b/internal/schema/message.go
@@ -45,6 +45,12 @@ type Message struct {
 	// ToolCallID 用于 Observation（user 角色）消息中，标识此消息是对哪个 ToolCall
 	// 的响应（Request-Response 关联），使 LLM 能够将 Observation 与其原始请求进行匹配。
 	ToolCallID string `json:"tool_call_id,omitempty"`
+
+	// IsError 标记本条 Observation 是否为工具执行失败的结果。
+	// 仅对 ToolCallID 非空的工具结果消息有意义：Provider 据此向模型传递结构化错误信号
+	// （如 Anthropic 的 tool_result.is_error=true），强化模型的自愈（Self-Healing）行为，
+	// 而不仅依赖文本前缀 "Error executing..." 让模型自行解析。
+	IsError bool `json:"is_error,omitempty"`
 }
 
 // ToolCall 代表模型发出的单个工具调用请求。模型指定要调用的已注册工具名称，

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -13,18 +13,28 @@ import (
 	"fmt"
 	"os/exec"
 	"time"
+	"unicode/utf8"
 
 	"github.com/harness9/internal/sandbox"
 	"github.com/harness9/internal/schema"
 )
 
-const maxOutputLen = 8000
-const bashHardTimeout = 30 * time.Second
+const maxOutputLen = 16000
+
+// defaultBashTimeout 是单条 bash 命令的默认超时。
+// 之前硬编码为 30s，对 SWE-bench 等场景过短：pip install / 项目测试套件
+// 普遍超过 30s 而被强杀，使 Agent 无法真正验证修复。提高到 120s 作为更合理的默认值，
+// 并允许通过 WithBashTimeout 覆盖、或由 LLM 在单次调用中通过 timeout_secs 临时放宽。
+const defaultBashTimeout = 120 * time.Second
+
+// maxBashTimeout 是单次调用 timeout_secs 可请求的上限，防止 Agent 设置过长超时拖死整体预算。
+const maxBashTimeout = 600 * time.Second
 
 // BashTool 实现 BaseTool 接口，在 workDir 下执行任意 bash 命令。
 type BashTool struct {
 	workDir string
 	env     sandbox.Environment // nil = 本地执行；非 nil = 路由进 Sandbox 容器
+	timeout time.Duration       // 单条命令超时；0 时使用 defaultBashTimeout
 }
 
 // BashOption 是 BashTool 的功能选项函数。
@@ -36,6 +46,17 @@ func WithEnvironment(env sandbox.Environment) BashOption {
 	return func(t *BashTool) { t.env = env }
 }
 
+// WithBashTimeout 设置单条 bash 命令的默认超时（覆盖 defaultBashTimeout）。
+// 用于 SWE-bench 等需要运行较慢测试套件/安装命令的场景（如 300s）。
+// d <= 0 时忽略，沿用默认值。
+func WithBashTimeout(d time.Duration) BashOption {
+	return func(t *BashTool) {
+		if d > 0 {
+			t.timeout = d
+		}
+	}
+}
+
 // NewBashTool 创建绑定到指定工作目录的 Bash 工具实例。
 func NewBashTool(workDir string, opts ...BashOption) *BashTool {
 	t := &BashTool{workDir: workDir}
@@ -43,6 +64,22 @@ func NewBashTool(workDir string, opts ...BashOption) *BashTool {
 		opt(t)
 	}
 	return t
+}
+
+// effectiveTimeout 返回本次执行采用的超时：单次 timeout_secs（钳制到 maxBashTimeout）优先，
+// 否则用工具配置的 timeout，最后回退到 defaultBashTimeout。
+func (t *BashTool) effectiveTimeout(perCallSecs int) time.Duration {
+	if perCallSecs > 0 {
+		d := time.Duration(perCallSecs) * time.Second
+		if d > maxBashTimeout {
+			d = maxBashTimeout
+		}
+		return d
+	}
+	if t.timeout > 0 {
+		return t.timeout
+	}
+	return defaultBashTimeout
 }
 
 func (t *BashTool) Name() string { return "bash" }
@@ -58,6 +95,10 @@ func (t *BashTool) Definition() schema.ToolDefinition {
 					"type":        "string",
 					"description": "要执行的 bash 命令，例如: ls -la 或 go test ./... 等等",
 				},
+				"timeout_secs": map[string]interface{}{
+					"type":        "integer",
+					"description": fmt.Sprintf("可选：本次命令的超时秒数（默认 %d，上限 %d）。运行较慢的测试套件或安装命令时可适当调大。", int(defaultBashTimeout.Seconds()), int(maxBashTimeout.Seconds())),
+				},
 			},
 			"required": []string{"command"},
 		},
@@ -65,7 +106,8 @@ func (t *BashTool) Definition() schema.ToolDefinition {
 }
 
 type bashArgs struct {
-	Command string `json:"command"`
+	Command     string `json:"command"`
+	TimeoutSecs int    `json:"timeout_secs,omitempty"`
 }
 
 func (t *BashTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
@@ -77,36 +119,38 @@ func (t *BashTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		return "Error: 命令为空字符串", nil
 	}
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, bashHardTimeout)
+	timeout := t.effectiveTimeout(input.TimeoutSecs)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	if t.env != nil {
-		return t.runInSandbox(timeoutCtx, input.Command)
+		return t.runInSandbox(timeoutCtx, input.Command, timeout)
 	}
-	return t.runLocal(timeoutCtx, input.Command)
+	return t.runLocal(timeoutCtx, input.Command, timeout)
 }
 
 // runInSandbox 通过注入的 Environment 在容器内执行命令。
 //
 // 超时处理说明：DockerEnvironment.RunBash 内部将 docker exec 的失败（含 ctx 取消/超时）
-// 转换为错误字符串返回（err==nil），因此不在此处检查 ctx.Err()，
-// 避免"命令刚好在超时边界成功完成"时误加超时警告。
-func (t *BashTool) runInSandbox(ctx context.Context, cmd string) (string, error) {
+// 转换为错误字符串返回（err==nil）。这里显式检查 ctx 是否因超时取消，
+// 追加一条明确的超时横幅，使 LLM 能区分"命令本身报错"与"被 harness 因超时强杀"，
+// 从而采取不同策略（运行单个测试 / 不要据此误改源码）。
+func (t *BashTool) runInSandbox(ctx context.Context, cmd string, timeout time.Duration) (string, error) {
 	out, err := t.env.RunBash(ctx, cmd, t.workDir)
+	if ctx.Err() == context.DeadlineExceeded {
+		return truncateOutput(out) + timeoutBanner(timeout), nil
+	}
 	if err != nil {
 		return fmt.Sprintf("执行报错: %v", err), nil
 	}
 	if out == "" {
 		return "命令执行成功，无终端输出。", nil
 	}
-	if len(out) > maxOutputLen {
-		return fmt.Sprintf("%s\n\n...[终端输出过长，已截断至前 %d 字节]...", out[:maxOutputLen], maxOutputLen), nil
-	}
-	return out, nil
+	return truncateOutput(out), nil
 }
 
 // runLocal 在本地进程中执行命令（Sandbox 关闭时的原有路径）。
-func (t *BashTool) runLocal(ctx context.Context, cmd string) (string, error) {
+func (t *BashTool) runLocal(ctx context.Context, cmd string, timeout time.Duration) (string, error) {
 	c := exec.CommandContext(ctx, "bash", "-c", cmd)
 	c.Dir = t.workDir
 	out, err := c.CombinedOutput()
@@ -114,19 +158,54 @@ func (t *BashTool) runLocal(ctx context.Context, cmd string) (string, error) {
 
 	if ctx.Err() == context.DeadlineExceeded {
 		// 先截断，再追加警告，避免警告被截断掉
-		if len(outputStr) > maxOutputLen {
-			outputStr = outputStr[:maxOutputLen]
-		}
-		return outputStr + fmt.Sprintf("\n[警告: 命令执行超时(%s)，已被系统强制终止。]", bashHardTimeout), nil
+		return truncateOutput(outputStr) + timeoutBanner(timeout), nil
 	}
 	if err != nil {
-		return fmt.Sprintf("执行报错: %v\n输出:\n%s", err, outputStr), nil
+		return fmt.Sprintf("执行报错: %v\n输出:\n%s", err, truncateOutput(outputStr)), nil
 	}
 	if outputStr == "" {
 		return "命令执行成功，无终端输出。", nil
 	}
-	if len(outputStr) > maxOutputLen {
-		return fmt.Sprintf("%s\n\n...[终端输出过长，已截断至前 %d 字节]...", outputStr[:maxOutputLen], maxOutputLen), nil
+	return truncateOutput(outputStr), nil
+}
+
+// timeoutBanner 返回一条清晰、机器可读的超时提示，供 LLM 调整策略。
+func timeoutBanner(timeout time.Duration) string {
+	return fmt.Sprintf("\n\n[TIMEOUT %s: 命令超时被强制终止，这不是代码错误。"+
+		"如在跑测试/安装：尝试只跑单个测试、或用 timeout_secs 调大超时。]", timeout)
+}
+
+// truncateOutput 在输出超过 maxOutputLen 时同时保留头部与尾部（UTF-8 安全）。
+//
+// 关键设计：测试运行器（pytest / go test 等）的 verbose 进度在前、而最关键的
+// FAILED/AssertionError/traceback 与 "=== N failed ===" 汇总行在最后。
+// 旧实现只保留头部、丢弃尾部，恰好把诊断信息切掉。这里保留 head + tail，
+// 中间用标记省略，并在 rune 边界回退，避免切碎多字节字符破坏 JSON/OTLP 序列化。
+func truncateOutput(s string) string {
+	if len(s) <= maxOutputLen {
+		return s
 	}
-	return outputStr, nil
+	// 头部约 1/3、尾部约 2/3（尾部信息更关键）。
+	headLen := maxOutputLen / 3
+	tailLen := maxOutputLen - headLen
+	head := trimToValidUTF8Suffix(s[:headLen])
+	tail := trimToValidUTF8Prefix(s[len(s)-tailLen:])
+	elided := len(s) - len(head) - len(tail)
+	return fmt.Sprintf("%s\n\n...[输出过长，中间 %d 字节已截断，保留首尾；如需完整内容请缩小命令范围]...\n\n%s", head, elided, tail)
+}
+
+// trimToValidUTF8Suffix 去掉字符串末尾可能被切碎的不完整 UTF-8 字节。
+func trimToValidUTF8Suffix(s string) string {
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// trimToValidUTF8Prefix 去掉字符串开头可能被切碎的不完整 UTF-8 字节。
+func trimToValidUTF8Prefix(s string) string {
+	for len(s) > 0 && !utf8.ValidString(s) {
+		s = s[1:]
+	}
+	return s
 }

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -135,6 +135,77 @@ func TestBashTool_Execute_ParentContextCancelled(t *testing.T) {
 	}
 }
 
+// TestBashTool_Truncation_KeepsHeadAndTail 验证大输出同时保留头部与尾部，
+// 不再像旧实现那样只留头部丢尾部（测试失败摘要/traceback 在尾部）。
+func TestBashTool_Truncation_KeepsHeadAndTail(t *testing.T) {
+	head := "HEAD_MARKER_START"
+	tail := "TAIL_MARKER_FAILED_ASSERTION"
+	mid := strings.Repeat("x", maxOutputLen+1000)
+	full := head + mid + tail
+	env := &mockEnv{runOut: full}
+	tool := NewBashTool("/tmp", WithEnvironment(env))
+
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"command":"pytest"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, head) {
+		t.Error("截断后应保留头部")
+	}
+	if !strings.Contains(out, tail) {
+		t.Error("截断后必须保留尾部（pytest 的 FAILED/traceback 在尾部）")
+	}
+	if !strings.Contains(out, "截断") {
+		t.Error("应包含截断标记")
+	}
+}
+
+// TestBashTool_PerCallTimeout 验证 timeout_secs 能放宽单次命令超时。
+func TestBashTool_PerCallTimeout(t *testing.T) {
+	tool := NewBashTool("/tmp")
+	// 默认 120s 足够；这里只验证 timeout_secs 被解析且命令正常完成。
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"command":"echo ok","timeout_secs":5}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "ok") {
+		t.Errorf("expected ok, got %q", out)
+	}
+}
+
+// TestBashTool_EffectiveTimeout 验证超时优先级：per-call > 工具配置 > 默认。
+func TestBashTool_EffectiveTimeout(t *testing.T) {
+	base := NewBashTool("/tmp")
+	if got := base.effectiveTimeout(0); got != defaultBashTimeout {
+		t.Errorf("default timeout = %v, want %v", got, defaultBashTimeout)
+	}
+	configured := NewBashTool("/tmp", WithBashTimeout(300*time.Second))
+	if got := configured.effectiveTimeout(0); got != 300*time.Second {
+		t.Errorf("configured timeout = %v, want 300s", got)
+	}
+	if got := configured.effectiveTimeout(45); got != 45*time.Second {
+		t.Errorf("per-call timeout should win: got %v, want 45s", got)
+	}
+	// 钳制到上限
+	if got := base.effectiveTimeout(99999); got != maxBashTimeout {
+		t.Errorf("per-call timeout should be clamped to %v, got %v", maxBashTimeout, got)
+	}
+}
+
+// TestBashTool_TimeoutBanner 验证本地超时路径追加清晰的 TIMEOUT 横幅。
+func TestBashTool_TimeoutBanner(t *testing.T) {
+	tool := NewBashTool("/tmp", WithBashTimeout(120*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	out, err := tool.Execute(ctx, json.RawMessage(`{"command":"sleep 10"}`))
+	if err != nil {
+		t.Fatalf("bash 不应返回 Go error: %v", err)
+	}
+	if !strings.Contains(out, "TIMEOUT") {
+		t.Errorf("超时应包含 TIMEOUT 横幅，got: %q", out)
+	}
+}
+
 // mockEnv 是 sandbox.Environment 的测试 mock，记录所有 RunBash 调用。
 type mockEnv struct {
 	runOut string

--- a/internal/tools/edit_file.go
+++ b/internal/tools/edit_file.go
@@ -116,7 +116,7 @@ func (t *EditFileTool) Execute(ctx context.Context, args json.RawMessage) (strin
 	}
 	originalContent := string(contentBytes)
 
-	newContent, err := fuzzyReplace(originalContent, input.SourceText, input.TargetText)
+	newContent, level, err := fuzzyReplaceWithLevel(originalContent, input.SourceText, input.TargetText)
 	if err != nil {
 		return "", err
 	}
@@ -125,8 +125,19 @@ func (t *EditFileTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		return "", fmt.Errorf("写回文件失败: %w", err)
 	}
 
-	return buildEditSummary(input.Path, originalContent, newContent), nil
+	// level==1（精确匹配）时改动字节与意图完全一致，可声明权威无需复核；
+	// L2-L4（换行/去空/缩进容错）写入的字节可能与模型预期不同（尤其 Python 缩进敏感），
+	// 因此给出"建议复核缩进"的提示而非"无需确认"，避免在最该验证时抑制自愈。
+	return buildEditSummary(input.Path, originalContent, newContent, level == matchExact), nil
 }
+
+// 匹配级别常量：标识 fuzzyReplace 命中的容错层级，用于决定编辑结果的可信度提示。
+const (
+	matchExact      = 1 // L1 精确匹配
+	matchNewline    = 2 // L2 换行符归一化
+	matchTrimmed    = 3 // L3 整体首尾去空
+	matchLineByLine = 4 // L4 逐行去缩进
+)
 
 // editContextLines 是改动上下文中前后各保留的行数。
 const editContextLines = 3
@@ -141,7 +152,11 @@ const editContextLines = 3
 //   - 改动后的 3 行上下文（无前缀）
 //
 // 当变更行数超过 20 行时，只输出行数统计，避免结果过长撑满 LLM 上下文。
-func buildEditSummary(path, originalContent, newContent string) string {
+//
+// exactMatch 标识本次替换是否为 L1 精确匹配：
+//   - true：diff 即权威确认，提示无需额外复核；
+//   - false：L2-L4 容错匹配，写入字节可能与意图有出入，提示建议复核缩进/上下文。
+func buildEditSummary(path, originalContent, newContent string, exactMatch bool) string {
 	// 归一化换行符，保证跨平台比较一致
 	orig := strings.ReplaceAll(originalContent, "\r\n", "\n")
 	next := strings.ReplaceAll(newContent, "\r\n", "\n")
@@ -207,7 +222,12 @@ func buildEditSummary(path, originalContent, newContent string) string {
 	for i := origEnd + 1; i <= ctxEnd; i++ {
 		fmt.Fprintf(&sb, "  %s\n", origLines[i])
 	}
-	fmt.Fprint(&sb, "---\n✓ 以上 diff 已完整验证改动落地，无需额外 grep/sed/read_file 再次确认。")
+	if exactMatch {
+		fmt.Fprint(&sb, "---\n✓ 精确匹配，以上 diff 已确认改动落地，无需额外 grep/sed/read_file 再次确认。")
+	} else {
+		fmt.Fprint(&sb, "---\n⚠️ 本次为模糊匹配（换行/空白/缩进经过容错处理），写入字节可能与预期略有出入。"+
+			"建议用 read_file 复核改动处的缩进与上下文是否正确（尤其 Python 等缩进敏感语言）。")
+	}
 	return sb.String()
 }
 
@@ -227,17 +247,25 @@ func buildEditSummary(path, originalContent, newContent string) string {
 //	    逐行去除首尾空白后滑动窗口匹配，容忍缩进差异（空格 vs Tab）。
 //
 // 所有级别的匹配结果必须是唯一的（count == 1），多匹配或零匹配均返回明确错误。
+// fuzzyReplace 是 fuzzyReplaceWithLevel 的兼容封装，仅返回结果与错误。
 func fuzzyReplace(originalContent, sourceText, targetText string) (string, error) {
+	result, _, err := fuzzyReplaceWithLevel(originalContent, sourceText, targetText)
+	return result, err
+}
+
+// fuzzyReplaceWithLevel 在 fuzzyReplace 基础上额外返回命中的匹配层级（matchExact..matchLineByLine），
+// 供调用方据此调整结果可信度提示（精确匹配可声明权威，模糊匹配建议复核）。
+func fuzzyReplaceWithLevel(originalContent, sourceText, targetText string) (string, int, error) {
 	// 归一化 targetText 的换行符，避免替换后混用 \r\n 和 \n
 	normalizedTarget := strings.ReplaceAll(targetText, "\r\n", "\n")
 
 	// L1: 原始文本精确匹配（Exact Match）
 	count := strings.Count(originalContent, sourceText)
 	if count == 1 {
-		return strings.Replace(originalContent, sourceText, targetText, 1), nil
+		return strings.Replace(originalContent, sourceText, targetText, 1), matchExact, nil
 	}
 	if count > 1 {
-		return "", fmt.Errorf("source_text 匹配到了 %d 处，请提供更多的上下文代码以确保唯一性", count)
+		return "", 0, fmt.Errorf("source_text 匹配到了 %d 处，请提供更多的上下文代码以确保唯一性", count)
 	}
 
 	// 对原始内容做换行符归一化，进入 L2-L4
@@ -254,7 +282,7 @@ func fuzzyReplace(originalContent, sourceText, targetText string) (string, error
 		if hasCRLF {
 			result = strings.ReplaceAll(result, "\n", "\r\n")
 		}
-		return result, nil
+		return result, matchNewline, nil
 	}
 
 	// L3: 整体首尾去空匹配（Trimmed Match）
@@ -266,12 +294,16 @@ func fuzzyReplace(originalContent, sourceText, targetText string) (string, error
 			if hasCRLF {
 				result = strings.ReplaceAll(result, "\n", "\r\n")
 			}
-			return result, nil
+			return result, matchTrimmed, nil
 		}
 	}
 
 	// L4: 逐行去缩进匹配（Line-by-Line Indent-Agnostic Matching）
-	return lineByLineReplace(normalizedContent, normalizedSource, normalizedTarget, hasCRLF)
+	result, err := lineByLineReplace(normalizedContent, normalizedSource, normalizedTarget, hasCRLF)
+	if err != nil {
+		return "", 0, err
+	}
+	return result, matchLineByLine, nil
 }
 
 // lineByLineReplace 将文本按行切割，去除首尾空白后进行滑动窗口匹配（Sliding Window Matching）。
@@ -328,9 +360,16 @@ func lineByLineReplace(content, sourceText, targetText string, hasCRLF bool) (st
 		return "", fmt.Errorf("模糊匹配到了 %d 处代码，请提供更多上下文以定位", matchCount)
 	}
 
+	// 关键修正：L4 是缩进无关匹配，模型提供的 targetText 缩进未必与文件一致，
+	// 若原样写入会破坏缩进敏感语言（Python）的结构，产生 IndentationError。
+	// 这里以被匹配块首行的缩进为基准，对 targetText 重新缩进：保留其相对结构，
+	// 但将整体基准对齐到文件中被替换块的缩进。
+	baseIndent := leadingWhitespace(contentLines[matchStartIndex])
+	reindentedTarget := reindentBlock(targetText, baseIndent)
+
 	var newContentLines []string
 	newContentLines = append(newContentLines, contentLines[:matchStartIndex]...)
-	newContentLines = append(newContentLines, targetText)
+	newContentLines = append(newContentLines, reindentedTarget)
 	newContentLines = append(newContentLines, contentLines[matchEndIndex:]...)
 
 	result := strings.Join(newContentLines, "\n")
@@ -338,4 +377,53 @@ func lineByLineReplace(content, sourceText, targetText string, hasCRLF bool) (st
 		result = strings.ReplaceAll(result, "\n", "\r\n")
 	}
 	return result, nil
+}
+
+// leadingWhitespace 返回字符串开头的空白前缀（空格 / Tab）。
+func leadingWhitespace(s string) string {
+	return s[:len(s)-len(strings.TrimLeft(s, " \t"))]
+}
+
+// commonStringPrefix 返回 a 与 b 的最长公共前缀。
+func commonStringPrefix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
+}
+
+// reindentBlock 将多行 target 重新缩进到 baseIndent 基准。
+//
+// 算法：先求所有非空行的最长公共空白前缀（target 自身的基准缩进），
+// 逐行剥离该公共前缀后改用 baseIndent，从而保留行间相对缩进、把整体对齐到文件中
+// 被替换块的缩进层级。纯空白行归一化为空行。
+func reindentBlock(target, baseIndent string) string {
+	lines := strings.Split(target, "\n")
+	common := ""
+	seeded := false
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		lead := leadingWhitespace(ln)
+		if !seeded {
+			common = lead
+			seeded = true
+			continue
+		}
+		common = commonStringPrefix(common, lead)
+	}
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			lines[i] = ""
+			continue
+		}
+		lines[i] = baseIndent + strings.TrimPrefix(ln, common)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/tools/edit_file_test.go
+++ b/internal/tools/edit_file_test.go
@@ -478,7 +478,7 @@ func TestFuzzyReplace_L4_LineByLineIndentDifference(t *testing.T) {
 func TestBuildEditSummary_SingleLineChange(t *testing.T) {
 	orig := "line1\nline2_old\nline3\n"
 	next := "line1\nline2_new\nline3\n"
-	out := buildEditSummary("foo.py", orig, next)
+	out := buildEditSummary("foo.py", orig, next, true)
 
 	if !strings.Contains(out, "- line2_old") {
 		t.Errorf("should show removed line, got: %s", out)
@@ -502,7 +502,7 @@ func TestBuildEditSummary_SingleLineChange(t *testing.T) {
 func TestBuildEditSummary_InsertionOnly(t *testing.T) {
 	orig := "line1\nline3\n"
 	next := "line1\nline2_inserted\nline3\n"
-	out := buildEditSummary("foo.py", orig, next)
+	out := buildEditSummary("foo.py", orig, next, true)
 
 	if !strings.Contains(out, "+ line2_inserted") {
 		t.Errorf("should show inserted line, got: %s", out)
@@ -517,7 +517,7 @@ func TestBuildEditSummary_InsertionOnly(t *testing.T) {
 func TestBuildEditSummary_DeletionOnly(t *testing.T) {
 	orig := "line1\nline2_removed\nline3\n"
 	next := "line1\nline3\n"
-	out := buildEditSummary("foo.py", orig, next)
+	out := buildEditSummary("foo.py", orig, next, true)
 
 	if !strings.Contains(out, "- line2_removed") {
 		t.Errorf("should show removed line, got: %s", out)
@@ -537,7 +537,7 @@ func TestBuildEditSummary_LargeChange(t *testing.T) {
 	}
 	orig := strings.Join(origLines, "\n")
 	next := strings.Join(nextLines, "\n")
-	out := buildEditSummary("big.py", orig, next)
+	out := buildEditSummary("big.py", orig, next, true)
 
 	if !strings.Contains(out, "删除") || !strings.Contains(out, "新增") {
 		t.Errorf("large diff should report line counts, got: %s", out)
@@ -548,11 +548,76 @@ func TestBuildEditSummary_LargeChange(t *testing.T) {
 	}
 }
 
+// TestFuzzyReplace_L4_PreservesBlockIndentation 验证 L4 缩进无关匹配命中后，
+// 模型提供的 target 会被重新缩进到被替换块的缩进层级（防止 Python IndentationError）。
+func TestFuzzyReplace_L4_PreservesBlockIndentation(t *testing.T) {
+	// 文件中方法体缩进 4/8 空格；source 用 0/4 空格触发 L4（逐行去缩进）匹配。
+	content := "class A:\n    def old(self):\n        return 1\n"
+	source := "def old(self):\n    return 1" // 缩进与文件不同 → 走 L4
+	// 模型给出的 target 以 0 缩进书写，依赖框架对齐到块基准缩进。
+	target := "def new(self):\n    return 2"
+
+	result, level, err := fuzzyReplaceWithLevel(content, source, target)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if level != matchLineByLine {
+		t.Fatalf("expected L4 match, got level %d (result=%q)", level, result)
+	}
+	// 被替换块首行原缩进为 4 空格 → def new 应为 4 空格，return 2 应为 8 空格。
+	if !strings.Contains(result, "\n    def new(self):\n") {
+		t.Errorf("def new 应重缩进到 4 空格基准，got:\n%s", result)
+	}
+	if !strings.Contains(result, "\n        return 2\n") {
+		t.Errorf("return 2 应重缩进到 8 空格（保留相对结构），got:\n%s", result)
+	}
+}
+
+// TestEditFile_FuzzyMatch_CautionBanner 验证模糊匹配（L3/L4）的成功提示
+// 不再声称"无需确认"，而是建议复核（避免在最该验证时抑制自愈）。
+func TestEditFile_FuzzyMatch_CautionBanner(t *testing.T) {
+	dir := t.TempDir()
+	// 文件缩进与 source 不同，强制走 L3/L4 模糊匹配。
+	content := "class A:\n    def m(self):\n        return 1\n"
+	if err := os.WriteFile(dir+"/a.py", []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewEditFileTool(dir)
+	// source 缩进与文件不同
+	args := json.RawMessage(`{"path":"a.py","source_text":"def m(self):\n    return 1","target_text":"def m(self):\n    return 2"}`)
+	out, err := tool.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(out, "无需额外") {
+		t.Errorf("模糊匹配不应声称无需确认，got: %q", out)
+	}
+	if !strings.Contains(out, "模糊匹配") || !strings.Contains(out, "复核") {
+		t.Errorf("模糊匹配应提示复核，got: %q", out)
+	}
+}
+
+// TestEditFile_ExactMatch_AuthoritativeBanner 验证精确匹配仍声明权威无需复核。
+func TestEditFile_ExactMatch_AuthoritativeBanner(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(dir+"/a.txt", []byte("hello world\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewEditFileTool(dir)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"path":"a.txt","source_text":"world","target_text":"harness9"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "✓") || !strings.Contains(out, "精确匹配") {
+		t.Errorf("精确匹配应声明权威确认，got: %q", out)
+	}
+}
+
 // buildEditSummary：CRLF 文件归一化后正常展示
 func TestBuildEditSummary_CRLFContent(t *testing.T) {
 	orig := "line1\r\nline2_old\r\nline3\r\n"
 	next := "line1\r\nline2_new\r\nline3\r\n"
-	out := buildEditSummary("foo.py", orig, next)
+	out := buildEditSummary("foo.py", orig, next, true)
 
 	if !strings.Contains(out, "- line2_old") {
 		t.Errorf("CRLF: should show removed line, got: %s", out)

--- a/internal/tools/read_file.go
+++ b/internal/tools/read_file.go
@@ -13,6 +13,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,8 +25,9 @@ import (
 )
 
 // maxReadLen 单次文件读取的最大字节数（Max Read Bytes）。
-// 未指定 limit 参数时的默认上限。
-const maxReadLen = 4096
+// 未指定 limit 参数时的默认上限。SWE-bench 源文件普遍较大，4096 字节（约 60-80 行）
+// 会造成频繁分页（每次一个 LLM turn），故提高到 8192。
+const maxReadLen = 8192
 
 // ReadFileTool 实现了 BaseTool 接口，提供受限工作区内的安全文件读取能力。
 type ReadFileTool struct {
@@ -60,9 +62,9 @@ func (t *ReadFileTool) Definition() schema.ToolDefinition {
 	return schema.ToolDefinition{
 		Name: t.Name(),
 		Description: "读取指定路径的文件内容。" +
-			"推荐使用 start_line/end_line 按行号读取片段（最直观）；" +
-			"也支持 offset/limit 字节偏移分页。" +
-			"注意：offset/limit 单位为字节，不是行号。",
+			"推荐使用 start_line/end_line 按行号读取片段（最直观）：返回的每行带 `行号→Tab→内容` 前缀，便于定位。" +
+			"⚠️ 行号前缀仅供显示，调用 edit_file 时 source_text 必须是不含行号前缀的原始代码。" +
+			"也支持 offset/limit 字节偏移分页（单位为字节，不是行号）。",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -103,7 +105,8 @@ type readFileArgs struct {
 }
 
 // maxLineRead 行号模式下单次最多读取的行数（防止大文件占满上下文）。
-const maxLineRead = 200
+// 200 行对 SWE-bench 大源文件偏小、需多次往返；提高到 500 行减少分页抖动。
+const maxLineRead = 500
 
 // Execute 执行文件读取操作，支持行号模式（start_line/end_line）和字节偏移模式（offset/limit）。
 // 设置了 start_line 时优先走行号模式。
@@ -209,10 +212,17 @@ func readFileByLines(fullPath string, startLine, endLine int) (string, error) {
 			truncated = true
 			break
 		}
-		sb.WriteString(scanner.Text())
-		sb.WriteByte('\n')
+		// 每行带 1-based 行号前缀（`行号→Tab→内容`），便于 LLM 精确定位、
+		// 减少 edit_file 的多匹配失败。行号仅供显示，调用 edit_file 时
+		// source_text 不应包含该前缀（见 Definition 说明）。
+		fmt.Fprintf(&sb, "%6d\t%s\n", lineNum, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
+		// 单行超过 scanner 缓冲（>512KB，如压缩/生成代码、长 JSON）时优雅降级，
+		// 提示改用字节模式，而非抛出难以理解的通用错误。
+		if errors.Is(err, bufio.ErrTooLong) {
+			return "", fmt.Errorf("文件含超长行（>512KB），行号模式不支持；请改用 offset/limit 字节模式读取该文件")
+		}
 		return "", fmt.Errorf("读取文件失败: %w", err)
 	}
 

--- a/internal/tools/read_file_test.go
+++ b/internal/tools/read_file_test.go
@@ -173,6 +173,31 @@ func TestReadFileTool_Execute_StartEndLine(t *testing.T) {
 	}
 }
 
+// TestReadFileTool_LineNumbers 验证行号模式为每行加 `行号→Tab→内容` 前缀，
+// 便于 LLM 精确定位、减少 edit_file 多匹配失败。
+func TestReadFileTool_LineNumbers(t *testing.T) {
+	dir := t.TempDir()
+	content := "alpha\nbeta\ngamma\n"
+	if err := os.WriteFile(dir+"/f.txt", []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tool := NewReadFileTool(dir)
+	out, err := tool.Execute(context.Background(), json.RawMessage(`{"path":"f.txt","start_line":1,"end_line":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 每行应带行号与 Tab 分隔；第 2 行内容为 beta。
+	if !strings.Contains(out, "\tbeta") {
+		t.Errorf("行号模式应以 Tab 分隔行号与内容，got: %q", out)
+	}
+	if !strings.Contains(out, "2\tbeta") {
+		t.Errorf("beta 应标注为第 2 行，got: %q", out)
+	}
+	if !strings.Contains(out, "1\talpha") || !strings.Contains(out, "3\tgamma") {
+		t.Errorf("应包含第 1、3 行行号，got: %q", out)
+	}
+}
+
 func TestReadFileTool_Execute_StartLineOnly(t *testing.T) {
 	dir := t.TempDir()
 	var lines []string

--- a/internal/tools/registry.go
+++ b/internal/tools/registry.go
@@ -80,7 +80,7 @@ func (r *registryImpl) GetAvailableTools() []schema.ToolDefinition {
 // Execute 根据工具名称查找并执行对应工具。若工具不存在，返回包含错误信息的 ToolResult。
 // 工具执行失败时，错误会被捕获并封装为 IsError=true 的 ToolResult，
 // 使引擎能够将错误信息作为 Observation 回传给 LLM，支持自愈（Self-Healing）重试。
-func (r *registryImpl) Execute(ctx context.Context, call schema.ToolCall) schema.ToolResult {
+func (r *registryImpl) Execute(ctx context.Context, call schema.ToolCall) (result schema.ToolResult) {
 	r.mu.RLock()
 	tool, exists := r.tools[call.Name]
 	r.mu.RUnlock()
@@ -92,6 +92,19 @@ func (r *registryImpl) Execute(ctx context.Context, call schema.ToolCall) schema
 			IsError:    true,
 		}
 	}
+
+	// 兜底 recover：将工具内部的 panic（如自定义工具 / MCP 适配器的 nil map 写、
+	// 越界等）转换为 IsError 结果，而非让单个工具崩溃拖垮整个进程
+	// （并发执行时一个 goroutine panic 会终止整个 agent loop / benchmark 实例）。
+	defer func() {
+		if rec := recover(); rec != nil {
+			result = schema.ToolResult{
+				ToolCallID: call.ID,
+				Output:     fmt.Sprintf("Error: 工具 '%s' 执行时发生 panic: %v", call.Name, rec),
+				IsError:    true,
+			}
+		}
+	}()
 
 	output, err := tool.Execute(ctx, call.Arguments)
 

--- a/internal/tools/registry_test.go
+++ b/internal/tools/registry_test.go
@@ -27,6 +27,36 @@ func (t *testTool) Execute(_ context.Context, _ json.RawMessage) (string, error)
 	return t.output, t.err
 }
 
+// panicTool 在 Execute 时 panic，用于验证 Registry 的兜底 recover。
+type panicTool struct{ name string }
+
+func (t *panicTool) Name() string { return t.name }
+func (t *panicTool) Definition() schema.ToolDefinition {
+	return schema.ToolDefinition{Name: t.name, Description: "panics"}
+}
+func (t *panicTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	panic("boom")
+}
+
+// TestRegistry_Execute_RecoversPanic 验证工具内部 panic 被转换为 IsError 结果，
+// 而非让整个进程崩溃（并发执行时尤为关键）。
+func TestRegistry_Execute_RecoversPanic(t *testing.T) {
+	r := NewRegistry()
+	if err := r.Register(&panicTool{name: "boom"}); err != nil {
+		t.Fatal(err)
+	}
+	res := r.Execute(context.Background(), schema.ToolCall{ID: "c1", Name: "boom"})
+	if !res.IsError {
+		t.Error("panic 应转为 IsError 结果")
+	}
+	if !strings.Contains(res.Output, "panic") {
+		t.Errorf("结果应说明 panic，got: %q", res.Output)
+	}
+	if res.ToolCallID != "c1" {
+		t.Errorf("应保留 ToolCallID，got: %q", res.ToolCallID)
+	}
+}
+
 func TestNewRegistry_IsEmpty(t *testing.T) {
 	r := NewRegistry()
 	if defs := r.GetAvailableTools(); len(defs) != 0 {

--- a/internal/tools/safe_path.go
+++ b/internal/tools/safe_path.go
@@ -67,19 +67,23 @@ func isSensitivePath(absPath string) bool {
 //	safePath("/project", "../../etc/passwd")     → "", error
 //	safePath("/project", "./README.md")          → "/project/README.md", nil
 func safePath(workDir, inputPath string) (string, error) {
-	// 敏感路径先检：对绝对路径输入，在拼接前直接校验，防止攻击者通过绝对路径绕过沙箱。
-	if filepath.IsAbs(inputPath) {
-		cleanInput := filepath.Clean(inputPath)
-		if isSensitivePath(cleanInput) {
-			return "", fmt.Errorf("路径 '%s' 是受保护的敏感路径，禁止访问", inputPath)
-		}
-	}
-
 	cleanWorkDir := filepath.Clean(workDir)
-	joined := filepath.Join(cleanWorkDir, inputPath)
-	absPath, err := filepath.Abs(joined)
-	if err != nil {
-		return "", fmt.Errorf("解析路径失败: %w", err)
+
+	// 绝对路径输入直接规范化，绝不再与 workDir 拼接。
+	// filepath.Join(workDir, "/abs/path") 不会把第二个参数当作绝对路径处理，
+	// 而是直接拼接成 "/workDir/abs/path"；当输入恰好是 workDir 下的绝对路径
+	// （如 SWE-bench prompt 注入的绝对工作目录 + 子路径）时会产生
+	// "/workDir/workDir/sub" 的翻倍路径，虽通过前缀校验却指向不存在的文件。
+	// 因此对绝对路径走独立分支，相对路径才与 workDir 拼接。
+	var absPath string
+	if filepath.IsAbs(inputPath) {
+		absPath = filepath.Clean(inputPath)
+	} else {
+		var err error
+		absPath, err = filepath.Abs(filepath.Join(cleanWorkDir, inputPath))
+		if err != nil {
+			return "", fmt.Errorf("解析路径失败: %w", err)
+		}
 	}
 
 	// 安全校验：确保解析后的绝对路径仍以工作区目录为前缀。

--- a/internal/tools/safe_path_test.go
+++ b/internal/tools/safe_path_test.go
@@ -46,6 +46,46 @@ func TestSafePath_AllowsInsideWorkDir(t *testing.T) {
 	}
 }
 
+// TestSafePath_AbsolutePathInsideWorkDir 验证：当输入已是 workDir 下的绝对路径时，
+// safePath 直接返回该绝对路径，而不会与 workDir 拼接成翻倍路径（回归测试）。
+// 这是 SWE-bench 轨迹中 10/12 实例命中的 read_file/edit_file "no such file" 根因。
+func TestSafePath_AbsolutePathInsideWorkDir(t *testing.T) {
+	workDir := "/var/folders/rj/swebench-abc123"
+	cases := map[string]string{
+		// 绝对路径恰好在 workDir 下 → 原样返回，绝不翻倍
+		"/var/folders/rj/swebench-abc123/src/flask/cli.py": "/var/folders/rj/swebench-abc123/src/flask/cli.py",
+		"/var/folders/rj/swebench-abc123":                  "/var/folders/rj/swebench-abc123",
+		"/var/folders/rj/swebench-abc123/a/b/../c.py":      "/var/folders/rj/swebench-abc123/a/c.py",
+		// 相对路径仍正常拼接
+		"src/flask/cli.py": "/var/folders/rj/swebench-abc123/src/flask/cli.py",
+	}
+	for in, want := range cases {
+		got, err := safePath(workDir, in)
+		if err != nil {
+			t.Errorf("safePath(%q, %q) unexpected error: %v", workDir, in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("safePath(%q, %q) = %q, want %q (path-doubling regression?)", workDir, in, got, want)
+		}
+	}
+}
+
+// TestSafePath_AbsolutePathOutsideWorkDir 验证绝对路径逃逸 workDir 时仍被拒绝。
+func TestSafePath_AbsolutePathOutsideWorkDir(t *testing.T) {
+	workDir := "/var/folders/rj/swebench-abc123"
+	cases := []string{
+		"/etc/passwd",
+		"/var/folders/rj/swebench-abc123-evil/x.py", // 前缀相近但非子目录
+		"/var/folders/rj/other/y.py",
+	}
+	for _, p := range cases {
+		if _, err := safePath(workDir, p); err == nil {
+			t.Errorf("safePath(%q, %q) should reject out-of-workdir absolute path", workDir, p)
+		}
+	}
+}
+
 func TestSafePath_SensitivePathBlocked(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
结合 SWE-bench 评估结果与完整 trajectory 取证（31-agent 并行审计 + 逐行复核），修复多处会**静默产出错误 / 丢失结果**、或**被瞬时故障杀死实例**的框架问题。改动覆盖工具层、引擎层、provider 层、sandbox 与 SWE-bench runner，均配套单测与 eval 用例。

## Summary

**正确性（静默错误类）**
- `safePath`：绝对路径不再二次拼接 workDir —— 修复路径翻倍导致 `read_file`/`edit_file` 失效、退化为 bash 打补丁（轨迹中 10/12 命中）
- `edit_file`：L4 模糊匹配重缩进到被替换块基准，避免破坏 Python 缩进；仅精确匹配声明权威，模糊匹配改为提示复核
- `read_file`：行号模式加行号前缀便于精确定位；超长行优雅降级；放宽读取上限
- `tool_call_accumulator.finalize`：按 index 升序，修复稀疏 index（Anthropic thinking 块）下漏工具调用

**鲁棒性（瞬时故障杀实例类）**
- 引擎新增有界指数退避生成重试 `WithGenerateRetry`
- provider 显式请求超时 + 重试次数（env 可调）
- `registry.Execute` 兜底 recover；工具 `IsError` 透传给模型；空输出兜底

**可验证性**
- bash 超时可配置（默认 120s）+ 单次 `timeout_secs`；输出改为头+尾保留且 UTF-8 安全（保住测试失败尾部）
- sandbox 新增依赖 bootstrap 钩子（为接入官方 SWE-bench 镜像铺路）

**SWE-bench runner**
- 接入 Compactor + ContextWindow + BypassAll + 生成重试
- 收集 patch 前 `git add -N` 纳入新建文件；固定 `--seed`（默认 1）保证可复现
- 日志按 RunID 隔离；`--resume` 仅跳过非空 patch
- prompt 重写：行为验证优先、引导阅读现有测试、文件工具用相对路径、英文推理

## Test Plan
- [x] `go test ./...` 全绿（21 包）
- [x] `gofmt -l` / `go vet ./...` 干净
- [x] 新增单元测试：safePath / bash / edit_file / read_file / registry / accumulator / engine 重试 / sandbox bootstrap
- [x] 新增 eval 黄金用例 `tool_calling/edit_file_fuzzy_indent`
- [x] SWE-bench Lite 抽样复跑（sample 1，python:3.11-slim）：6/12 resolved，0 错误 / 0 空 patch，修复均在线生效（真实 pip/pytest、maxTurns 截断、路径错误归零）
- [ ] 更大样本（sample 5）以获得统计意义分数