### PR TITLE
provider: enable include_reasoning for Requesty gateways

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -75,6 +75,15 @@ func WithIncludeReasoning() OpenAIOption {
 	}
 }
 
+// baseURLEnablesReasoning 判断给定的 base URL 是否为需要 include_reasoning=true
+// 才会暴露推理内容的 OpenAI 兼容网关（OpenRouter、Requesty）。
+// baseURLEnablesReasoning reports whether the base URL is an OpenAI-compatible
+// gateway (OpenRouter, Requesty) that needs include_reasoning=true to surface
+// reasoning content in delta.reasoning.
+func baseURLEnablesReasoning(baseURL string) bool {
+	return strings.Contains(baseURL, "openrouter") || strings.Contains(baseURL, "requesty")
+}
+
 // NewOpenAIProvider 创建并返回 OpenAIProvider 实例。
 // 从环境变量读取 OPENAI_API_KEY 和 OPENAI_BASE_URL 完成认证配置。
 // 当 OPENAI_BASE_URL 中包含 "openrouter" 时自动启用 includeReasoning，
@@ -97,9 +106,10 @@ func NewOpenAIProvider(model string, opts ...OpenAIOption) (*OpenAIProvider, err
 			option.WithRequestTimeout(providerRequestTimeout()),
 		),
 		model: model,
-		// OpenRouter 需要 include_reasoning=true 才会在 delta.reasoning 中返回推理内容。
-		// 其他 OpenAI 兼容后端不含此参数时默认忽略，不产生副作用。
-		includeReasoning: strings.Contains(baseURL, "openrouter"),
+		// OpenRouter 和 Requesty 需要 include_reasoning=true 才会在 delta.reasoning 中返回推理内容。
+		// 两者均为 OpenAI 兼容网关，使用相同的 reasoning 字段；其他后端不含此参数时默认忽略，不产生副作用。
+		// OpenRouter and Requesty both expose reasoning via delta.reasoning when include_reasoning=true.
+		includeReasoning: baseURLEnablesReasoning(baseURL),
 	}
 	for _, opt := range opts {
 		opt(p)

--- a/internal/provider/openai_reasoning_test.go
+++ b/internal/provider/openai_reasoning_test.go
@@ -24,6 +24,18 @@ func TestWithIncludeReasoning_AutoDetectOpenRouter(t *testing.T) {
 	}
 }
 
+func TestWithIncludeReasoning_AutoDetectRequesty(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENAI_BASE_URL", "https://router.requesty.ai/v1")
+	p, err := NewOpenAIProvider("gpt-4o")
+	if err != nil {
+		t.Fatalf("NewOpenAIProvider: %v", err)
+	}
+	if !p.includeReasoning {
+		t.Error("Requesty base URL should auto-enable includeReasoning")
+	}
+}
+
 func TestWithIncludeReasoning_NonOpenRouterDisabled(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")


### PR DESCRIPTION
## What

The OpenAI provider auto-enables `include_reasoning=true` when the base URL is OpenRouter, so reasoning models surface `delta.reasoning`. [Requesty](https://requesty.ai) is an OpenAI-compatible gateway that uses the same reasoning field, so this extends the auto-detection to Requesty base URLs too.

- `internal/provider/openai.go`: extract `baseURLEnablesReasoning()` matching `openrouter` **or** `requesty` (replaces the inline `strings.Contains(baseURL, "openrouter")`)
- `internal/provider/openai_reasoning_test.go`: add a Requesty auto-detect test mirroring the OpenRouter one

Users already point the provider at any OpenAI-compatible backend via `OPENAI_BASE_URL`; this just makes Requesty get the same reasoning treatment OpenRouter gets. No behavior change for other backends.

## Tested

- `go build ./...`, `go vet ./internal/provider/` — clean
- `go test ./internal/provider/` — pass (incl. the new `TestWithIncludeReasoning_AutoDetectRequesty`)
- `gofmt` — clean

## Disclosure

I work at Requesty. This mirrors the existing OpenRouter detection 1:1. Happy to adjust or close if it's not a fit.