### PR TITLE
fix: 修复 Sandbox 博客导致的 VitePress 构建失败

### DIFF
--- a/website/blog/sandbox/index.md
+++ b/website/blog/sandbox/index.md
@@ -121,7 +121,7 @@ const (
 )
 ```
 
-`Start` 方法有个关键设计：**反复问几次"好了没"，而不是问一次就当真**。`docker run -d` 拿到容器 ID 并不代表容器已经真正准备好干活了，尤其是要拉取新镜像或者启动比较重的场景时更明显。所以 `Start` 拿到 dockerID 之后，会进入一个每 200 毫秒问一次的轮询循环，反复执行 `docker inspect --format={{.State.Running}}`，直到看到返回 `true`，或者等到 `StartTimeout`（默认 30 秒）到点还没成功，就转成 `StateFailed`：
+`Start` 方法有个关键设计：**反复问几次"好了没"，而不是问一次就当真**。`docker run -d` 拿到容器 ID 并不代表容器已经真正准备好干活了，尤其是要拉取新镜像或者启动比较重的场景时更明显。所以 `Start` 拿到 dockerID 之后，会进入一个每 200 毫秒问一次的轮询循环，反复执行 <code v-pre>docker inspect --format={{.State.Running}}</code>，直到看到返回 `true`，或者等到 `StartTimeout`（默认 30 秒）到点还没成功，就转成 `StateFailed`：
 
 ```go
 for {


### PR DESCRIPTION
## Summary
- `website/blog/sandbox/index.md` 中一段内联代码 `` `docker inspect --format={{.State.Running}}` `` 触发了 VitePress 的 Vue 模板编译错误：`{{.State.Running}}` 被当作 Vue 插值表达式解析，因表达式以 `.` 开头而报 `Unexpected token (1:1)`，导致 `Deploy Website` workflow 的 Build 步骤失败（run 29227639381）
- 修复方式：将该内联代码改为 `<code v-pre>docker inspect --format={{.State.Running}}</code>`，用 `v-pre` 让 Vue 编译器跳过该节点的插值解析，内容原样渲染为纯文本
- 已在本地用 `cd website && npm run build` 复现故障并验证修复后构建通过，同时检查了构建产物 HTML，确认该行以纯文本形式正确渲染
- 文件中其余两处 `{{ }}`（分别在 `container.go` 和 `manager.go` 对应的 fenced code block 内）确认不受影响：VitePress 默认对普通 fenced code block（无 `-vue` 后缀）不做 Vue 插值处理，本地构建也证实了这一点

## Test Plan
- [x] `cd website && npm run build` 本地复现原始失败并确认修复后构建成功
- [x] 检查构建产物 `dist/blog/sandbox/index.html`，确认 `{{.State.Running}}` 渲染为纯文本而非被解析
- [ ] CI `Deploy Website` workflow 在此分支/合并后重新跑绿