### PR TITLE
fix: 用 CI 自动生成的静态图表替换失效的 star-history 徽章

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,47 @@
+name: Star History
+
+# GitHub 于 2026-06-30 起限制 stargazers API，仅允许仓库自身的 owner/collaborator
+# 读取 starred_at 时间戳，导致 star-history.com 等第三方服务无法再为非自有仓库生成
+# 实时图表。本工作流使用仓库自带的 GITHUB_TOKEN（对本仓库天然具备访问权限）定期离线
+# 生成静态 SVG 并提交回仓库，README 直接引用该本地文件，不再依赖第三方服务的可用性。
+on:
+  schedule:
+    - cron: "0 0 * * *" # 每天 UTC 00:00
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: star-history
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update Chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: 生成 star-history.svg
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run ./cmd/starhistory -output star-history.svg
+
+      - name: 提交变更
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add star-history.svg
+          if git diff --cached --quiet; then
+            echo "star-history.svg 无变化，跳过提交"
+            exit 0
+          fi
+          git commit -m "chore: 更新 star history 图表"
+          git push

--- a/README.md
+++ b/README.md
@@ -579,7 +579,9 @@ harness9/
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ZhangShenao/harness9&type=Date)](https://star-history.com/#ZhangShenao/harness9&Date)
+[![Star History Chart](star-history.svg)](https://github.com/ZhangShenao/harness9/stargazers)
+
+> GitHub 于 2026-06-30 起限制了 stargazers API 的访问权限（仅 owner/collaborator 可读），star-history.com 等第三方实时徽章因此普遍失效。上图由 [`.github/workflows/star-history.yml`](.github/workflows/star-history.yml) 每日用仓库自身 `GITHUB_TOKEN` 离线生成并提交为静态文件，不依赖任何第三方服务的实时可用性。
 
 ---
 

--- a/cmd/starhistory/main.go
+++ b/cmd/starhistory/main.go
@@ -1,0 +1,167 @@
+// Package main 生成 GitHub Star History 图表并写入本地 SVG 文件。
+//
+// GitHub 于 2026-06-30 起限制 stargazers API，仅允许仓库自身的
+// owner/collaborator 读取 starred_at 时间戳，导致 star-history.com
+// 等第三方服务无法再为非自有仓库生成实时徽章，README 中原有的实时图表因此失效。
+// 本工具运行于 CI，使用仓库自带的 GITHUB_TOKEN（对本仓库天然具备访问权限）
+// 离线抓取数据并渲染为静态 SVG 定期提交回仓库，从而彻底摆脱对第三方服务
+// 运行时可用性的依赖。
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAPIBase = "https://api.github.com"
+	defaultPerPage = 100
+	// defaultRepo 是本仓库自身维护脚本的专属默认值（非通用参数化设计），
+	// 仅在 GITHUB_REPOSITORY 未设置时（如本地手动运行）回退到此仓库。
+	defaultRepo    = "ZhangShenao/harness9"
+	defaultOutput  = "star-history.svg"
+	requestTimeout = 15 * time.Second
+)
+
+// dailyPoint 表示某一天结束时的累计 star 数。
+type dailyPoint struct {
+	Date  time.Time
+	Count int
+}
+
+func main() {
+	outputPath := flag.String("output", defaultOutput, "生成的 SVG 文件路径")
+	flag.Parse()
+
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	if repo == "" {
+		repo = defaultRepo
+	}
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "error: GITHUB_TOKEN environment variable is required")
+		os.Exit(1)
+	}
+
+	events, err := fetchStarEvents(defaultAPIBase, repo, token, defaultPerPage)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	points := aggregateDaily(events)
+	svg := renderSVG(repo, points)
+
+	if err := os.WriteFile(*outputPath, []byte(svg), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error: write svg: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("wrote %s (%d stars, %d data points)\n", *outputPath, len(events), len(points))
+}
+
+// fetchStarEvents 分页拉取仓库全部 stargazers 的 starred_at 时间戳，按时间升序返回。
+func fetchStarEvents(apiBase, repo, token string, perPage int) ([]time.Time, error) {
+	client := &http.Client{Timeout: requestTimeout}
+	var all []time.Time
+
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("%s/repos/%s/stargazers?per_page=%d&page=%d", apiBase, repo, perPage, page)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		// star+json 媒体类型是拿到 starred_at 时间戳的必要条件，默认响应只返回 user 对象
+		req.Header.Set("Accept", "application/vnd.github.star+json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		batch, err := requestStarPage(client, req, page)
+		if err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		all = append(all, batch...)
+		if len(batch) < perPage {
+			break
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool { return all[i].Before(all[j]) })
+	return all, nil
+}
+
+// requestStarPage 执行单页请求并解析出 starred_at 时间戳列表。
+func requestStarPage(client *http.Client, req *http.Request, page int) ([]time.Time, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request stargazers page %d: %w", page, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, fmt.Errorf("stargazers page %d returned %d (failed to read response body: %w)", page, resp.StatusCode, readErr)
+		}
+		return nil, fmt.Errorf("stargazers page %d returned %d: %s", page, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var rows []struct {
+		StarredAt time.Time `json:"starred_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rows); err != nil {
+		return nil, fmt.Errorf("decode stargazers page %d: %w", page, err)
+	}
+
+	timestamps := make([]time.Time, len(rows))
+	for i, r := range rows {
+		// 零值时间戳意味着响应里没有 starred_at 字段，通常是 Accept 头未被遵循、
+		// 退化为默认 user 列表格式——必须报错而非静默生成一张数据错乱的图表。
+		if r.StarredAt.IsZero() {
+			return nil, fmt.Errorf("stargazers page %d: entry %d missing starred_at (unexpected response format)", page, i)
+		}
+		timestamps[i] = r.StarredAt
+	}
+	return timestamps, nil
+}
+
+// aggregateDaily 将逐次 star 事件聚合为按天累计的计数曲线，并延伸到当前日期。
+// events 不要求调用方预先排序，函数内部会先复制并按时间升序排列。
+func aggregateDaily(events []time.Time) []dailyPoint {
+	if len(events) == 0 {
+		return nil
+	}
+
+	sorted := make([]time.Time, len(events))
+	copy(sorted, events)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Before(sorted[j]) })
+
+	var points []dailyPoint
+	cur := sorted[0].UTC().Truncate(24 * time.Hour)
+	count := 0
+	for _, t := range sorted {
+		day := t.UTC().Truncate(24 * time.Hour)
+		if day.After(cur) {
+			points = append(points, dailyPoint{Date: cur, Count: count})
+			cur = day
+		}
+		count++
+	}
+	points = append(points, dailyPoint{Date: cur, Count: count})
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	if today.After(cur) {
+		points = append(points, dailyPoint{Date: today, Count: count})
+	}
+	return points
+}

--- a/cmd/starhistory/main_test.go
+++ b/cmd/starhistory/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestFetchStarEventsPagination 验证跨分页拉取会合并全部结果并按时间升序排列。
+func TestFetchStarEventsPagination(t *testing.T) {
+	pages := [][]string{
+		{"2026-05-01T00:00:00Z", "2026-05-03T00:00:00Z"},
+		{"2026-05-02T00:00:00Z"},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Accept"); got != "application/vnd.github.star+json" {
+			t.Errorf("Accept header = %q, want star+json", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization header = %q, want Bearer test-token", got)
+		}
+		page := r.URL.Query().Get("page")
+		var body string
+		switch page {
+		case "1":
+			body = fmt.Sprintf(`[{"starred_at":%q},{"starred_at":%q}]`, pages[0][0], pages[0][1])
+		case "2":
+			body = fmt.Sprintf(`[{"starred_at":%q}]`, pages[1][0])
+		default:
+			body = `[]`
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	// perPage=2：第一页返回 2 条（=perPage，继续翻页），第二页返回 1 条（<perPage，终止）
+	events, err := fetchStarEvents(srv.URL, "owner/repo", "test-token", 2)
+	if err != nil {
+		t.Fatalf("fetchStarEvents returned error: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	for i := 1; i < len(events); i++ {
+		if events[i].Before(events[i-1]) {
+			t.Errorf("events not sorted ascending: %v before %v", events[i], events[i-1])
+		}
+	}
+}
+
+// TestFetchStarEventsErrorResponse 验证非 200 响应会被包装为可读错误而非静默丢弃。
+func TestFetchStarEventsErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Not Found"))
+	}))
+	defer srv.Close()
+
+	_, err := fetchStarEvents(srv.URL, "owner/repo", "test-token", 100)
+	if err == nil {
+		t.Fatal("expected error for 403 response, got nil")
+	}
+}
+
+// TestFetchStarEventsMissingStarredAt 验证响应缺少 starred_at 字段（如 Accept 头未被遵循，
+// 退化为默认 user 列表格式）时会显式报错，而不是静默生成零值时间戳。
+func TestFetchStarEventsMissingStarredAt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"login":"octocat"}]`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchStarEvents(srv.URL, "owner/repo", "test-token", 100)
+	if err == nil {
+		t.Fatal("expected error when starred_at is missing, got nil")
+	}
+}
+
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return tm
+}
+
+// TestAggregateDaily 验证按天聚合累计计数、同日多次 star 合并、乱序输入、并延伸到当前日期。
+func TestAggregateDaily(t *testing.T) {
+	t.Run("空输入返回空", func(t *testing.T) {
+		if got := aggregateDaily(nil); got != nil {
+			t.Errorf("aggregateDaily(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("同日多次star合并为一个点", func(t *testing.T) {
+		events := []time.Time{
+			mustParse(t, "2026-05-01T01:00:00Z"),
+			mustParse(t, "2026-05-01T23:00:00Z"),
+		}
+		points := aggregateDaily(events)
+		if len(points) < 1 || points[0].Count != 2 {
+			t.Fatalf("got points=%v, want first point Count=2", points)
+		}
+	})
+
+	t.Run("跨天累计单调不减", func(t *testing.T) {
+		events := []time.Time{
+			mustParse(t, "2026-05-01T00:00:00Z"),
+			mustParse(t, "2026-05-02T00:00:00Z"),
+			mustParse(t, "2026-05-02T12:00:00Z"),
+			mustParse(t, "2026-05-04T00:00:00Z"),
+		}
+		points := aggregateDaily(events)
+		wantCounts := []int{1, 3, 4}
+		if len(points) < len(wantCounts) {
+			t.Fatalf("got %d points, want at least %d: %+v", len(points), len(wantCounts), points)
+		}
+		for i, want := range wantCounts {
+			if points[i].Count != want {
+				t.Errorf("points[%d].Count = %d, want %d", i, points[i].Count, want)
+			}
+		}
+		for i := 1; i < len(points); i++ {
+			if points[i].Count < points[i-1].Count {
+				t.Errorf("count decreased at index %d: %+v", i, points)
+			}
+		}
+	})
+
+	t.Run("乱序输入结果与升序输入一致", func(t *testing.T) {
+		ordered := []time.Time{
+			mustParse(t, "2026-05-01T00:00:00Z"),
+			mustParse(t, "2026-05-02T00:00:00Z"),
+			mustParse(t, "2026-05-04T00:00:00Z"),
+		}
+		shuffled := []time.Time{ordered[2], ordered[0], ordered[1]}
+
+		want := aggregateDaily(ordered)
+		got := aggregateDaily(shuffled)
+		if len(got) != len(want) {
+			t.Fatalf("got %d points, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if !got[i].Date.Equal(want[i].Date) || got[i].Count != want[i].Count {
+				t.Errorf("points[%d] = %+v, want %+v", i, got[i], want[i])
+			}
+		}
+	})
+}

--- a/cmd/starhistory/render.go
+++ b/cmd/starhistory/render.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	svgWidth  = 860
+	svgHeight = 420
+	padLeft   = 56
+	padRight  = 24
+	padTop    = 48
+	padBottom = 40
+	gridLines = 4
+	xTicks    = 5
+)
+
+// renderSVG 将按天累计的 star 曲线渲染为一张支持 GitHub 明暗主题自适应的 SVG 图表。
+func renderSVG(repo string, points []dailyPoint) string {
+	plotW := float64(svgWidth - padLeft - padRight)
+	plotH := float64(svgHeight - padTop - padBottom)
+
+	minDate, maxDate := dateRange(points)
+	hoursSpan := maxDate.Sub(minDate).Hours()
+	if hoursSpan <= 0 {
+		hoursSpan = 1
+	}
+	yMax := float64(maxCount(points)) * 1.15
+	if yMax <= 0 {
+		yMax = 1
+	}
+
+	x := func(d time.Time) float64 { return float64(padLeft) + d.Sub(minDate).Hours()/hoursSpan*plotW }
+	y := func(c int) float64 { return float64(padTop) + plotH - float64(c)/yMax*plotH }
+
+	linePath, areaPath := buildPaths(points, x, y)
+
+	generated := time.Now().UTC().Format("2006-01-02 15:04 UTC")
+
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%d" height="%d" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+  <style>
+    .bg { fill: #ffffff; }
+    .grid { stroke: #d0d7de; stroke-width: 1; }
+    .axis { fill: #57606a; font-size: 12px; }
+    .title { fill: #24292f; font-size: 16px; font-weight: 600; }
+    .footer { fill: #8c959f; font-size: 11px; }
+    .area { fill: #2f81f7; opacity: 0.12; }
+    .line { stroke: #2f81f7; stroke-width: 2; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0d1117; }
+      .grid { stroke: #30363d; }
+      .axis { fill: #8b949e; }
+      .title { fill: #c9d1d9; }
+      .footer { fill: #6e7681; }
+      .area { fill: #58a6ff; opacity: 0.15; }
+      .line { stroke: #58a6ff; }
+    }
+  </style>
+  <rect class="bg" x="0" y="0" width="%d" height="%d"/>
+  <text class="title" x="%d" y="26">%s Star History</text>
+  %s
+  %s
+  <path class="area" d="%s"/>
+  <path class="line" d="%s"/>
+  %s
+  <text class="footer" x="%d" y="%d" text-anchor="end">自动生成 · %s</text>
+</svg>`,
+		svgWidth, svgHeight, svgWidth, svgHeight,
+		svgWidth, svgHeight,
+		padLeft, repo,
+		renderYGrid(plotH),
+		renderYLabels(yMax, plotH),
+		areaPath,
+		linePath,
+		renderXLabels(minDate, hoursSpan, x),
+		svgWidth-padRight, svgHeight-6, generated,
+	)
+}
+
+// dateRange 返回数据点覆盖的起止日期，空数据时退化为当前日期的单点区间。
+func dateRange(points []dailyPoint) (time.Time, time.Time) {
+	if len(points) == 0 {
+		now := time.Now().UTC()
+		return now, now
+	}
+	return points[0].Date, points[len(points)-1].Date
+}
+
+// maxCount 返回数据点中的最大累计值，空数据时返回 0。
+func maxCount(points []dailyPoint) int {
+	m := 0
+	for _, p := range points {
+		m = max(m, p.Count)
+	}
+	return m
+}
+
+// buildPaths 将数据点转换为折线与其下方填充区域的 SVG path 描述。
+func buildPaths(points []dailyPoint, x func(time.Time) float64, y func(int) float64) (line, area string) {
+	if len(points) == 0 {
+		return "", ""
+	}
+	coords := make([]string, len(points))
+	for i, p := range points {
+		coords[i] = fmt.Sprintf("%.1f,%.1f", x(p.Date), y(p.Count))
+	}
+	line = "M " + strings.Join(coords, " L ")
+	area = fmt.Sprintf("%s L %.1f,%.1f L %.1f,%.1f Z", line, x(points[len(points)-1].Date), y(0), x(points[0].Date), y(0))
+	return line, area
+}
+
+// renderYGrid 绘制水平网格线。
+func renderYGrid(plotH float64) string {
+	var b strings.Builder
+	for i := 0; i <= gridLines; i++ {
+		frac := float64(i) / float64(gridLines)
+		gy := float64(padTop) + plotH*(1-frac)
+		fmt.Fprintf(&b, `<line class="grid" x1="%d" y1="%.1f" x2="%d" y2="%.1f"/>`, padLeft, gy, svgWidth-padRight, gy)
+	}
+	return b.String()
+}
+
+// renderYLabels 绘制纵轴的累计 star 数刻度标签。
+func renderYLabels(yMax, plotH float64) string {
+	var b strings.Builder
+	for i := 0; i <= gridLines; i++ {
+		frac := float64(i) / float64(gridLines)
+		gy := float64(padTop) + plotH*(1-frac)
+		val := int(yMax * frac)
+		fmt.Fprintf(&b, `<text class="axis" x="%d" y="%.1f" text-anchor="end">%d</text>`, padLeft-8, gy+4, val)
+	}
+	return b.String()
+}
+
+// renderXLabels 绘制横轴的日期刻度标签。
+func renderXLabels(minDate time.Time, hoursSpan float64, x func(time.Time) float64) string {
+	var b strings.Builder
+	for i := 0; i <= xTicks; i++ {
+		frac := float64(i) / float64(xTicks)
+		t := minDate.Add(time.Duration(hoursSpan*frac) * time.Hour)
+		fmt.Fprintf(&b, `<text class="axis" x="%.1f" y="%d" text-anchor="middle">%s</text>`, x(t), svgHeight-padBottom+20, t.Format("2006-01-02"))
+	}
+	return b.String()
+}

--- a/cmd/starhistory/render_test.go
+++ b/cmd/starhistory/render_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+	"time"
+)
+
+func day(t *testing.T, s string) time.Time {
+	t.Helper()
+	tm, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return tm
+}
+
+// TestDateRange 验证起止日期取自首末数据点，空数据退化为当前日期的单点区间。
+func TestDateRange(t *testing.T) {
+	t.Run("空数据", func(t *testing.T) {
+		min, max := dateRange(nil)
+		if min.IsZero() || max.IsZero() || !min.Equal(max) {
+			t.Errorf("dateRange(nil) = (%v, %v), want equal non-zero timestamps", min, max)
+		}
+	})
+
+	t.Run("多点取首末", func(t *testing.T) {
+		points := []dailyPoint{
+			{Date: day(t, "2026-05-01"), Count: 1},
+			{Date: day(t, "2026-05-10"), Count: 5},
+			{Date: day(t, "2026-05-20"), Count: 9},
+		}
+		min, max := dateRange(points)
+		if !min.Equal(points[0].Date) || !max.Equal(points[2].Date) {
+			t.Errorf("dateRange = (%v, %v), want (%v, %v)", min, max, points[0].Date, points[2].Date)
+		}
+	})
+}
+
+// TestMaxCount 验证最大值提取，空数据返回 0。
+func TestMaxCount(t *testing.T) {
+	cases := []struct {
+		name   string
+		points []dailyPoint
+		want   int
+	}{
+		{"空数据", nil, 0},
+		{"单点", []dailyPoint{{Count: 7}}, 7},
+		{"非单调也能取到最大值", []dailyPoint{{Count: 3}, {Count: 9}, {Count: 5}}, 9},
+	}
+	for _, c := range cases {
+		if got := maxCount(c.points); got != c.want {
+			t.Errorf("%s: maxCount() = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+// TestBuildPaths 验证空数据返回空 path，非空数据首尾闭合成合法的填充区域。
+func TestBuildPaths(t *testing.T) {
+	x := func(t time.Time) float64 { return float64(t.Unix()) }
+	y := func(c int) float64 { return float64(100 - c) }
+
+	t.Run("空数据", func(t *testing.T) {
+		line, area := buildPaths(nil, x, y)
+		if line != "" || area != "" {
+			t.Errorf("buildPaths(nil) = (%q, %q), want empty strings", line, area)
+		}
+	})
+
+	t.Run("非空数据以M开头且area以Z闭合", func(t *testing.T) {
+		points := []dailyPoint{
+			{Date: day(t, "2026-05-01"), Count: 1},
+			{Date: day(t, "2026-05-02"), Count: 2},
+		}
+		line, area := buildPaths(points, x, y)
+		if !strings.HasPrefix(line, "M ") {
+			t.Errorf("line path = %q, want prefix %q", line, "M ")
+		}
+		if !strings.HasSuffix(area, "Z") {
+			t.Errorf("area path = %q, want suffix %q", area, "Z")
+		}
+		if !strings.HasPrefix(area, line) {
+			t.Errorf("area path should extend line path, line=%q area=%q", line, area)
+		}
+	})
+}
+
+// TestRenderSVGWellFormed 验证渲染结果是合法 XML，且包含仓库名与预期结构元素。
+func TestRenderSVGWellFormed(t *testing.T) {
+	points := []dailyPoint{
+		{Date: day(t, "2026-05-01"), Count: 1},
+		{Date: day(t, "2026-06-01"), Count: 10},
+		{Date: day(t, "2026-07-01"), Count: 42},
+	}
+	svg := renderSVG("owner/repo", points)
+
+	if !strings.Contains(svg, "owner/repo") {
+		t.Errorf("svg does not contain repo name, got: %s", svg)
+	}
+	if !strings.Contains(svg, "prefers-color-scheme: dark") {
+		t.Errorf("svg missing dark-mode media query")
+	}
+	if err := xml.Unmarshal([]byte(svg), new(any)); err != nil {
+		t.Errorf("renderSVG output is not well-formed XML: %v", err)
+	}
+}
+
+// TestRenderSVGEmptyPoints 验证无数据点时不会 panic 或产生除零错误。
+func TestRenderSVGEmptyPoints(t *testing.T) {
+	svg := renderSVG("owner/repo", nil)
+	if err := xml.Unmarshal([]byte(svg), new(any)); err != nil {
+		t.Errorf("renderSVG(nil) output is not well-formed XML: %v", err)
+	}
+}

--- a/star-history.svg
+++ b/star-history.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 420" width="860" height="420" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+  <style>
+    .bg { fill: #ffffff; }
+    .grid { stroke: #d0d7de; stroke-width: 1; }
+    .axis { fill: #57606a; font-size: 12px; }
+    .title { fill: #24292f; font-size: 16px; font-weight: 600; }
+    .footer { fill: #8c959f; font-size: 11px; }
+    .area { fill: #2f81f7; opacity: 0.12; }
+    .line { stroke: #2f81f7; stroke-width: 2; fill: none; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0d1117; }
+      .grid { stroke: #30363d; }
+      .axis { fill: #8b949e; }
+      .title { fill: #c9d1d9; }
+      .footer { fill: #6e7681; }
+      .area { fill: #58a6ff; opacity: 0.15; }
+      .line { stroke: #58a6ff; }
+    }
+  </style>
+  <rect class="bg" x="0" y="0" width="860" height="420"/>
+  <text class="title" x="56" y="26">ZhangShenao/harness9 Star History</text>
+  <line class="grid" x1="56" y1="380.0" x2="836" y2="380.0"/><line class="grid" x1="56" y1="297.0" x2="836" y2="297.0"/><line class="grid" x1="56" y1="214.0" x2="836" y2="214.0"/><line class="grid" x1="56" y1="131.0" x2="836" y2="131.0"/><line class="grid" x1="56" y1="48.0" x2="836" y2="48.0"/>
+  <text class="axis" x="48" y="384.0" text-anchor="end">0</text><text class="axis" x="48" y="301.0" text-anchor="end">39</text><text class="axis" x="48" y="218.0" text-anchor="end">78</text><text class="axis" x="48" y="135.0" text-anchor="end">117</text><text class="axis" x="48" y="52.0" text-anchor="end">156</text>
+  <path class="area" d="M 56.0,363.0 L 150.1,360.9 L 163.6,358.8 L 203.9,356.6 L 217.4,352.4 L 230.8,348.2 L 271.2,339.7 L 284.6,335.4 L 311.5,333.3 L 325.0,312.1 L 338.4,303.6 L 351.9,293.0 L 365.3,280.2 L 378.8,259.0 L 392.2,233.5 L 405.7,210.2 L 419.1,189.0 L 432.6,163.5 L 446.0,150.7 L 459.4,140.1 L 472.9,108.3 L 620.8,104.0 L 674.6,101.9 L 688.1,99.8 L 741.9,97.7 L 809.1,95.5 L 836.0,91.3 L 836.0,380.0 L 56.0,380.0 Z"/>
+  <path class="line" d="M 56.0,363.0 L 150.1,360.9 L 163.6,358.8 L 203.9,356.6 L 217.4,352.4 L 230.8,348.2 L 271.2,339.7 L 284.6,335.4 L 311.5,333.3 L 325.0,312.1 L 338.4,303.6 L 351.9,293.0 L 365.3,280.2 L 378.8,259.0 L 392.2,233.5 L 405.7,210.2 L 419.1,189.0 L 432.6,163.5 L 446.0,150.7 L 459.4,140.1 L 472.9,108.3 L 620.8,104.0 L 674.6,101.9 L 688.1,99.8 L 741.9,97.7 L 809.1,95.5 L 836.0,91.3"/>
+  <text class="axis" x="56.0" y="400" text-anchor="middle">2026-05-19</text><text class="axis" x="211.8" y="400" text-anchor="middle">2026-05-30</text><text class="axis" x="367.6" y="400" text-anchor="middle">2026-06-11</text><text class="axis" x="523.9" y="400" text-anchor="middle">2026-06-22</text><text class="axis" x="679.7" y="400" text-anchor="middle">2026-07-04</text><text class="axis" x="836.0" y="400" text-anchor="middle">2026-07-16</text>
+  <text class="footer" x="836" y="414" text-anchor="end">自动生成 · 2026-07-16 07:45 UTC</text>
+</svg>


### PR DESCRIPTION
## Summary
- GitHub 于 2026-06-30 起限制 stargazers API，仅允许仓库自身的 owner/collaborator 读取星标时间戳，导致 star-history.com 等第三方服务无法再为非自有仓库生成图表，README 中的实时徽章因此普遍失效（非本仓库特有问题，直接请求验证 `facebook/react` 等仓库同样受影响）
- 新增 `cmd/starhistory` 工具：零新增依赖，用仓库自身 `GITHUB_TOKEN` 分页抓取 stargazers 时间戳、按天聚合累计曲线、渲染支持 GitHub 明暗主题自适应的 SVG
- 新增 `.github/workflows/star-history.yml`：每日 UTC 0 点 + 手动触发，生成图表并提交回仓库，不再依赖任何第三方服务的运行时可用性
- `README.md` 图表引用改为本地静态文件 `star-history.svg`，并说明原因与来源

## Test Plan
- [x] `go build ./...`、`go vet ./...`、`gofmt -l .`、`goimports -l .` 全部通过
- [x] `go test ./... -race` 全量通过，`cmd/starhistory` 新增测试覆盖分页、错误响应、缺失 `starred_at` 校验、按天聚合（含乱序输入）、SVG 合法性
- [x] 用真实 `GITHUB_TOKEN` 对本仓库端到端跑通生成逻辑（136 stars、27 个数据点），产出 SVG 经 XML 校验合法
- [ ] 合并后手动触发一次 `gh workflow run star-history.yml`，确认 Actions 运行时默认 `GITHUB_TOKEN` 同样具备读取 stargazers 时间戳的权限