### PR TITLE
feat: M2 Scheduler — dispatch loop, concurrency limits, crash recovery

### DIFF
--- a/internal/mission/policy.go
+++ b/internal/mission/policy.go
@@ -1,0 +1,37 @@
+package mission
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Policy describes Scheduler-enforced limits derived from a Mission's PolicyJSON.
+// Only concurrency is defined so far; approval/retry/tool-scope policy fields are
+// added by later Mission Control milestones once their consumers exist.
+type Policy struct {
+	// MaxConcurrentTasks caps how many Tasks the Scheduler may run at once for
+	// one Mission. Missing or zero in PolicyJSON defaults to 1.
+	MaxConcurrentTasks int
+}
+
+// ParsePolicy decodes a Mission's PolicyJSON into a Policy with defaults applied.
+func ParsePolicy(raw string) (Policy, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = "{}"
+	}
+	var decoded struct {
+		MaxConcurrentTasks int `json:"max_concurrent_tasks"`
+	}
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return Policy{}, fmt.Errorf("decode mission policy: %w", err)
+	}
+	if decoded.MaxConcurrentTasks < 0 {
+		return Policy{}, fmt.Errorf("policy max_concurrent_tasks cannot be negative")
+	}
+	if decoded.MaxConcurrentTasks == 0 {
+		decoded.MaxConcurrentTasks = 1
+	}
+	return Policy{MaxConcurrentTasks: decoded.MaxConcurrentTasks}, nil
+}

--- a/internal/mission/policy_test.go
+++ b/internal/mission/policy_test.go
@@ -1,0 +1,39 @@
+package mission
+
+import "testing"
+
+func TestParsePolicyDefaultsMaxConcurrentTasksToOne(t *testing.T) {
+	tests := []string{"", "{}", `{"max_concurrent_tasks":0}`}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			policy, err := ParsePolicy(raw)
+			if err != nil {
+				t.Fatalf("ParsePolicy(%q): %v", raw, err)
+			}
+			if policy.MaxConcurrentTasks != 1 {
+				t.Fatalf("MaxConcurrentTasks = %d, want 1", policy.MaxConcurrentTasks)
+			}
+		})
+	}
+}
+
+func TestParsePolicyReadsMaxConcurrentTasks(t *testing.T) {
+	policy, err := ParsePolicy(`{"max_concurrent_tasks":3}`)
+	if err != nil {
+		t.Fatalf("ParsePolicy: %v", err)
+	}
+	if policy.MaxConcurrentTasks != 3 {
+		t.Fatalf("MaxConcurrentTasks = %d, want 3", policy.MaxConcurrentTasks)
+	}
+}
+
+func TestParsePolicyRejectsInvalidInput(t *testing.T) {
+	tests := []string{`{`, `{"max_concurrent_tasks":-1}`, `[]`}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParsePolicy(raw); err == nil {
+				t.Fatalf("ParsePolicy(%q) = nil error, want an error", raw)
+			}
+		})
+	}
+}

--- a/internal/mission/scheduler_store.go
+++ b/internal/mission/scheduler_store.go
@@ -1,0 +1,124 @@
+package mission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ListSchedulableTasks returns queued Tasks whose Mission is eligible to run
+// and whose Plan version matches the Mission's current approved Plan version.
+// Results are ordered oldest first so Wave-style dispatch processes Tasks FIFO.
+func (s *Store) ListSchedulableTasks(ctx context.Context) ([]Task, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT tasks.id, tasks.mission_id, tasks.title, COALESCE(tasks.client_id, ''),
+		       tasks.position, tasks.contract, tasks.status, tasks.created_at, tasks.updated_at
+		FROM tasks
+		JOIN missions ON missions.id = tasks.mission_id
+		WHERE tasks.status = ?
+		  AND tasks.plan_version = missions.current_plan_version
+		  AND missions.status IN (?, ?)
+		ORDER BY tasks.created_at ASC, tasks.id ASC`,
+		TaskQueued, MissionReady, MissionRunning)
+	if err != nil {
+		return nil, fmt.Errorf("list schedulable tasks: %w", err)
+	}
+	defer rows.Close()
+	var tasks []Task
+	for rows.Next() {
+		task, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		task.DependsOn, err = s.taskDependencies(ctx, task.ID)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schedulable tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// ActiveTaskCounts returns the number of Tasks with an in-flight lease (leased
+// or running) grouped by Mission ID, plus the global total across all Missions.
+func (s *Store) ActiveTaskCounts(ctx context.Context) (map[string]int, int, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT mission_id, COUNT(*)
+		FROM tasks
+		WHERE status IN (?, ?)
+		GROUP BY mission_id`,
+		TaskLeased, TaskRunning)
+	if err != nil {
+		return nil, 0, fmt.Errorf("count active tasks: %w", err)
+	}
+	defer rows.Close()
+	perMission := make(map[string]int)
+	total := 0
+	for rows.Next() {
+		var missionID string
+		var count int
+		if err := rows.Scan(&missionID, &count); err != nil {
+			return nil, 0, fmt.Errorf("scan active task count: %w", err)
+		}
+		perMission[missionID] = count
+		total += count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate active task counts: %w", err)
+	}
+	return perMission, total, nil
+}
+
+// MarkMissionRunning transitions a ready Mission into running the first time
+// the Scheduler dispatches into it. Calling it again on an already-running
+// Mission is a no-op so the Scheduler can call it unconditionally.
+func (s *Store) MarkMissionRunning(ctx context.Context, missionID string) (Mission, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Mission{}, fmt.Errorf("begin mission running transition: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	mission, err := scanMission(tx.QueryRowContext(ctx, `
+		SELECT id, goal, acceptance_contract, budget_cents, policy_json,
+		       current_plan_version, status, created_at, updated_at
+		FROM missions WHERE id = ?`, missionID))
+	if err != nil {
+		return Mission{}, wrapMissionNotFound(missionID, err)
+	}
+	if mission.Status == MissionRunning {
+		return mission, nil
+	}
+	if !mission.Status.CanTransitionTo(MissionRunning) {
+		return Mission{}, fmt.Errorf(
+			"%w: mission %s cannot move from %s to %s",
+			ErrInvalidTransition, missionID, mission.Status, MissionRunning,
+		)
+	}
+	now := s.currentTime()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE missions SET status = ?, updated_at = ? WHERE id = ?`,
+		MissionRunning, unixMillis(now), missionID,
+	); err != nil {
+		return Mission{}, fmt.Errorf("mark mission running: %w", err)
+	}
+	payload, err := json.Marshal(map[string]any{"from": mission.Status, "to": MissionRunning})
+	if err != nil {
+		return Mission{}, fmt.Errorf("marshal mission.running event: %w", err)
+	}
+	if err := insertEvent(ctx, tx, Event{
+		ID: newID(), MissionID: missionID, Type: "mission.running",
+		Payload: payload, CreatedAt: now,
+	}); err != nil {
+		return Mission{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Mission{}, fmt.Errorf("commit mission running transition: %w", err)
+	}
+	mission.Status = MissionRunning
+	mission.UpdatedAt = now
+	return mission, nil
+}

--- a/internal/mission/scheduler_store_test.go
+++ b/internal/mission/scheduler_store_test.go
@@ -1,0 +1,126 @@
+package mission
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestListSchedulableTasksReturnsQueuedRootTaskForApprovedPlan(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, samplePlanInput(), "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks, err := store.ListSchedulableTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListSchedulableTasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].ClientID != "spec" || tasks[0].Status != TaskQueued {
+		t.Fatalf("schedulable tasks = %+v, want only the queued root task \"spec\"", tasks)
+	}
+}
+
+func TestListSchedulableTasksExcludesSupersededPlanVersion(t *testing.T) {
+	store, mission := newApprovedRunningMission(t)
+	v1Tasks, err := store.ListSchedulableTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListSchedulableTasks (v1): %v", err)
+	}
+	if len(v1Tasks) != 1 {
+		t.Fatalf("v1 schedulable tasks = %+v, want exactly the root \"spec\" task", v1Tasks)
+	}
+	v1SpecTaskID := v1Tasks[0].ID
+
+	request, err := store.createPlanChangeRequest(
+		context.Background(), mission.ID, mission.CurrentPlanVersion, revisedPlanInput(), "missing docs", "coordinator",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := NewCommandService(store)
+	if _, err := svc.ResolvePlanChange(context.Background(), ResolvePlanChangeCommand{
+		MissionID:       mission.ID,
+		ChangeRequestID: request.ID,
+		Plan:            revisedPlanInput(),
+		Approve:         true,
+		Actor:           "user:zsa",
+		Reason:          "approve v2",
+		IdempotencyKey:  "resolve-v2",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	v2Tasks, err := store.ListSchedulableTasks(context.Background())
+	if err != nil {
+		t.Fatalf("ListSchedulableTasks (v2): %v", err)
+	}
+	for _, task := range v2Tasks {
+		if task.ID == v1SpecTaskID {
+			t.Fatalf("schedulable tasks after the plan change still include the superseded v1 task: %+v", task)
+		}
+	}
+	foundV2Root := false
+	for _, task := range v2Tasks {
+		if task.ClientID == "docs" {
+			foundV2Root = true
+		}
+	}
+	if !foundV2Root {
+		t.Fatalf("v2 schedulable tasks = %+v, want the new version's \"docs\" root task", v2Tasks)
+	}
+}
+
+func TestActiveTaskCountsGroupsLeasedAndRunningByMission(t *testing.T) {
+	store, attempt := newRunningAttempt(t)
+	task, err := store.GetTask(context.Background(), attempt.TaskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	perMission, total, err := store.ActiveTaskCounts(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveTaskCounts: %v", err)
+	}
+	if perMission[task.MissionID] != 1 || total != 1 {
+		t.Fatalf("ActiveTaskCounts = %+v/%d, want 1/1 for mission %s", perMission, total, task.MissionID)
+	}
+}
+
+func TestMarkMissionRunningTransitionsReadyToRunningIdempotently(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, samplePlanInput(), "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.MarkMissionRunning(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatalf("MarkMissionRunning: %v", err)
+	}
+	if got.Status != MissionRunning {
+		t.Fatalf("Status = %s, want running", got.Status)
+	}
+
+	again, err := store.MarkMissionRunning(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatalf("MarkMissionRunning (repeat call): %v", err)
+	}
+	if again.Status != MissionRunning {
+		t.Fatalf("Status = %s, want running on repeat call", again.Status)
+	}
+}
+
+func TestMarkMissionRunningRejectsMissionNotReady(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	if _, err := store.MarkMissionRunning(context.Background(), mission.ID); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("MarkMissionRunning on draft mission: err = %v, want ErrInvalidTransition", err)
+	}
+}

--- a/internal/scheduler/run.go
+++ b/internal/scheduler/run.go
@@ -1,0 +1,50 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/harness9/internal/logfmt"
+)
+
+// RecoverInterrupted reconciles Attempts left running by a previous process
+// that exited without a clean shutdown, marking them indeterminate for later
+// reconciliation instead of silently retrying them. Call it once before Run's
+// first Tick.
+func (s *Scheduler) RecoverInterrupted(ctx context.Context) (int, error) {
+	count, err := s.store.MarkInterruptedAttemptsIndeterminate(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("recover interrupted attempts: %w", err)
+	}
+	if count > 0 {
+		log.Print(logfmt.FormatMsg("scheduler", fmt.Sprintf("对账 %d 个中断 Attempt 为 indeterminate", count)))
+	}
+	return count, nil
+}
+
+// Run recovers interrupted Attempts once, then calls Tick on every interval
+// until ctx is cancelled. Tick errors are logged, not returned, so one failing
+// Task or Mission never stops the dispatch loop for the rest of the fleet.
+func (s *Scheduler) Run(ctx context.Context, interval time.Duration) error {
+	if _, err := s.RecoverInterrupted(ctx); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			dispatched, err := s.Tick(ctx)
+			if err != nil {
+				log.Print(logfmt.FormatMsg("scheduler", fmt.Sprintf("tick 出错: %v", err)))
+			}
+			if dispatched > 0 {
+				log.Print(logfmt.FormatMsg("scheduler", fmt.Sprintf("本轮调度 %d 个 Task", dispatched)))
+			}
+		}
+	}
+}

--- a/internal/scheduler/run.go
+++ b/internal/scheduler/run.go
@@ -28,6 +28,9 @@ func (s *Scheduler) RecoverInterrupted(ctx context.Context) (int, error) {
 // until ctx is cancelled. Tick errors are logged, not returned, so one failing
 // Task or Mission never stops the dispatch loop for the rest of the fleet.
 func (s *Scheduler) Run(ctx context.Context, interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("scheduler run interval must be positive")
+	}
 	if _, err := s.RecoverInterrupted(ctx); err != nil {
 		return err
 	}

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -1,0 +1,51 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRecoverInterruptedMarksRunningAttemptsIndeterminate(t *testing.T) {
+	store := newTestStore(t)
+	approvedMissionWithTwoRootTasks(t, store, `{"max_concurrent_tasks":2}`)
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(10))
+	dispatched, err := s.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if dispatched != 2 {
+		t.Fatalf("dispatched = %d, want 2 running attempts before recovery", dispatched)
+	}
+
+	count, err := s.RecoverInterrupted(context.Background())
+	if err != nil {
+		t.Fatalf("RecoverInterrupted: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("RecoverInterrupted count = %d, want 2", count)
+	}
+}
+
+func TestRunStopsWhenContextIsCancelled(t *testing.T) {
+	store := newTestStore(t)
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(10))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx, 5*time.Millisecond) }()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not stop within 1s of context cancellation")
+	}
+}

--- a/internal/scheduler/run_test.go
+++ b/internal/scheduler/run_test.go
@@ -49,3 +49,16 @@ func TestRunStopsWhenContextIsCancelled(t *testing.T) {
 		t.Fatal("Run did not stop within 1s of context cancellation")
 	}
 }
+
+func TestRunRejectsNonPositiveInterval(t *testing.T) {
+	store := newTestStore(t)
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(10))
+
+	if err := s.Run(context.Background(), 0); err == nil {
+		t.Fatal("Run(interval=0) error = nil, want an error")
+	}
+	if err := s.Run(context.Background(), -time.Second); err == nil {
+		t.Fatal("Run(interval=-1s) error = nil, want an error")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -70,6 +70,7 @@ func (s *Scheduler) Tick(ctx context.Context) (int, error) {
 
 	remainingGlobal := s.maxGlobalConcurrency - globalActive
 	policies := make(map[string]mission.Policy)
+	policyErrors := make(map[string]error)
 	dispatched := 0
 	var dispatchErrors []error
 
@@ -77,10 +78,15 @@ func (s *Scheduler) Tick(ctx context.Context) (int, error) {
 		if remainingGlobal <= 0 {
 			break
 		}
+		if prepErr, failed := policyErrors[task.MissionID]; failed {
+			dispatchErrors = append(dispatchErrors, fmt.Errorf("task %s: %w", task.ID, prepErr))
+			continue
+		}
 		policy, cached := policies[task.MissionID]
 		if !cached {
 			policy, err = s.prepareMission(ctx, task.MissionID)
 			if err != nil {
+				policyErrors[task.MissionID] = err
 				dispatchErrors = append(dispatchErrors, fmt.Errorf("task %s: %w", task.ID, err))
 				continue
 			}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,120 @@
+// Package scheduler assigns queued Mission Control Tasks to Workers without
+// using an LLM for any safety-critical decision. It only reads and writes
+// durable state through internal/mission.Store, so a restarted Scheduler
+// resumes from the same source of truth instead of private memory.
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/harness9/internal/mission"
+)
+
+// Dispatcher launches one Worker Attempt for a schedulable Task. Implementations
+// must leave the Task in mission.TaskQueued when Dispatch returns an error, so
+// the Scheduler retries the Task on a later Tick instead of losing it.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, task mission.Task) error
+}
+
+// Scheduler assigns queued Tasks to a Dispatcher within global and per-Mission
+// concurrency limits. It holds no unpersisted state: every Tick re-reads the
+// durable Store, so it is safe to construct a fresh Scheduler after a restart.
+type Scheduler struct {
+	store                *mission.Store
+	dispatcher           Dispatcher
+	maxGlobalConcurrency int
+}
+
+// Option configures a Scheduler constructed by NewScheduler.
+type Option func(*Scheduler)
+
+// WithMaxGlobalConcurrency caps how many Tasks may be leased across all
+// Missions at once. n must be positive; non-positive values are ignored and
+// the default of 4 is kept.
+func WithMaxGlobalConcurrency(n int) Option {
+	return func(s *Scheduler) {
+		if n > 0 {
+			s.maxGlobalConcurrency = n
+		}
+	}
+}
+
+// NewScheduler creates a Scheduler backed by store and dispatcher.
+func NewScheduler(store *mission.Store, dispatcher Dispatcher, opts ...Option) *Scheduler {
+	s := &Scheduler{store: store, dispatcher: dispatcher, maxGlobalConcurrency: 4}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Tick performs one non-blocking dispatch pass: it lists schedulable Tasks,
+// respects global and per-Mission concurrency limits, transitions each
+// Mission from ready to running the first time it dispatches into it, and
+// calls Dispatcher.Dispatch for every Task within budget. It returns how many
+// Tasks it dispatched and a joined error for Tasks it could not dispatch;
+// those Tasks remain queued and are retried on a later Tick. Tick is not safe
+// for concurrent use — call it from a single goroutine (see Run).
+func (s *Scheduler) Tick(ctx context.Context) (int, error) {
+	perMissionActive, globalActive, err := s.store.ActiveTaskCounts(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count active tasks: %w", err)
+	}
+	tasks, err := s.store.ListSchedulableTasks(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list schedulable tasks: %w", err)
+	}
+
+	remainingGlobal := s.maxGlobalConcurrency - globalActive
+	policies := make(map[string]mission.Policy)
+	dispatched := 0
+	var dispatchErrors []error
+
+	for _, task := range tasks {
+		if remainingGlobal <= 0 {
+			break
+		}
+		policy, cached := policies[task.MissionID]
+		if !cached {
+			policy, err = s.prepareMission(ctx, task.MissionID)
+			if err != nil {
+				dispatchErrors = append(dispatchErrors, fmt.Errorf("task %s: %w", task.ID, err))
+				continue
+			}
+			policies[task.MissionID] = policy
+		}
+		if perMissionActive[task.MissionID] >= policy.MaxConcurrentTasks {
+			continue
+		}
+		if err := s.dispatcher.Dispatch(ctx, task); err != nil {
+			dispatchErrors = append(dispatchErrors, fmt.Errorf("task %s: %w", task.ID, err))
+			continue
+		}
+		perMissionActive[task.MissionID]++
+		remainingGlobal--
+		dispatched++
+	}
+	return dispatched, errors.Join(dispatchErrors...)
+}
+
+// prepareMission loads a Mission's Policy and, the first time this Tick sees a
+// ready Mission, transitions it to running before any Task is dispatched.
+func (s *Scheduler) prepareMission(ctx context.Context, missionID string) (mission.Policy, error) {
+	m, err := s.store.GetMission(ctx, missionID)
+	if err != nil {
+		return mission.Policy{}, fmt.Errorf("load mission: %w", err)
+	}
+	policy, err := mission.ParsePolicy(m.PolicyJSON)
+	if err != nil {
+		return mission.Policy{}, fmt.Errorf("parse mission policy: %w", err)
+	}
+	if m.Status == mission.MissionReady {
+		if _, err := s.store.MarkMissionRunning(ctx, missionID); err != nil {
+			return mission.Policy{}, fmt.Errorf("mark mission running: %w", err)
+		}
+	}
+	return policy, nil
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -153,3 +153,18 @@ func TestTickLeavesFailedTaskQueuedAndContinuesOthers(t *testing.T) {
 		t.Fatalf("failed task status = %s, want queued so it retries next tick", failedTask.Status)
 	}
 }
+
+func TestTickCachesPolicyErrorPerMissionWithinOneTick(t *testing.T) {
+	store := newTestStore(t)
+	approvedMissionWithTwoRootTasks(t, store, `{"max_concurrent_tasks":-1}`)
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(10))
+
+	dispatched, err := s.Tick(context.Background())
+	if err == nil {
+		t.Fatal("Tick error = nil, want an error for the broken policy")
+	}
+	if dispatched != 0 {
+		t.Fatalf("dispatched = %d, want 0 (mission policy is invalid)", dispatched)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,155 @@
+package scheduler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/harness9/internal/mission"
+)
+
+// fakeDispatcher simulates a Worker Adapter by performing the same Store
+// transitions a real Dispatcher must perform: acquire a lease and start an
+// Attempt. This exercises real concurrency accounting without needing git
+// worktrees, Sandbox containers, or a real sub-agent.
+type fakeDispatcher struct {
+	store    *mission.Store
+	failTask map[string]bool
+}
+
+func (f *fakeDispatcher) Dispatch(ctx context.Context, task mission.Task) error {
+	if f.failTask[task.ID] {
+		return errors.New("simulated dispatch failure")
+	}
+	if _, err := f.store.AcquireLease(ctx, task.ID, "/tmp/fake-"+task.ID, "fake-branch", "fake-sandbox", time.Hour); err != nil {
+		return err
+	}
+	if _, err := f.store.StartAttempt(ctx, task.ID, "fake-worker"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func newTestStore(t *testing.T) *mission.Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "mission.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := mission.NewStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func approvedMissionWithTwoRootTasks(t *testing.T, store *mission.Store, policyJSON string) mission.Mission {
+	t.Helper()
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, mission.CreateMissionInput{Goal: "ship feature", PolicyJSON: policyJSON})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := store.CreateDraftPlan(ctx, m.ID, mission.PlanInput{Tasks: []mission.TaskInput{
+		{ClientID: "a", Position: 1, Title: "Task A", Contract: "A done"},
+		{ClientID: "b", Position: 2, Title: "Task B", Contract: "B done"},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := mission.NewCommandService(store)
+	if _, err := svc.ApprovePlan(ctx, mission.ApprovePlanCommand{
+		MissionID: m.ID, Version: plan.Version, Actor: "user:zsa", Reason: "looks good", IdempotencyKey: "approve-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.GetMission(ctx, m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func TestTickRespectsPerMissionConcurrencyLimit(t *testing.T) {
+	store := newTestStore(t)
+	m := approvedMissionWithTwoRootTasks(t, store, `{"max_concurrent_tasks":1}`)
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(10))
+
+	dispatched, err := s.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if dispatched != 1 {
+		t.Fatalf("dispatched = %d, want 1 (mission cap is 1)", dispatched)
+	}
+
+	dispatched, err = s.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second Tick: %v", err)
+	}
+	if dispatched != 0 {
+		t.Fatalf("second tick dispatched = %d, want 0 (mission still at cap)", dispatched)
+	}
+
+	got, err := store.GetMission(context.Background(), m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != mission.MissionRunning {
+		t.Fatalf("mission status = %s, want running", got.Status)
+	}
+}
+
+func TestTickRespectsGlobalConcurrencyAcrossMissions(t *testing.T) {
+	store := newTestStore(t)
+	approvedMissionWithTwoRootTasks(t, store, `{"max_concurrent_tasks":2}`)
+	approvedMissionWithTwoRootTasks(t, store, `{"max_concurrent_tasks":2}`)
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(1))
+
+	dispatched, err := s.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if dispatched != 1 {
+		t.Fatalf("dispatched = %d, want 1 (global cap is 1)", dispatched)
+	}
+}
+
+func TestTickLeavesFailedTaskQueuedAndContinuesOthers(t *testing.T) {
+	store := newTestStore(t)
+	approvedMissionWithTwoRootTasks(t, store, `{}`)
+	tasks, err := store.ListSchedulableTasks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("schedulable tasks = %d, want 2", len(tasks))
+	}
+	failing := tasks[0].ID
+	dispatcher := &fakeDispatcher{store: store, failTask: map[string]bool{failing: true}}
+	s := NewScheduler(store, dispatcher, WithMaxGlobalConcurrency(10))
+
+	dispatched, err := s.Tick(context.Background())
+	if err == nil {
+		t.Fatal("Tick error = nil, want an error for the failing task")
+	}
+	if dispatched != 1 {
+		t.Fatalf("dispatched = %d, want 1 (the non-failing task)", dispatched)
+	}
+
+	failedTask, err := store.GetTask(context.Background(), failing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if failedTask.Status != mission.TaskQueued {
+		t.Fatalf("failed task status = %s, want queued so it retries next tick", failedTask.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a deterministic, LLM-free Scheduler for harness9's Mission Control system (M2 Agent OS, Phase 2 per the design in `docs/superpowers/specs/2026-07-26-m2-agent-os-design.md`), building on top of the Mission Foundation work in this branch's base (`codex/m2-mission-foundation`).

- `internal/mission/policy.go` — `Policy`/`ParsePolicy`: per-Mission concurrency cap parsed from `PolicyJSON` (defaults to 1).
- `internal/mission/scheduler_store.go` — three new `Store` queries: `ListSchedulableTasks` (cross-mission dispatch candidates, correctly scoped to each Mission's current approved Plan version), `ActiveTaskCounts` (per-mission + global in-flight Task counts), `MarkMissionRunning` (idempotent ready→running transition).
- `internal/scheduler` (new package) — `Dispatcher` interface, `Scheduler`/`NewScheduler`/`WithMaxGlobalConcurrency`, `Tick` (the dispatch loop: respects global + per-Mission concurrency, transitions Missions to running, isolates per-task dispatch failures so one bad task never blocks others), `RecoverInterrupted` + `Run` (ticker-driven loop with startup crash recovery).

**Scope note:** this PR intentionally does not wire anything into `cmd/harness9/main.go` or add user docs — there's currently no way to create a Mission at all (no GUI/Coordinator/CLI yet), so wiring the Scheduler in now would just be a permanently-idle goroutine. That, plus the real `Dispatcher` implementation (a Worker Adapter that actually provisions git worktrees/Sandbox and launches a sub-agent), is deferred to a follow-up plan.

Built via subagent-driven development: one implementer + two-stage review (spec compliance, then code quality) per task, plus a final whole-branch review. Two issues surfaced by review and fixed in follow-up commits:
- Per-Mission policy-parse failures weren't cached within a `Tick`, causing redundant Store round-trips for a Mission with an invalid policy.
- `Scheduler.Run` would panic (not error) on a non-positive interval.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages, whole repo)
- [x] `go test ./internal/mission ./internal/scheduler -race -count=1 -v`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] Independent spec-compliance + code-quality review per task, plus a final holistic review across all 6 commits