### PR TITLE
feat: M2 Worker Adapter — real scheduler.Dispatcher implementation

### DIFF
--- a/internal/worker/adapter.go
+++ b/internal/worker/adapter.go
@@ -35,6 +35,13 @@ type Adapter struct {
 	workerName string
 }
 
+// var _ interface{ Dispatch(...) error } = (*Adapter)(nil) structurally checks
+// that Adapter has the method shape scheduler.Dispatcher requires, without
+// importing internal/scheduler and creating a needless dependency.
+var _ interface {
+	Dispatch(ctx context.Context, task mission.Task) error
+} = (*Adapter)(nil)
+
 // NewAdapter creates an Adapter. repoRoot is the harness9 repository root new
 // worktrees are created relative to.
 func NewAdapter(store *mission.Store, repoRoot string, executor Executor, baseCtx context.Context) *Adapter {

--- a/internal/worker/adapter.go
+++ b/internal/worker/adapter.go
@@ -1,0 +1,98 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/harness9/internal/mission"
+	"github.com/harness9/internal/subagent"
+)
+
+// Executor runs one Task's implementation sub-agent to completion inside a
+// given worktree and returns its raw result. The real implementation
+// (Task 5's RunnerExecutor) wraps subagent.Runner + an optional Sandbox;
+// tests use a fake that performs real git operations without a real LLM.
+type Executor interface {
+	Execute(ctx context.Context, workDir, prompt string) (subagent.SubAgentResult, error)
+}
+
+// Adapter implements scheduler.Dispatcher. Dispatch only performs the fast,
+// synchronous bookkeeping (worktree + lease + attempt); the slow part
+// (running the sub-agent to completion) happens in a detached goroutine
+// bounded by baseCtx, not by Dispatch's caller-supplied ctx, so an Attempt
+// keeps running after a single Scheduler.Tick call returns.
+type Adapter struct {
+	store      *mission.Store
+	repoRoot   string
+	leaseTTL   time.Duration
+	executor   Executor
+	baseCtx    context.Context
+	workerName string
+}
+
+// NewAdapter creates an Adapter. repoRoot is the harness9 repository root new
+// worktrees are created relative to.
+func NewAdapter(store *mission.Store, repoRoot string, executor Executor, baseCtx context.Context) *Adapter {
+	return &Adapter{
+		store:      store,
+		repoRoot:   repoRoot,
+		leaseTTL:   2 * time.Hour,
+		executor:   executor,
+		baseCtx:    baseCtx,
+		workerName: "worker-adapter",
+	}
+}
+
+// Dispatch implements scheduler.Dispatcher. On any failure it leaves no
+// partial state behind: an already-created worktree is removed before the
+// error is returned, and the Task remains schedulable (queued, or whatever
+// status it already had) for the Scheduler to retry or an operator to
+// inspect.
+func (a *Adapter) Dispatch(ctx context.Context, task mission.Task) error {
+	path, branch := worktreeFor(a.repoRoot, task)
+	if err := CreateWorktree(a.repoRoot, path, branch); err != nil {
+		return fmt.Errorf("create worktree: %w", err)
+	}
+
+	lease, err := a.store.AcquireLease(ctx, task.ID, path, branch, "", a.leaseTTL)
+	if err != nil {
+		if removeErr := RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			return fmt.Errorf("acquire lease: %w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("acquire lease: %w", err)
+	}
+
+	attempt, err := a.store.StartAttempt(ctx, task.ID, a.workerName)
+	if err != nil {
+		if _, releaseErr := a.store.ReleaseLease(ctx, lease.ID); releaseErr != nil {
+			err = fmt.Errorf("%w (lease release also failed: %v)", err, releaseErr)
+		}
+		if removeErr := RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			err = fmt.Errorf("%w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("start attempt: %w", err)
+	}
+
+	go a.run(task, lease, attempt)
+	return nil
+}
+
+// worktreeFor computes a deterministic, collision-free worktree path and
+// branch name for one Task, rooted under the repo's .harness9/missions/ tree.
+func worktreeFor(repoRoot string, task mission.Task) (path, branch string) {
+	name := task.ClientID
+	if name == "" {
+		name = task.ID
+	}
+	path = filepath.Join(repoRoot, ".harness9", "missions", task.MissionID, name)
+	branch = fmt.Sprintf("mission/%s/%s", task.MissionID, name)
+	return path, branch
+}
+
+// run is deliberately a no-op in this task: Task 3's tests only assert on
+// Dispatch's synchronous bookkeeping, not on any asynchronous outcome. Task 4
+// replaces this body with real completion logic (and its own tests).
+func (a *Adapter) run(task mission.Task, lease mission.WorkspaceLease, attempt mission.TaskAttempt) {
+}

--- a/internal/worker/adapter.go
+++ b/internal/worker/adapter.go
@@ -69,6 +69,13 @@ func (a *Adapter) Dispatch(ctx context.Context, task mission.Task) error {
 		if _, releaseErr := a.store.ReleaseLease(ctx, lease.ID); releaseErr != nil {
 			err = fmt.Errorf("%w (lease release also failed: %v)", err, releaseErr)
 		}
+		// AcquireLease already advanced the Task from queued to leased; undo
+		// that here so it is not left stuck in mission.TaskLeased with no
+		// active lease and no attempt, which would make it permanently
+		// unschedulable (see scheduler.Dispatcher's contract).
+		if _, transitionErr := a.store.TransitionTask(ctx, task.ID, mission.TaskQueued); transitionErr != nil {
+			err = fmt.Errorf("%w (task requeue also failed: %v)", err, transitionErr)
+		}
 		if removeErr := RemoveWorktree(a.repoRoot, path); removeErr != nil {
 			err = fmt.Errorf("%w (worktree cleanup also failed: %v)", err, removeErr)
 		}

--- a/internal/worker/adapter.go
+++ b/internal/worker/adapter.go
@@ -98,13 +98,17 @@ func (a *Adapter) Dispatch(ctx context.Context, task mission.Task) error {
 
 // worktreeFor computes a deterministic, collision-free worktree path and
 // branch name for one Task, rooted under the repo's .harness9/missions/ tree.
+//
+// This keys off task.ID, never task.ClientID. ClientID is only unique within
+// one (mission_id, plan_version) — internal/mission's Plan Change Request flow
+// (CreateDraftPlan/ApprovePlan/ResolvePlanChange) can create a new Plan
+// version whose Tasks reuse a ClientID from an earlier version. task.ID, in
+// contrast, is a fresh call to newID() for every Task row insertPlanGraphTx
+// writes (see internal/mission/plan_store.go), including across re-plans that
+// reuse a ClientID, so it is globally unique and never collides.
 func worktreeFor(repoRoot string, task mission.Task) (path, branch string) {
-	name := task.ClientID
-	if name == "" {
-		name = task.ID
-	}
-	path = filepath.Join(repoRoot, ".harness9", "missions", task.MissionID, name)
-	branch = fmt.Sprintf("mission/%s/%s", task.MissionID, name)
+	path = filepath.Join(repoRoot, ".harness9", "missions", task.MissionID, task.ID)
+	branch = fmt.Sprintf("mission/%s/%s", task.MissionID, task.ID)
 	return path, branch
 }
 
@@ -123,6 +127,32 @@ func (a *Adapter) run(task mission.Task, lease mission.WorkspaceLease, attempt m
 // as an Artifact, passing Evidence, and advances the Task to verifying —
 // independent re-verification is a later increment's responsibility, not
 // this Adapter's.
+//
+// Neither this method nor fail ever calls RemoveWorktree: a completed
+// Attempt's worktree (win or lose) is intentionally retained on disk, not
+// garbage-collected here. This is deliberate, not an oversight — the
+// worktree stays available for later debugging and for a future Integration
+// Task to reference the Attempt's actual working tree. Reaping old
+// worktrees (e.g. once a Task reaches a genuinely terminal state) is
+// deferred to a future hardening/GC pass, mirroring how internal/sandbox's
+// Manager exposes ReapOrphans for the analogous container-cleanup concern.
+// worktreeFor keying off task.ID (rather than the reusable-across-plan-
+// versions ClientID) means this permanent retention never causes a path
+// collision on a later re-plan.
+//
+// KNOWN LIMITATION: the sequence below is not transactional across the two
+// Store calls it ends with. If TransitionAttempt(..., AttemptSucceeded)
+// succeeds but the following TransitionTask(..., TaskVerifying) then fails,
+// the code falls through to fail() — but fail()'s own
+// TransitionAttempt(..., AttemptFailed) call is illegal from AttemptSucceeded
+// (only AttemptRunning can transition further) and silently no-ops. The
+// net result can be a Task left TaskFailed while its Attempt is still
+// AttemptSucceeded, with both a passing and a failing Evidence record on
+// file. This is a narrow, two-sequential-writes-diverge edge case that would
+// need wrapping the whole completion sequence in one Store-level transaction
+// to close properly (mission.Store does not currently expose a public
+// multi-call transaction API for that) — tracked here as a known gap, not
+// attempted in this pass.
 func (a *Adapter) complete(
 	task mission.Task,
 	attempt mission.TaskAttempt,

--- a/internal/worker/adapter.go
+++ b/internal/worker/adapter.go
@@ -3,9 +3,12 @@ package worker
 import (
 	"context"
 	"fmt"
+	"log"
+	"os/exec"
 	"path/filepath"
 	"time"
 
+	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/mission"
 	"github.com/harness9/internal/subagent"
 )
@@ -98,8 +101,103 @@ func worktreeFor(repoRoot string, task mission.Task) (path, branch string) {
 	return path, branch
 }
 
-// run is deliberately a no-op in this task: Task 3's tests only assert on
-// Dispatch's synchronous bookkeeping, not on any asynchronous outcome. Task 4
-// replaces this body with real completion logic (and its own tests).
+// run executes the Attempt's Task Contract via a.executor and records the
+// outcome. It always runs on a's baseCtx, not the ctx Dispatch's caller
+// passed in, so it survives past the lifetime of any single Tick call.
 func (a *Adapter) run(task mission.Task, lease mission.WorkspaceLease, attempt mission.TaskAttempt) {
+	prompt := fmt.Sprintf("Task: %s\n\n%s", task.Title, task.Contract)
+	subResult, err := a.executor.Execute(a.baseCtx, lease.Path, prompt)
+	a.complete(task, attempt, lease, subResult, err)
+}
+
+// complete records the final outcome of one Attempt: on any failure (execution
+// error, unparseable output, or a reported task failure) it records failing
+// Evidence and marks the Task failed; on success it records the commit diff
+// as an Artifact, passing Evidence, and advances the Task to verifying —
+// independent re-verification is a later increment's responsibility, not
+// this Adapter's.
+func (a *Adapter) complete(
+	task mission.Task,
+	attempt mission.TaskAttempt,
+	lease mission.WorkspaceLease,
+	subResult subagent.SubAgentResult,
+	execErr error,
+) {
+	defer func() {
+		if _, err := a.store.ReleaseLease(a.baseCtx, lease.ID); err != nil {
+			log.Print(logfmt.FormatMsg("worker", fmt.Sprintf("释放 lease %s 失败: %v", lease.ID, err)))
+		}
+	}()
+
+	if execErr != nil {
+		a.fail(task, attempt, "worker execution error", execErr.Error())
+		return
+	}
+	result, err := ParseResult(subResult.FinalText)
+	if err != nil {
+		a.fail(task, attempt, "unparseable worker output", err.Error())
+		return
+	}
+	if !result.Success {
+		a.fail(task, attempt, "worker reported failure", result.Reason)
+		return
+	}
+
+	diff := captureDiff(lease.Path, result.Commit)
+	if _, err := a.store.AddArtifact(a.baseCtx, mission.CreateArtifactInput{
+		MissionID: task.MissionID, TaskID: task.ID, AttemptID: attempt.ID,
+		Kind: "commit_diff", Content: []byte(diff),
+	}); err != nil {
+		a.fail(task, attempt, "record artifact", err.Error())
+		return
+	}
+	if _, err := a.store.AddEvidence(a.baseCtx, mission.CreateEvidenceInput{
+		MissionID: task.MissionID, TaskID: task.ID, AttemptID: attempt.ID,
+		Kind: "worker_report", Content: []byte(subResult.FinalText), Passed: true,
+	}); err != nil {
+		a.fail(task, attempt, "record evidence", err.Error())
+		return
+	}
+	if _, err := a.store.TransitionAttempt(a.baseCtx, attempt.ID, mission.AttemptSucceeded); err != nil {
+		a.fail(task, attempt, "transition attempt", err.Error())
+		return
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, task.ID, mission.TaskVerifying); err != nil {
+		a.fail(task, attempt, "transition task", err.Error())
+		return
+	}
+}
+
+// fail records a single failing Evidence entry describing what went wrong,
+// then marks the Attempt and Task failed. Store errors during this best-
+// effort cleanup path are logged, not escalated further — there is no
+// caller left to propagate them to once Dispatch has already returned.
+func (a *Adapter) fail(task mission.Task, attempt mission.TaskAttempt, kind, detail string) {
+	if _, err := a.store.AddEvidence(a.baseCtx, mission.CreateEvidenceInput{
+		MissionID: task.MissionID, TaskID: task.ID, AttemptID: attempt.ID,
+		Kind: "worker_report", Content: []byte(fmt.Sprintf("%s: %s", kind, detail)), Passed: false,
+	}); err != nil {
+		log.Print(logfmt.FormatMsg("worker", fmt.Sprintf("记录失败 evidence 失败: %v", err)))
+	}
+	if _, err := a.store.TransitionAttempt(a.baseCtx, attempt.ID, mission.AttemptFailed); err != nil {
+		log.Print(logfmt.FormatMsg("worker", fmt.Sprintf("推进 attempt %s 到 failed 失败: %v", attempt.ID, err)))
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, task.ID, mission.TaskFailed); err != nil {
+		log.Print(logfmt.FormatMsg("worker", fmt.Sprintf("推进 task %s 到 failed 失败: %v", task.ID, err)))
+	}
+}
+
+// captureDiff returns the full patch of one commit inside worktreePath, for
+// storage as an Artifact. If git itself fails (e.g. an invalid commit sha),
+// the error text is captured as the artifact content instead of losing the
+// failure silently — Store.AddArtifact requires non-empty content, and a
+// visible error is more useful downstream than a fabricated empty diff.
+func captureDiff(worktreePath, commit string) string {
+	cmd := exec.Command("git", "show", commit)
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Sprintf("git show %s failed: %v\n%s", commit, err, out)
+	}
+	return string(out)
 }

--- a/internal/worker/adapter_test.go
+++ b/internal/worker/adapter_test.go
@@ -3,6 +3,8 @@ package worker
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -170,4 +172,107 @@ func runGitErr(dir string, args ...string) (string, error) {
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	return string(out), err
+}
+
+// fakeExecutor simulates the implementation Task Contract by performing real
+// git operations in the given workDir — writing a file and committing it (or
+// not, for the failure case) — so the full Adapter pipeline (including
+// captureDiff's real `git show`) is exercised end to end without a real LLM.
+type fakeExecutor struct {
+	succeed bool
+	reason  string
+}
+
+func (f *fakeExecutor) Execute(ctx context.Context, workDir, prompt string) (subagent.SubAgentResult, error) {
+	if !f.succeed {
+		return subagent.SubAgentResult{
+			FinalText: "TASK_RESULT: FAILED\nREASON: " + f.reason,
+		}, nil
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "output.txt"), []byte("done\n"), 0o644); err != nil {
+		return subagent.SubAgentResult{}, err
+	}
+	runGitInDir(workDir, "add", "-A")
+	runGitInDir(workDir, "commit", "-q", "-m", "feat: fake implementation")
+	sha := runGitInDir(workDir, "rev-parse", "HEAD")
+	return subagent.SubAgentResult{
+		FinalText: "did the work\n\nTASK_RESULT: SUCCESS\nCOMMIT: " + sha,
+	}, nil
+}
+
+// runGitInDir runs git in dir and returns trimmed stdout, panicking on error
+// (test-only helper — a git failure here means the test fixture itself is
+// broken, not the code under test).
+func runGitInDir(dir string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		panic(fmt.Sprintf("git %v in %s: %v\n%s", args, dir, err, out))
+	}
+	return trimTrailingNewline(string(out))
+}
+
+// waitForTaskStatus polls the store until task reaches one of the wanted
+// statuses or the timeout elapses, failing the test on timeout. Dispatch's
+// completion runs in a background goroutine, so tests must poll rather than
+// assert immediately after Dispatch returns.
+func waitForTaskStatus(t *testing.T, store *mission.Store, taskID string, want mission.TaskStatus, timeout time.Duration) mission.Task {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		task, err := store.GetTask(context.Background(), taskID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if task.Status == want {
+			return task
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %s status = %s after %s, want %s", taskID, task.Status, timeout, want)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestDispatchSucceedsRecordsArtifactAndEvidenceAndReachesVerifying(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	task := newQueuedTask(t, store)
+	adapter := NewAdapter(store, repoRoot, &fakeExecutor{succeed: true}, context.Background())
+
+	if err := adapter.Dispatch(context.Background(), task); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	waitForTaskStatus(t, store, task.ID, mission.TaskVerifying, time.Second)
+
+	evidence, err := store.ListEvidence(context.Background(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || !evidence[0].Passed {
+		t.Fatalf("evidence = %+v, want exactly one passing record", evidence)
+	}
+}
+
+func TestDispatchFailureRecordsEvidenceAndReachesFailed(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	task := newQueuedTask(t, store)
+	adapter := NewAdapter(store, repoRoot, &fakeExecutor{succeed: false, reason: "tests kept failing"}, context.Background())
+
+	if err := adapter.Dispatch(context.Background(), task); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	waitForTaskStatus(t, store, task.ID, mission.TaskFailed, time.Second)
+
+	evidence, err := store.ListEvidence(context.Background(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || evidence[0].Passed {
+		t.Fatalf("evidence = %+v, want exactly one failing record", evidence)
+	}
 }

--- a/internal/worker/adapter_test.go
+++ b/internal/worker/adapter_test.go
@@ -16,10 +16,20 @@ import (
 	"github.com/harness9/internal/subagent"
 )
 
-// newTestStore creates a fresh in-memory-backed mission.Store for tests.
+// newTestStore creates a fresh in-memory-backed mission.Store for tests. The
+// _pragma=busy_timeout DSN parameter makes concurrent writers block-and-retry
+// instead of immediately failing with SQLITE_BUSY ("database is locked"):
+// Task 4's Adapter.run genuinely executes on a background goroutine
+// concurrently with the test goroutine's polling reads, unlike Task 3's
+// no-op run, so this package is the first in this codebase to put real
+// concurrent load on a mission.Store. (A single-connection pool was also
+// tried and rejected: mission.Store.ListSchedulableTasks holds an open
+// *sql.Rows while issuing a nested per-row query, which self-deadlocks with
+// SetMaxOpenConns(1).)
 func newTestStore(t *testing.T) *mission.Store {
 	t.Helper()
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "mission.db"))
+	dsn := filepath.Join(t.TempDir(), "mission.db") + "?_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,12 +75,30 @@ func newQueuedTask(t *testing.T, store *mission.Store) mission.Task {
 	return mission.Task{}
 }
 
-// noopExecutor never actually gets called by this task's tests (Dispatch's
-// synchronous half returns before the goroutine reaches the executor), but is
-// needed to construct an Adapter.
+// noopExecutor never actually gets called by the two rollback tests below
+// (Dispatch's synchronous half returns an error before the goroutine reaches
+// the executor in either case), but is needed to construct an Adapter.
 type noopExecutor struct{}
 
 func (noopExecutor) Execute(ctx context.Context, workDir, prompt string) (subagent.SubAgentResult, error) {
+	return subagent.SubAgentResult{}, nil
+}
+
+// blockingExecutor blocks in Execute until release is closed. Used only by
+// TestDispatchCreatesWorktreeLeaseAndAttempt, which asserts on Dispatch's
+// synchronous bookkeeping alone: now that Task 4's a.run actually calls the
+// executor, a noopExecutor's empty SubAgentResult fails ParseResult and races
+// the Task past running to failed before the test observes the running
+// state (the background completion routinely outruns the test's own
+// post-Dispatch git subprocess calls). Parking the goroutine here removes
+// that race so the test observes exactly the synchronous state Dispatch
+// itself is responsible for.
+type blockingExecutor struct {
+	release chan struct{}
+}
+
+func (b *blockingExecutor) Execute(ctx context.Context, workDir, prompt string) (subagent.SubAgentResult, error) {
+	<-b.release
 	return subagent.SubAgentResult{}, nil
 }
 
@@ -78,7 +106,7 @@ func TestDispatchCreatesWorktreeLeaseAndAttempt(t *testing.T) {
 	repoRoot := newTestRepo(t)
 	store := newTestStore(t)
 	task := newQueuedTask(t, store)
-	adapter := NewAdapter(store, repoRoot, noopExecutor{}, context.Background())
+	adapter := NewAdapter(store, repoRoot, &blockingExecutor{release: make(chan struct{})}, context.Background())
 
 	if err := adapter.Dispatch(context.Background(), task); err != nil {
 		t.Fatalf("Dispatch: %v", err)

--- a/internal/worker/adapter_test.go
+++ b/internal/worker/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 
@@ -114,6 +115,46 @@ func TestDispatchRollsBackWorktreeWhenLeaseAcquisitionFails(t *testing.T) {
 	err := adapter.Dispatch(context.Background(), task)
 	if err == nil {
 		t.Fatal("Dispatch error = nil, want an error since the task cannot acquire a lease")
+	}
+
+	path, _ := worktreeFor(repoRoot, task)
+	if _, statErr := runGitErr(path, "rev-parse", "--is-inside-work-tree"); statErr == nil {
+		t.Fatalf("worktree at %s still exists after a failed Dispatch, want it rolled back", path)
+	}
+}
+
+// TestDispatchRevertsTaskToQueuedWhenStartAttemptFails exercises the rollback
+// branch that runs after AcquireLease has already advanced the Task from
+// queued to leased but StartAttempt subsequently fails. Regression test for a
+// bug where the rollback released the lease and removed the worktree but
+// never called TransitionTask, permanently stranding the Task in
+// mission.TaskLeased (with no active lease and no attempt row) where
+// ListSchedulableTasks would never pick it up again. A near-zero lease TTL
+// deterministically makes StartAttempt observe an already-expired lease.
+func TestDispatchRevertsTaskToQueuedWhenStartAttemptFails(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	task := newQueuedTask(t, store)
+	adapter := &Adapter{
+		store:      store,
+		repoRoot:   repoRoot,
+		leaseTTL:   time.Nanosecond,
+		executor:   noopExecutor{},
+		baseCtx:    context.Background(),
+		workerName: "worker-adapter",
+	}
+
+	err := adapter.Dispatch(context.Background(), task)
+	if err == nil {
+		t.Fatal("Dispatch error = nil, want an error since the lease is already expired by the time StartAttempt runs")
+	}
+
+	updated, getErr := store.GetTask(context.Background(), task.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status != mission.TaskQueued {
+		t.Fatalf("task status = %s, want queued (Dispatch must revert the Task to queued when StartAttempt fails, per scheduler.Dispatcher's contract)", updated.Status)
 	}
 
 	path, _ := worktreeFor(repoRoot, task)

--- a/internal/worker/adapter_test.go
+++ b/internal/worker/adapter_test.go
@@ -1,0 +1,132 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/harness9/internal/mission"
+	"github.com/harness9/internal/subagent"
+)
+
+// newTestStore creates a fresh in-memory-backed mission.Store for tests.
+func newTestStore(t *testing.T) *mission.Store {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "mission.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := mission.NewStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+// newQueuedTask creates an approved Mission with one root Task (no
+// dependencies), returning it in mission.TaskQueued status, ready to Dispatch.
+func newQueuedTask(t *testing.T, store *mission.Store) mission.Task {
+	t.Helper()
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, mission.CreateMissionInput{Goal: "ship a feature"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := store.CreateDraftPlan(ctx, m.ID, mission.PlanInput{Tasks: []mission.TaskInput{
+		{ClientID: "task-a", Position: 1, Title: "Task A", Contract: "implement A and make tests pass"},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := mission.NewCommandService(store)
+	if _, err := svc.ApprovePlan(ctx, mission.ApprovePlanCommand{
+		MissionID: m.ID, Version: plan.Version, Actor: "user:zsa", Reason: "looks good", IdempotencyKey: "approve-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListSchedulableTasks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, task := range tasks {
+		if task.MissionID == m.ID {
+			return task
+		}
+	}
+	t.Fatal("newQueuedTask: no schedulable task found after approving the plan")
+	return mission.Task{}
+}
+
+// noopExecutor never actually gets called by this task's tests (Dispatch's
+// synchronous half returns before the goroutine reaches the executor), but is
+// needed to construct an Adapter.
+type noopExecutor struct{}
+
+func (noopExecutor) Execute(ctx context.Context, workDir, prompt string) (subagent.SubAgentResult, error) {
+	return subagent.SubAgentResult{}, nil
+}
+
+func TestDispatchCreatesWorktreeLeaseAndAttempt(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	task := newQueuedTask(t, store)
+	adapter := NewAdapter(store, repoRoot, noopExecutor{}, context.Background())
+
+	if err := adapter.Dispatch(context.Background(), task); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	path, branch := worktreeFor(repoRoot, task)
+	if _, err := runGitErr(path, "rev-parse", "--is-inside-work-tree"); err != nil {
+		t.Fatalf("worktree at %s was not created: %v", path, err)
+	}
+	got := runGit(t, path, "branch", "--show-current")
+	if got != branch {
+		t.Fatalf("branch = %q, want %q", got, branch)
+	}
+
+	updated, err := store.GetTask(context.Background(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != mission.TaskRunning {
+		t.Fatalf("task status = %s, want running (AcquireLease+StartAttempt should have advanced it)", updated.Status)
+	}
+}
+
+func TestDispatchRollsBackWorktreeWhenLeaseAcquisitionFails(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	task := newQueuedTask(t, store)
+	// Force AcquireLease to fail: transition the task to a status from which
+	// no lease can legally be acquired (queued/leased only). CreateWorktree
+	// will still succeed first, since the path is fresh.
+	if _, err := store.TransitionTask(context.Background(), task.ID, mission.TaskFailed); err != nil {
+		t.Fatalf("pre-transition task to failed: %v", err)
+	}
+	adapter := NewAdapter(store, repoRoot, noopExecutor{}, context.Background())
+
+	err := adapter.Dispatch(context.Background(), task)
+	if err == nil {
+		t.Fatal("Dispatch error = nil, want an error since the task cannot acquire a lease")
+	}
+
+	path, _ := worktreeFor(repoRoot, task)
+	if _, statErr := runGitErr(path, "rev-parse", "--is-inside-work-tree"); statErr == nil {
+		t.Fatalf("worktree at %s still exists after a failed Dispatch, want it rolled back", path)
+	}
+}
+
+// runGitErr runs a git command in dir and returns an error without failing
+// the test, for asserting that a path is (or isn't) a valid git worktree.
+func runGitErr(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/worker/contract.go
+++ b/internal/worker/contract.go
@@ -1,0 +1,85 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/harness9/internal/subagent"
+)
+
+// implementationSystemPrompt is the system prompt for Mission's default
+// implementation Task Contract. It replaces AutoDev's dev.md: unlike AutoDev
+// (which keeps a worktree as a subdirectory of a shared, fixed-workDir
+// Runner and has the sub-agent `cd` into it), each Attempt here gets its own
+// Runner whose WorkDir is the worktree root itself, so paths and bash
+// commands are used directly with no cd/relative-path indirection.
+const implementationSystemPrompt = `你是 Mission 的 implementation Worker，在一个专属 git worktree 中独立完成被分配的 Task。
+
+你的工作目录就是这个 Task 专属的 git worktree 根目录——所有文件路径和 bash 命令都直接使用，不需要 cd 到任何子目录。
+
+工作流程：
+1. 如果存在 AGENTS.md，先阅读它了解项目规范。
+2. 探索代码库，理解需要改动的范围。
+3. 实现 Task 描述里的目标。
+4. 运行 go build ./...，编译通过前不要进入下一步。
+5. 运行 go test ./... -timeout 5m，最多重试 3 次修复失败；3 次仍失败则如实报告失败，不得伪造通过。
+6. gofmt -w . 格式化。
+7. git add -A && git commit -m "<简明 commit message>" 提交。
+
+完成后，在最后一条消息末尾附上（不要用代码块包裹）：
+TASK_RESULT: SUCCESS
+COMMIT: <git rev-parse HEAD 的输出>
+
+如果第 5 步 3 次仍失败，附上：
+TASK_RESULT: FAILED
+REASON: <一句话原因>`
+
+// ImplementationContract is Mission's default Task Contract for code
+// implementation work, used by the Worker Adapter for every Task unless a
+// future Contract type (e.g. integration, verification) overrides it.
+var ImplementationContract = subagent.SubAgentDefinition{
+	Name:         "mission-implementation",
+	Description:  "Mission 默认的实现类 Task Contract：在专属 worktree 中实现、测试并提交一个 Task",
+	SystemPrompt: implementationSystemPrompt,
+	Tools:        []string{"bash", "read_file", "write_file", "edit_file", "web_search", "web_fetch"},
+	Source:       "builtin",
+}
+
+// Result is the outcome the Worker Adapter extracts from a sub-agent's final
+// text, per the TASK_RESULT/COMMIT/REASON convention in
+// implementationSystemPrompt.
+type Result struct {
+	Success bool
+	Commit  string
+	Reason  string
+}
+
+// ParseResult extracts a Result from a sub-agent's raw final text. It returns
+// an error if no TASK_RESULT marker is present, or if a reported success is
+// missing its COMMIT sha.
+func ParseResult(finalText string) (Result, error) {
+	var result Result
+	found := false
+	for _, line := range strings.Split(finalText, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "TASK_RESULT: SUCCESS"):
+			result.Success = true
+			found = true
+		case strings.HasPrefix(line, "TASK_RESULT: FAILED"):
+			result.Success = false
+			found = true
+		case strings.HasPrefix(line, "COMMIT:"):
+			result.Commit = strings.TrimSpace(strings.TrimPrefix(line, "COMMIT:"))
+		case strings.HasPrefix(line, "REASON:"):
+			result.Reason = strings.TrimSpace(strings.TrimPrefix(line, "REASON:"))
+		}
+	}
+	if !found {
+		return Result{}, fmt.Errorf("worker output is missing a TASK_RESULT marker")
+	}
+	if result.Success && result.Commit == "" {
+		return Result{}, fmt.Errorf("worker reported success without a COMMIT sha")
+	}
+	return result, nil
+}

--- a/internal/worker/contract_test.go
+++ b/internal/worker/contract_test.go
@@ -1,0 +1,56 @@
+package worker
+
+import "testing"
+
+func TestImplementationContractIsValid(t *testing.T) {
+	if err := ImplementationContract.Validate(); err != nil {
+		t.Fatalf("ImplementationContract.Validate(): %v", err)
+	}
+	if len(ImplementationContract.Tools) == 0 {
+		t.Fatal("ImplementationContract.Tools is empty, want an explicit allowlist")
+	}
+	for _, forbidden := range []string{"task"} {
+		for _, tool := range ImplementationContract.Tools {
+			if tool == forbidden {
+				t.Fatalf("ImplementationContract.Tools contains forbidden tool %q", forbidden)
+			}
+		}
+	}
+}
+
+func TestParseResultSuccess(t *testing.T) {
+	text := "some narration\n\nTASK_RESULT: SUCCESS\nCOMMIT: abc123def456\n"
+	result, err := ParseResult(text)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if !result.Success || result.Commit != "abc123def456" {
+		t.Fatalf("result = %+v, want Success=true Commit=abc123def456", result)
+	}
+}
+
+func TestParseResultFailure(t *testing.T) {
+	text := "TASK_RESULT: FAILED\nREASON: tests still failing after 3 attempts\n"
+	result, err := ParseResult(text)
+	if err != nil {
+		t.Fatalf("ParseResult: %v", err)
+	}
+	if result.Success {
+		t.Fatalf("result.Success = true, want false")
+	}
+	if result.Reason != "tests still failing after 3 attempts" {
+		t.Fatalf("result.Reason = %q, want the failure reason", result.Reason)
+	}
+}
+
+func TestParseResultRejectsMissingMarker(t *testing.T) {
+	if _, err := ParseResult("I did some work but forgot the marker"); err == nil {
+		t.Fatal("ParseResult on text without TASK_RESULT = nil error, want an error")
+	}
+}
+
+func TestParseResultRejectsSuccessWithoutCommit(t *testing.T) {
+	if _, err := ParseResult("TASK_RESULT: SUCCESS\n"); err == nil {
+		t.Fatal("ParseResult on SUCCESS without COMMIT = nil error, want an error")
+	}
+}

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/harness9/internal/hooks"
 	"github.com/harness9/internal/memory"
 	"github.com/harness9/internal/provider"
 	"github.com/harness9/internal/sandbox"
@@ -13,9 +14,20 @@ import (
 
 // RunnerExecutorConfig configures a RunnerExecutor.
 type RunnerExecutorConfig struct {
-	ProviderFor        func(model string) (provider.LLMProvider, int, error)
-	CompactorFor       func(p provider.LLMProvider, ctxWin int) memory.Compactor
-	SandboxMgr         *sandbox.Manager // optional; nil = no Sandbox for any Attempt
+	ProviderFor  func(model string) (provider.LLMProvider, int, error)
+	CompactorFor func(p provider.LLMProvider, ctxWin int) memory.Compactor
+	SandboxMgr   *sandbox.Manager // optional; nil = no Sandbox for any Attempt
+	// SharedHooks is threaded straight through to subagent.RunnerConfig.SharedHooks
+	// for every Attempt this Executor runs. Worker Attempts run unattended
+	// (Execute always passes background=true to Runner.Run, which auto-denies
+	// any HookActionAsk decision since there is no human present to answer an
+	// approval prompt), so this is the only seam through which a caller can
+	// give the Attempt's bash tool the same high-risk-pattern interception
+	// (e.g. hooks.NewDangerHook()) the rest of the codebase relies on. This
+	// package deliberately does not construct any default hooks itself —
+	// choosing which hooks (if any) to install is left to whoever builds a
+	// RunnerExecutorConfig.
+	SharedHooks        []hooks.ToolHook
 	SettingsPath       string
 	DefaultMaxTurns    int
 	ToolTimeout        time.Duration
@@ -54,6 +66,7 @@ func (e *RunnerExecutor) Execute(ctx context.Context, workDir, prompt string) (s
 	}
 	runner := subagent.NewRunner(subagent.RunnerConfig{
 		BaseTools:          baseTools,
+		SharedHooks:        e.cfg.SharedHooks,
 		SettingsPath:       e.cfg.SettingsPath,
 		WorkDir:            workDir,
 		DefaultMaxTurns:    e.cfg.DefaultMaxTurns,

--- a/internal/worker/executor.go
+++ b/internal/worker/executor.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/provider"
+	"github.com/harness9/internal/sandbox"
+	"github.com/harness9/internal/subagent"
+	"github.com/harness9/internal/tools"
+)
+
+// RunnerExecutorConfig configures a RunnerExecutor.
+type RunnerExecutorConfig struct {
+	ProviderFor        func(model string) (provider.LLMProvider, int, error)
+	CompactorFor       func(p provider.LLMProvider, ctxWin int) memory.Compactor
+	SandboxMgr         *sandbox.Manager // optional; nil = no Sandbox for any Attempt
+	SettingsPath       string
+	DefaultMaxTurns    int
+	ToolTimeout        time.Duration
+	MaxConcurrentTools int
+	BaseCtx            context.Context
+}
+
+// RunnerExecutor is the real Executor: for every call it builds a fresh,
+// throwaway subagent.Runner whose WorkDir is the Attempt's own worktree, then
+// runs the implementation Task Contract in it. A fresh Runner per call is
+// required because subagent.Runner's WorkDir is fixed at construction and
+// cannot be changed per call.
+type RunnerExecutor struct {
+	cfg RunnerExecutorConfig
+}
+
+// NewRunnerExecutor creates a RunnerExecutor from cfg.
+func NewRunnerExecutor(cfg RunnerExecutorConfig) *RunnerExecutor {
+	return &RunnerExecutor{cfg: cfg}
+}
+
+// Execute implements Executor by constructing a dedicated Runner rooted at
+// workDir and running ImplementationContract in it. background=true is
+// passed to Runner.Run: Worker Attempts are unattended (no human present to
+// answer approval prompts), matching exactly the semantics Runner.Run already
+// applies for background sub-agent calls (auto-deny approvals, execution
+// bound to the Runner's own base context rather than the caller's).
+func (e *RunnerExecutor) Execute(ctx context.Context, workDir, prompt string) (subagent.SubAgentResult, error) {
+	baseTools := []tools.BaseTool{
+		tools.NewBashTool(workDir),
+		tools.NewReadFileTool(workDir),
+		tools.NewWriteFileTool(workDir),
+		tools.NewEditFileTool(workDir),
+		tools.NewWebFetchTool(),
+		tools.NewWebSearchTool(),
+	}
+	runner := subagent.NewRunner(subagent.RunnerConfig{
+		BaseTools:          baseTools,
+		SettingsPath:       e.cfg.SettingsPath,
+		WorkDir:            workDir,
+		DefaultMaxTurns:    e.cfg.DefaultMaxTurns,
+		ToolTimeout:        e.cfg.ToolTimeout,
+		MaxConcurrentTools: e.cfg.MaxConcurrentTools,
+		ProviderFor:        e.cfg.ProviderFor,
+		CompactorFor:       e.cfg.CompactorFor,
+		BaseCtx:            e.cfg.BaseCtx,
+		SandboxMgr:         e.cfg.SandboxMgr,
+	})
+	return runner.Run(ctx, ImplementationContract, prompt, true)
+}

--- a/internal/worker/executor_test.go
+++ b/internal/worker/executor_test.go
@@ -2,9 +2,13 @@ package worker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/harness9/internal/hooks"
 	"github.com/harness9/internal/memory"
 	"github.com/harness9/internal/provider"
 	"github.com/harness9/internal/provider/providertest"
@@ -36,5 +40,78 @@ func TestRunnerExecutorReturnsSubAgentFinalText(t *testing.T) {
 	}
 	if result.FinalText != wantText {
 		t.Fatalf("FinalText = %q, want %q", result.FinalText, wantText)
+	}
+}
+
+// alwaysDenyHook denies every tool call it sees. Used to prove that
+// RunnerExecutorConfig.SharedHooks is actually threaded through to the
+// subagent.Runner that executes tool calls, rather than being silently
+// dropped on the floor.
+type alwaysDenyHook struct{}
+
+func (alwaysDenyHook) BeforeExecute(ctx context.Context, tc schema.ToolCall) (context.Context, hooks.HookDecision, error) {
+	return ctx, hooks.Deny("denied-by-test-hook"), nil
+}
+
+func (alwaysDenyHook) AfterExecute(_ context.Context, _ schema.ToolCall, result schema.ToolResult) schema.ToolResult {
+	return result
+}
+
+// TestRunnerExecutorThreadsSharedHooks confirms RunnerExecutorConfig.SharedHooks
+// reaches the real subagent.Runner built inside Execute: a hook that denies
+// every tool call must cause the sub-agent's bash call to come back as an
+// error Observation carrying the hook's deny reason, proving the hook chain
+// was actually installed (as opposed to being accepted but ignored).
+func TestRunnerExecutorThreadsSharedHooks(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	// The permission hook always runs first in the chain (ahead of
+	// SharedHooks) and defaults every unmatched tool call to HookActionAsk,
+	// which a background sub-agent auto-denies before any SharedHooks entry
+	// gets a turn. Explicitly allow "bash" here so the permission hook lets it
+	// through and the chain actually reaches alwaysDenyHook, isolating what
+	// this test wants to prove.
+	settingsPath := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"permissions":{"allow":["bash"]}}`), 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+	var observedObservation string
+	turn := 0
+	mockLLM := providertest.NewMockWithCallback(func(msgs []schema.Message, _ []schema.ToolDefinition) schema.Message {
+		turn++
+		if turn == 1 {
+			return schema.Message{
+				Role:    schema.RoleAssistant,
+				Content: "invoking bash",
+				ToolCalls: []schema.ToolCall{
+					{ID: "call_1", Name: "bash", Arguments: []byte(`{"command": "echo hi"}`)},
+				},
+			}
+		}
+		// Second turn: the previous message in history is the Observation the
+		// engine appended for call_1's result — record it so the test can
+		// assert on it, then terminate the loop with a final answer.
+		observedObservation = msgs[len(msgs)-1].Content
+		return schema.Message{Role: schema.RoleAssistant, Content: "TASK_RESULT: FAILED\nREASON: tool denied"}
+	})
+
+	executor := NewRunnerExecutor(RunnerExecutorConfig{
+		ProviderFor: func(model string) (provider.LLMProvider, int, error) {
+			return mockLLM, 100000, nil
+		},
+		CompactorFor:       func(provider.LLMProvider, int) memory.Compactor { return nil },
+		SandboxMgr:         nil,
+		SharedHooks:        []hooks.ToolHook{alwaysDenyHook{}},
+		SettingsPath:       settingsPath,
+		DefaultMaxTurns:    5,
+		ToolTimeout:        10 * time.Second,
+		MaxConcurrentTools: 1,
+		BaseCtx:            context.Background(),
+	})
+
+	if _, err := executor.Execute(context.Background(), repoRoot, "implement the thing"); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(observedObservation, "denied-by-test-hook") {
+		t.Fatalf("observed tool Observation = %q, want it to contain the SharedHooks deny reason (denied-by-test-hook)", observedObservation)
 	}
 }

--- a/internal/worker/executor_test.go
+++ b/internal/worker/executor_test.go
@@ -1,0 +1,40 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/provider"
+	"github.com/harness9/internal/provider/providertest"
+	"github.com/harness9/internal/schema"
+)
+
+func TestRunnerExecutorReturnsSubAgentFinalText(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	const wantText = "TASK_RESULT: SUCCESS\nCOMMIT: deadbeef"
+	mockLLM := providertest.NewMockWithCallback(func(_ []schema.Message, _ []schema.ToolDefinition) schema.Message {
+		return schema.Message{Role: schema.RoleAssistant, Content: wantText}
+	})
+
+	executor := NewRunnerExecutor(RunnerExecutorConfig{
+		ProviderFor: func(model string) (provider.LLMProvider, int, error) {
+			return mockLLM, 100000, nil
+		},
+		CompactorFor:       func(provider.LLMProvider, int) memory.Compactor { return nil },
+		SandboxMgr:         nil, // no Docker required for this test
+		DefaultMaxTurns:    5,
+		ToolTimeout:        10 * time.Second,
+		MaxConcurrentTools: 1,
+		BaseCtx:            context.Background(),
+	})
+
+	result, err := executor.Execute(context.Background(), repoRoot, "implement the thing")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.FinalText != wantText {
+		t.Fatalf("FinalText = %q, want %q", result.FinalText, wantText)
+	}
+}

--- a/internal/worker/worktree.go
+++ b/internal/worker/worktree.go
@@ -1,0 +1,34 @@
+// Package worker implements the real scheduler.Dispatcher: it provisions an
+// isolated git worktree + WorkspaceLease per Task Attempt and runs the
+// default implementation Task Contract inside it.
+package worker
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// CreateWorktree creates a new git worktree at path on a new branch, using
+// repoRoot's current HEAD as the start point. It fails if path already
+// exists or branch is already checked out elsewhere.
+func CreateWorktree(repoRoot, path, branch string) error {
+	cmd := exec.Command("git", "worktree", "add", path, "-b", branch)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add %s: %w: %s", path, err, out)
+	}
+	return nil
+}
+
+// RemoveWorktree force-removes a git worktree previously created by
+// CreateWorktree, including any uncommitted changes inside it.
+func RemoveWorktree(repoRoot, path string) error {
+	cmd := exec.Command("git", "worktree", "remove", path, "--force")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree remove %s: %w: %s", path, err, out)
+	}
+	return nil
+}

--- a/internal/worker/worktree_test.go
+++ b/internal/worker/worktree_test.go
@@ -1,0 +1,90 @@
+package worker
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateWorktreeAddsWorktreeAtPath(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	worktreePath := filepath.Join(repoRoot, ".harness9", "missions", "m1", "task-a")
+
+	if err := CreateWorktree(repoRoot, worktreePath, "mission/m1/task-a"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(worktreePath, ".git")); err != nil {
+		t.Fatalf("worktree %s does not look like a git worktree: %v", worktreePath, err)
+	}
+	branch := runGit(t, worktreePath, "branch", "--show-current")
+	if branch != "mission/m1/task-a" {
+		t.Fatalf("branch = %q, want mission/m1/task-a", branch)
+	}
+}
+
+func TestCreateWorktreeRejectsDuplicatePath(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	worktreePath := filepath.Join(repoRoot, ".harness9", "missions", "m1", "task-a")
+
+	if err := CreateWorktree(repoRoot, worktreePath, "mission/m1/task-a"); err != nil {
+		t.Fatalf("first CreateWorktree: %v", err)
+	}
+	if err := CreateWorktree(repoRoot, worktreePath, "mission/m1/task-a-2"); err == nil {
+		t.Fatal("second CreateWorktree at the same path succeeded, want an error")
+	}
+}
+
+func TestRemoveWorktreeCleansUpPath(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	worktreePath := filepath.Join(repoRoot, ".harness9", "missions", "m1", "task-a")
+	if err := CreateWorktree(repoRoot, worktreePath, "mission/m1/task-a"); err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	if err := RemoveWorktree(repoRoot, worktreePath); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still exists after RemoveWorktree: err = %v", err)
+	}
+}
+
+// newTestRepo creates a fresh git repository in a temp dir with one initial
+// commit (so later `git worktree add -b <branch>` calls have a start point),
+// and local git identity configured (so test commits succeed without relying
+// on the host machine's global git config). Reused by later tasks' tests.
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+	runGit(t, root, "config", "user.email", "worker-test@example.com")
+	runGit(t, root, "config", "user.name", "worker-test")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("test repo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m", "initial commit")
+	return root
+}
+
+// runGit runs a git command in dir and returns trimmed stdout, failing the
+// test with full output on error.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return trimTrailingNewline(string(out))
+}
+
+func trimTrailingNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/worker/worktree_test.go
+++ b/internal/worker/worktree_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/harness9/internal/mission"
 )
 
 func TestCreateWorktreeAddsWorktreeAtPath(t *testing.T) {
@@ -48,6 +50,39 @@ func TestRemoveWorktreeCleansUpPath(t *testing.T) {
 	}
 	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
 		t.Fatalf("worktree path still exists after RemoveWorktree: err = %v", err)
+	}
+}
+
+// TestWorktreeForKeysOffTaskIDNotClientID is a regression test for a
+// permanent-collision bug: worktreeFor used to key off task.ClientID
+// (falling back to task.ID only when ClientID was empty). ClientID is only
+// unique within one (mission_id, plan_version) — internal/mission's Plan
+// Change Request flow can create a new Plan version whose Tasks legally
+// reuse a ClientID from an earlier version, each getting a fresh, globally
+// unique task.ID (see insertPlanGraphTx's newID() call in
+// internal/mission/plan_store.go). Two such Tasks must resolve to distinct,
+// non-colliding worktree paths/branches, and worktreeFor must key off
+// task.ID unconditionally to guarantee that.
+func TestWorktreeForKeysOffTaskIDNotClientID(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	taskV1 := mission.Task{ID: "task-id-v1", MissionID: "m1", ClientID: "task-a"}
+	taskV2 := mission.Task{ID: "task-id-v2", MissionID: "m1", ClientID: "task-a"}
+
+	pathV1, branchV1 := worktreeFor(repoRoot, taskV1)
+	pathV2, branchV2 := worktreeFor(repoRoot, taskV2)
+
+	if pathV1 == pathV2 {
+		t.Fatalf("worktreeFor produced identical paths for two Tasks with different IDs sharing a reused ClientID: %s", pathV1)
+	}
+	if branchV1 == branchV2 {
+		t.Fatalf("worktreeFor produced identical branches for two Tasks with different IDs sharing a reused ClientID: %s", branchV1)
+	}
+
+	if err := CreateWorktree(repoRoot, pathV1, branchV1); err != nil {
+		t.Fatalf("CreateWorktree for the first Task: %v", err)
+	}
+	if err := CreateWorktree(repoRoot, pathV2, branchV2); err != nil {
+		t.Fatalf("CreateWorktree for the second Task must not collide with the first despite the reused ClientID: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the real `scheduler.Dispatcher` for harness9's Mission Control system (M2, Phase 2 continuation, on top of this branch's base `feat/m2-scheduler`): a new `internal/worker` package that provisions an isolated git worktree + Lease per Task Attempt, runs a real sub-agent through the default implementation Task Contract, and records Artifact/Evidence.

- `internal/worker/worktree.go` — `CreateWorktree`/`RemoveWorktree`, real `git worktree add`/`remove` wrappers.
- `internal/worker/contract.go` — `ImplementationContract` (the default implementation Task Contract, replacing AutoDev's `dev.md`: no more `.autodev/<slug>/` subdirectory + `cd` indirection, since each Attempt gets its own Runner rooted directly at its worktree) + `ParseResult` (parses the sub-agent's `TASK_RESULT`/`COMMIT`/`REASON` convention).
- `internal/worker/adapter.go` — `Adapter` (implements `scheduler.Dispatcher`): `Dispatch` synchronously does worktree + `AcquireLease` + `StartAttempt` bookkeeping with full rollback on any failure (never leaves a Task stuck or an orphaned worktree), then asynchronously (detached goroutine, bounded by the Adapter's own long-lived context, not the caller's per-Tick `ctx`) runs the sub-agent and records the outcome — success advances the Task to `verifying` with Artifact + passing Evidence; failure (execution error, unparseable output, or a reported failure) advances it to `failed` with failing Evidence.
- `internal/worker/executor.go` — `RunnerExecutor`, the real `Executor` wiring a fresh `subagent.Runner` (+ optional `sandbox.Manager`) per Attempt, with a `SharedHooks` seam so a future caller can give unattended Worker Attempts the same DangerHook/OffloadHook protection production sub-agents already get.

**Scope note:** intentionally stops at `verifying` — independent re-verification (Verifier Task type) and multi-task Integration are Phase 3's job (the frozen Feature Mission), not this increment's. Also intentionally does not wire anything into `cmd/harness9/main.go` or add user docs — there's still no way to create a Mission (no GUI/Coordinator/CLI), so wiring now would just be dead code; that lands together with Phase 3.

Built via subagent-driven development (implementer + spec-compliance review + code-quality review per task, run through a Workflow), plus a final whole-branch review. Review caught and fixed real issues along the way:
- A Task could get permanently stuck in `leased` if `StartAttempt` failed after `AcquireLease` succeeded (now reverts to `queued`).
- A genuine SQLite-busy race surfaced once the real async path was exercised under `-race` (fixed with a busy-timeout DSN pragma + a deterministic test fix).
- Final review: `RunnerExecutorConfig` had no seam to pass safety hooks through to unattended Worker Attempts (added `SharedHooks`); worktree naming was keyed off `ClientID`, which isn't unique across Mission re-plans and could permanently collide (now keyed off the always-unique `Task.ID`).

One known, documented (not fixed) limitation remains: if `TransitionAttempt(Succeeded)` succeeds but the following `TransitionTask(verifying)` fails, the Task can land on `failed` while its Attempt reads `succeeded` — commented in code as a tracked gap, would need a broader multi-call transaction redesign to close properly.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages, whole repo)
- [x] `go test ./internal/worker -race -count=3 -v`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] Independent spec-compliance + code-quality review per task (6 tasks), plus a final holistic review across all 10 commits