### PR TITLE
feat: M2 Verifier mechanism — independent re-verification + ContractKind routing

### DIFF
--- a/internal/mission/execution_store_test.go
+++ b/internal/mission/execution_store_test.go
@@ -330,6 +330,113 @@ func TestAddEvidenceSeparatesProducerAndVerifierAttempts(t *testing.T) {
 	}
 }
 
+// TestAddEvidenceAcceptsVerifierAttemptFromADifferentTaskInTheSameMission
+// mirrors internal/verifier.Adapter's real shape: a verification Task's own
+// Attempt (started against the verification Task's ID, never the target's)
+// is used as VerifierAttemptID on Evidence recorded against a different Task
+// (the one being verified) in the same Mission. Regression coverage for
+// validateAttemptInMission: the producer/verifier Attempt pair no longer has
+// to share a Task, only a Mission.
+func TestAddEvidenceAcceptsVerifierAttemptFromADifferentTaskInTheSameMission(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, CreateMissionInput{Goal: "verify cross-task evidence"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := store.CreateTask(ctx, CreateTaskInput{MissionID: m.ID, Title: "target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifyTask, err := store.CreateTask(ctx, CreateTaskInput{MissionID: m.ID, Title: "verify"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AcquireLease(ctx, target.ID, "wt/target", "branch/target", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	producer, err := store.StartAttempt(ctx, target.ID, "worker-adapter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AcquireLease(ctx, verifyTask.ID, "wt/verify", "branch/verify", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	verifierAttempt, err := store.StartAttempt(ctx, verifyTask.ID, "verifier-adapter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	evidence, err := store.AddEvidence(ctx, CreateEvidenceInput{
+		MissionID:         m.ID,
+		TaskID:            target.ID,
+		AttemptID:         producer.ID,
+		VerifierAttemptID: verifierAttempt.ID,
+		Kind:              "independent_verification",
+		Content:           []byte("go build/vet/test all passed"),
+		Passed:            true,
+	})
+	if err != nil {
+		t.Fatalf("AddEvidence with a cross-Task verifier Attempt: %v", err)
+	}
+	if evidence.AttemptID != producer.ID || evidence.VerifierAttemptID != verifierAttempt.ID {
+		t.Fatalf("Evidence Attempts = %+v", evidence)
+	}
+}
+
+// TestAddEvidenceRejectsVerifierAttemptFromAnotherMission proves
+// validateAttemptInMission's relaxation from Task-scoped to Mission-scoped
+// still enforces a real boundary: an Attempt belonging to an unrelated
+// Mission must still be rejected as VerifierAttemptID.
+func TestAddEvidenceRejectsVerifierAttemptFromAnotherMission(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	m1, err := store.CreateMission(ctx, CreateMissionInput{Goal: "mission one"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task1, err := store.CreateTask(ctx, CreateTaskInput{MissionID: m1.ID, Title: "target"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AcquireLease(ctx, task1.ID, "wt/m1", "branch/m1", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	producer, err := store.StartAttempt(ctx, task1.ID, "worker-adapter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m2, err := store.CreateMission(ctx, CreateMissionInput{Goal: "mission two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task2, err := store.CreateTask(ctx, CreateTaskInput{MissionID: m2.ID, Title: "unrelated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AcquireLease(ctx, task2.ID, "wt/m2", "branch/m2", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	foreignAttempt, err := store.StartAttempt(ctx, task2.ID, "verifier-adapter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.AddEvidence(ctx, CreateEvidenceInput{
+		MissionID:         m1.ID,
+		TaskID:            task1.ID,
+		AttemptID:         producer.ID,
+		VerifierAttemptID: foreignAttempt.ID,
+		Kind:              "independent_verification",
+		Content:           []byte("borrowed from another mission"),
+		Passed:            true,
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("AddEvidence with a verifier Attempt from a different Mission error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestListEventsOrdersByCreationThenIDAndSupportsCursor(t *testing.T) {
 	store, task := newReadyTask(t)
 	now := time.Date(2026, time.July, 26, 10, 0, 0, 0, time.UTC)

--- a/internal/mission/plan_store.go
+++ b/internal/mission/plan_store.go
@@ -710,8 +710,8 @@ func insertPlanGraphTx(
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO tasks (
 				id, mission_id, title, status, plan_version,
-				client_id, position, contract, created_at, updated_at
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				client_id, position, contract, contract_kind, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			taskID,
 			missionID,
 			task.Title,
@@ -720,6 +720,7 @@ func insertPlanGraphTx(
 			task.ClientID,
 			task.Position,
 			task.Contract,
+			task.ContractKind,
 			unixMillis(now),
 			unixMillis(now),
 		); err != nil {
@@ -753,7 +754,7 @@ func scanPlanGraph(
 	version int,
 ) ([]TaskInput, error) {
 	rows, err := queryer.QueryContext(ctx, `
-		SELECT id, client_id, position, title, contract
+		SELECT id, client_id, position, title, contract, contract_kind
 		FROM tasks
 		WHERE mission_id = ? AND plan_version = ?
 		ORDER BY position ASC, id ASC`,
@@ -776,6 +777,7 @@ func scanPlanGraph(
 			&task.input.Position,
 			&task.input.Title,
 			&task.input.Contract,
+			&task.input.ContractKind,
 		); err != nil {
 			_ = rows.Close()
 			return nil, fmt.Errorf("scan plan task: %w", err)
@@ -833,10 +835,14 @@ func normalizePlanInput(input PlanInput) (PlanInput, error) {
 			return PlanInput{}, fmt.Errorf("task %q position cannot be negative", task.ClientID)
 		}
 		normalized.Tasks[index] = TaskInput{
-			ClientID: strings.TrimSpace(task.ClientID),
-			Position: task.Position,
-			Title:    strings.TrimSpace(task.Title),
-			Contract: strings.TrimSpace(task.Contract),
+			ClientID:     strings.TrimSpace(task.ClientID),
+			Position:     task.Position,
+			Title:        strings.TrimSpace(task.Title),
+			Contract:     strings.TrimSpace(task.Contract),
+			ContractKind: strings.TrimSpace(task.ContractKind),
+		}
+		if normalized.Tasks[index].ContractKind == "" {
+			normalized.Tasks[index].ContractKind = ContractImplementation
 		}
 		normalized.Tasks[index].Dependencies = make([]string, len(task.Dependencies))
 		seenDependencies := make(map[string]struct{}, len(task.Dependencies))

--- a/internal/mission/plan_store_test.go
+++ b/internal/mission/plan_store_test.go
@@ -594,3 +594,29 @@ func revisedPlanInput() PlanInput {
 		{ClientID: "code", Position: 2, Title: "Implement safely", Contract: "tests pass", Dependencies: []string{"spec", "docs"}},
 	}}
 }
+
+func TestNormalizePlanInputDefaultsContractKindToImplementation(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, PlanInput{Tasks: []TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A"},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Tasks[0].ContractKind != ContractImplementation {
+		t.Fatalf("ContractKind = %q, want %q", plan.Tasks[0].ContractKind, ContractImplementation)
+	}
+}
+
+func TestCreateDraftPlanPersistsExplicitContractKind(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, PlanInput{Tasks: []TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A", ContractKind: ContractVerification},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Tasks[0].ContractKind != ContractVerification {
+		t.Fatalf("ContractKind = %q, want %q", plan.Tasks[0].ContractKind, ContractVerification)
+	}
+}

--- a/internal/mission/scheduler_store.go
+++ b/internal/mission/scheduler_store.go
@@ -12,7 +12,8 @@ import (
 func (s *Store) ListSchedulableTasks(ctx context.Context) ([]Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT tasks.id, tasks.mission_id, tasks.title, COALESCE(tasks.client_id, ''),
-		       tasks.position, tasks.contract, tasks.status, tasks.created_at, tasks.updated_at
+		       tasks.position, tasks.contract, tasks.contract_kind, tasks.status,
+		       tasks.created_at, tasks.updated_at
 		FROM tasks
 		JOIN missions ON missions.id = tasks.mission_id
 		WHERE tasks.status = ?

--- a/internal/mission/scheduler_store_test.go
+++ b/internal/mission/scheduler_store_test.go
@@ -124,3 +124,23 @@ func TestMarkMissionRunningRejectsMissionNotReady(t *testing.T) {
 		t.Fatalf("MarkMissionRunning on draft mission: err = %v, want ErrInvalidTransition", err)
 	}
 }
+
+func TestListSchedulableTasksIncludesContractKind(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, PlanInput{Tasks: []TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A", ContractKind: ContractVerification},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListSchedulableTasks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 || tasks[0].ContractKind != ContractVerification {
+		t.Fatalf("schedulable tasks = %+v, want one task with ContractKind %q", tasks, ContractVerification)
+	}
+}

--- a/internal/mission/store.go
+++ b/internal/mission/store.go
@@ -220,6 +220,7 @@ var schemaMigrations = []struct {
 	{table: "tasks", column: "tool_scope_json", definition: "TEXT NOT NULL DEFAULT '{}'"},
 	{table: "tasks", column: "budget_cents", definition: "INTEGER NOT NULL DEFAULT 0"},
 	{table: "tasks", column: "acceptance_json", definition: "TEXT NOT NULL DEFAULT '{}'"},
+	{table: "tasks", column: "contract_kind", definition: "TEXT NOT NULL DEFAULT ''"},
 	{table: "task_attempts", column: "lease_id", definition: "TEXT"},
 	{table: "workspace_leases", column: "branch", definition: "TEXT NOT NULL DEFAULT ''"},
 	{table: "workspace_leases", column: "sandbox_id", definition: "TEXT NOT NULL DEFAULT ''"},
@@ -441,7 +442,7 @@ func (s *Store) CreateTask(ctx context.Context, in CreateTaskInput) (Task, error
 // GetTask reads a Task and its dependency IDs.
 func (s *Store) GetTask(ctx context.Context, id string) (Task, error) {
 	task, err := scanTask(s.db.QueryRowContext(ctx,
-		`SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract,
+		`SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract, contract_kind,
 		        status, created_at, updated_at
 		 FROM tasks WHERE id = ?`, id))
 	if err != nil {
@@ -458,7 +459,7 @@ func (s *Store) GetTask(ctx context.Context, id string) (Task, error) {
 // ListTasks returns a Mission's Tasks in creation order.
 func (s *Store) ListTasks(ctx context.Context, missionID string) ([]Task, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract,
+		`SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract, contract_kind,
 		        status, created_at, updated_at
 		 FROM tasks WHERE mission_id = ? ORDER BY created_at, id`, missionID)
 	if err != nil {
@@ -501,7 +502,7 @@ func (s *Store) StartAttempt(ctx context.Context, taskID, worker string) (TaskAt
 	}
 	defer func() { _ = tx.Rollback() }()
 	task, err := scanTask(tx.QueryRowContext(ctx, `
-		SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract,
+		SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract, contract_kind,
 		       status, created_at, updated_at
 		FROM tasks WHERE id = ?`, taskID))
 	if err != nil {
@@ -792,7 +793,7 @@ func (s *Store) TransitionTask(ctx context.Context, id string, next TaskStatus) 
 	}
 	defer func() { _ = tx.Rollback() }()
 	current, err := scanTask(tx.QueryRowContext(ctx,
-		`SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract,
+		`SELECT id, mission_id, title, COALESCE(client_id, ''), position, contract, contract_kind,
 		        status, created_at, updated_at
 		 FROM tasks WHERE id = ?`, id))
 	if err != nil {
@@ -805,7 +806,7 @@ func (s *Store) TransitionTask(ctx context.Context, id string, next TaskStatus) 
 	if _, err := tx.ExecContext(ctx, `UPDATE tasks SET status = ?, updated_at = ? WHERE id = ?`, next, unixMillis(now), id); err != nil {
 		return Task{}, fmt.Errorf("update task status: %w", err)
 	}
-	if next == TaskSucceeded {
+	if next == TaskSucceeded || next == TaskVerifying {
 		if err := queueReadyDependents(ctx, tx, id, now); err != nil {
 			return Task{}, err
 		}
@@ -854,6 +855,7 @@ func scanTask(row rowScanner) (Task, error) {
 		&task.ClientID,
 		&task.Position,
 		&task.Contract,
+		&task.ContractKind,
 		&task.Status,
 		&createdAt,
 		&updatedAt,
@@ -1020,7 +1022,11 @@ func queueReadyDependents(ctx context.Context, tx *sql.Tx, dependencyID string, 
 			SELECT COUNT(*)
 			FROM task_dependencies d
 			JOIN tasks dependency ON dependency.id = d.dependency_id
-			WHERE d.task_id = ? AND dependency.status != ?`, taskID, TaskSucceeded).Scan(&unmet); err != nil {
+			JOIN tasks dependent ON dependent.id = d.task_id
+			WHERE d.task_id = ?
+			  AND dependency.status != ?
+			  AND NOT (dependent.contract_kind = ? AND dependency.status = ?)`,
+			taskID, TaskSucceeded, ContractVerification, TaskVerifying).Scan(&unmet); err != nil {
 			return fmt.Errorf("check unmet dependencies: %w", err)
 		}
 		if unmet == 0 {

--- a/internal/mission/store.go
+++ b/internal/mission/store.go
@@ -683,11 +683,10 @@ func (s *Store) AddEvidence(ctx context.Context, in CreateEvidenceInput) (Eviden
 		return Evidence{}, err
 	}
 	if in.VerifierAttemptID != "" {
-		if err := validateAttemptWith(
+		if err := validateAttemptInMission(
 			ctx,
 			tx,
 			in.MissionID,
-			in.TaskID,
 			in.VerifierAttemptID,
 		); err != nil {
 			return Evidence{}, fmt.Errorf("validate verifier attempt: %w", err)
@@ -924,6 +923,32 @@ func validateAttemptWith(ctx context.Context, q queryRower, missionID, taskID, a
 		JOIN tasks task ON task.id = attempt.task_id
 		WHERE attempt.id = ? AND attempt.task_id = ? AND task.mission_id = ?`,
 		attemptID, taskID, missionID).Scan(&count); err != nil {
+		return fmt.Errorf("validate task attempt: %w", err)
+	}
+	if count == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// validateAttemptInMission confirms attemptID belongs to some Task within
+// missionID, without requiring it to belong to one specific Task. Unlike
+// validateAttemptWith's producer-Attempt check, a verifier Attempt
+// legitimately belongs to a different Task than the one it is producing
+// Evidence for — an independent verification Task depends on (but is not) the
+// Task it re-verifies, so its own Attempt's task_id never equals the target
+// Task's ID. Scoping the check to the Mission instead of one Task preserves
+// the invariant that actually matters (the verifier Attempt is real and
+// belongs to the same Mission) without wrongly rejecting this legitimate
+// cross-Task pattern.
+func validateAttemptInMission(ctx context.Context, q queryRower, missionID, attemptID string) error {
+	var count int
+	if err := q.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM task_attempts attempt
+		JOIN tasks task ON task.id = attempt.task_id
+		WHERE attempt.id = ? AND task.mission_id = ?`,
+		attemptID, missionID).Scan(&count); err != nil {
 		return fmt.Errorf("validate task attempt: %w", err)
 	}
 	if count == 0 {

--- a/internal/mission/store_test.go
+++ b/internal/mission/store_test.go
@@ -422,3 +422,102 @@ func tableHasColumn(t *testing.T, db *sql.DB, table, column string) bool {
 	}
 	return false
 }
+
+func TestTransitionTaskToVerifyingUnblocksVerificationDependent(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, PlanInput{Tasks: []TaskInput{
+		{ClientID: "impl", Position: 1, Title: "Implement", Contract: "do the work", ContractKind: ContractImplementation},
+		{ClientID: "verify", Position: 2, Title: "Verify", Contract: "verify the work", ContractKind: ContractVerification, Dependencies: []string{"impl"}},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var implID, verifyID string
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "impl":
+			implID = task.ID
+			if task.Status != TaskQueued {
+				t.Fatalf("impl task status = %s, want queued (root task)", task.Status)
+			}
+		case "verify":
+			verifyID = task.ID
+			if task.Status != TaskBlocked {
+				t.Fatalf("verify task status = %s, want blocked (has a dependency)", task.Status)
+			}
+		}
+	}
+	if implID == "" || verifyID == "" {
+		t.Fatal("expected both impl and verify tasks to exist")
+	}
+
+	if _, err := store.AcquireLease(context.Background(), implID, "/tmp/fake-impl", "impl-branch", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), implID, "test-worker"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(context.Background(), implID, TaskVerifying); err != nil {
+		t.Fatalf("TransitionTask to verifying: %v", err)
+	}
+
+	got, err := store.GetTask(context.Background(), verifyID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != TaskQueued {
+		t.Fatalf("verify task status = %s, want queued once its dependency reached verifying", got.Status)
+	}
+}
+
+func TestTransitionTaskToVerifyingDoesNotUnblockImplementationDependent(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, PlanInput{Tasks: []TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A", ContractKind: ContractImplementation},
+		{ClientID: "b", Position: 2, Title: "B", Contract: "do B, depends on A", ContractKind: ContractImplementation, Dependencies: []string{"a"}},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var aID, bID string
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "a":
+			aID = task.ID
+		case "b":
+			bID = task.ID
+		}
+	}
+
+	if _, err := store.AcquireLease(context.Background(), aID, "/tmp/fake-a", "a-branch", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), aID, "test-worker"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(context.Background(), aID, TaskVerifying); err != nil {
+		t.Fatalf("TransitionTask to verifying: %v", err)
+	}
+
+	got, err := store.GetTask(context.Background(), bID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != TaskBlocked {
+		t.Fatalf("regression: b task status = %s, want still blocked — an implementation dependent must wait for succeeded, not verifying", got.Status)
+	}
+}

--- a/internal/mission/types.go
+++ b/internal/mission/types.go
@@ -327,18 +327,28 @@ type Mission struct {
 	UpdatedAt          time.Time
 }
 
+// ContractKind values classify what behavior a Task's Worker should perform.
+// An empty ContractKind is treated as ContractImplementation everywhere it is
+// read (ValidateTaskInputs accepts it; normalizePlanInput defaults it).
+const (
+	ContractImplementation = "implementation"
+	ContractVerification   = "verification"
+	ContractIntegration    = "integration"
+)
+
 // Task is a dependency-aware unit of work within one Mission.
 type Task struct {
-	ID        string
-	MissionID string
-	Title     string
-	ClientID  string
-	Position  int
-	Contract  string
-	Status    TaskStatus
-	DependsOn []string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID           string
+	MissionID    string
+	Title        string
+	ClientID     string
+	Position     int
+	Contract     string
+	ContractKind string
+	Status       TaskStatus
+	DependsOn    []string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 // TaskAttempt records one Worker execution of a Task.
@@ -457,6 +467,7 @@ type TaskInput struct {
 	Position     int
 	Title        string
 	Contract     string
+	ContractKind string
 	Dependencies []string
 }
 
@@ -544,6 +555,11 @@ func ValidateTaskInputs(inputs []TaskInput) error {
 		}
 		if strings.TrimSpace(input.Contract) == "" {
 			return fmt.Errorf("task %q contract is required", clientID)
+		}
+		switch input.ContractKind {
+		case "", ContractImplementation, ContractVerification, ContractIntegration:
+		default:
+			return fmt.Errorf("task %q has unknown contract kind %q", clientID, input.ContractKind)
 		}
 		byClientID[clientID] = input
 	}

--- a/internal/mission/types_test.go
+++ b/internal/mission/types_test.go
@@ -128,6 +128,28 @@ func TestValidateTaskInputs(t *testing.T) {
 	}
 }
 
+func TestValidateTaskInputsAcceptsKnownContractKinds(t *testing.T) {
+	for _, kind := range []string{"", ContractImplementation, ContractVerification, ContractIntegration} {
+		t.Run(kind, func(t *testing.T) {
+			err := ValidateTaskInputs([]TaskInput{
+				{ClientID: "a", Title: "A", Contract: "do A", ContractKind: kind},
+			})
+			if err != nil {
+				t.Fatalf("ValidateTaskInputs(kind=%q): %v", kind, err)
+			}
+		})
+	}
+}
+
+func TestValidateTaskInputsRejectsUnknownContractKind(t *testing.T) {
+	err := ValidateTaskInputs([]TaskInput{
+		{ClientID: "a", Title: "A", Contract: "do A", ContractKind: "bogus"},
+	})
+	if err == nil {
+		t.Fatal("ValidateTaskInputs with unknown ContractKind = nil error, want an error")
+	}
+}
+
 type transitionCase[S comparable] struct {
 	name string
 	from S

--- a/internal/mission/verification_store.go
+++ b/internal/mission/verification_store.go
@@ -1,0 +1,58 @@
+package mission
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// GetLatestLease returns the most recently created WorkspaceLease for a Task,
+// regardless of its current status (active, released, or expired). Verifier
+// Tasks use this to find the worktree/branch an implementation Task's Worker
+// used, so they can check out the same commit independently.
+func (s *Store) GetLatestLease(ctx context.Context, taskID string) (WorkspaceLease, error) {
+	var lease WorkspaceLease
+	var expiresAt, createdAt int64
+	var releasedAt sql.NullInt64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, task_id, path, branch, sandbox_id, status, expires_at, created_at, released_at
+		FROM workspace_leases
+		WHERE task_id = ?
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1`, taskID,
+	).Scan(
+		&lease.ID, &lease.TaskID, &lease.Path, &lease.Branch, &lease.SandboxID,
+		&lease.Status, &expiresAt, &createdAt, &releasedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return WorkspaceLease{}, fmt.Errorf("task %s: %w", taskID, ErrNotFound)
+	}
+	if err != nil {
+		return WorkspaceLease{}, fmt.Errorf("get latest lease: %w", err)
+	}
+	lease.ExpiresAt = fromUnixMillis(expiresAt)
+	lease.CreatedAt = fromUnixMillis(createdAt)
+	if releasedAt.Valid {
+		value := fromUnixMillis(releasedAt.Int64)
+		lease.ReleasedAt = &value
+	}
+	return lease, nil
+}
+
+// GetLatestAttempt returns the most recently created TaskAttempt for a Task.
+// Verifier Tasks use this to find the AttemptID a passing/failing Evidence
+// record should reference as the artifact producer (Evidence.AttemptID),
+// distinct from the verifying Attempt itself (Evidence.VerifierAttemptID).
+func (s *Store) GetLatestAttempt(ctx context.Context, taskID string) (TaskAttempt, error) {
+	attempt, err := scanAttempt(s.db.QueryRowContext(ctx, `
+		SELECT id, task_id, COALESCE(lease_id, ''), worker, status, created_at, updated_at
+		FROM task_attempts
+		WHERE task_id = ?
+		ORDER BY created_at DESC, id DESC
+		LIMIT 1`, taskID))
+	if err != nil {
+		return TaskAttempt{}, fmt.Errorf("get latest attempt for task %s: %w", taskID, err)
+	}
+	return attempt, nil
+}

--- a/internal/mission/verification_store_test.go
+++ b/internal/mission/verification_store_test.go
@@ -1,0 +1,47 @@
+package mission
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGetLatestLeaseReturnsMostRecentLease(t *testing.T) {
+	store, task := newReadyTask(t)
+	if _, err := store.AcquireLease(context.Background(), task.ID, "wt/a", "branch/a", "sbx-a", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.GetLatestLease(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("GetLatestLease: %v", err)
+	}
+	if got.Path != "wt/a" || got.Branch != "branch/a" {
+		t.Fatalf("lease = %+v, want path=wt/a branch=branch/a", got)
+	}
+}
+
+func TestGetLatestLeaseRejectsUnknownTask(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.GetLatestLease(context.Background(), "does-not-exist"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetLatestLease on unknown task: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetLatestAttemptReturnsMostRecentAttempt(t *testing.T) {
+	store, attempt := newRunningAttempt(t)
+	got, err := store.GetLatestAttempt(context.Background(), attempt.TaskID)
+	if err != nil {
+		t.Fatalf("GetLatestAttempt: %v", err)
+	}
+	if got.ID != attempt.ID {
+		t.Fatalf("attempt.ID = %s, want %s", got.ID, attempt.ID)
+	}
+}
+
+func TestGetLatestAttemptRejectsUnknownTask(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.GetLatestAttempt(context.Background(), "does-not-exist"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetLatestAttempt on unknown task: err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/scheduler/routing.go
+++ b/internal/scheduler/routing.go
@@ -1,0 +1,40 @@
+// Package scheduler (existing package, new file).
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/harness9/internal/mission"
+)
+
+// RoutingDispatcher dispatches each Task to a different Dispatcher based on
+// its ContractKind, so the Scheduler itself stays agnostic to how many kinds
+// of Task Contract exist. A Task with an empty ContractKind routes to the
+// mission.ContractImplementation entry, matching mission.ValidateTaskInputs'
+// treatment of an unset ContractKind as an implicit default.
+type RoutingDispatcher struct {
+	byKind map[string]Dispatcher
+}
+
+// NewRoutingDispatcher creates a RoutingDispatcher. byKind's keys are
+// mission.ContractKind values (e.g. mission.ContractImplementation); a Task
+// whose resolved ContractKind has no matching entry causes Dispatch to
+// return an error rather than silently dropping the Task.
+func NewRoutingDispatcher(byKind map[string]Dispatcher) *RoutingDispatcher {
+	return &RoutingDispatcher{byKind: byKind}
+}
+
+// Dispatch implements Dispatcher by delegating to the sub-Dispatcher
+// registered for task's ContractKind.
+func (r *RoutingDispatcher) Dispatch(ctx context.Context, task mission.Task) error {
+	kind := task.ContractKind
+	if kind == "" {
+		kind = mission.ContractImplementation
+	}
+	d, ok := r.byKind[kind]
+	if !ok {
+		return fmt.Errorf("no dispatcher registered for contract kind %q", kind)
+	}
+	return d.Dispatch(ctx, task)
+}

--- a/internal/scheduler/routing_test.go
+++ b/internal/scheduler/routing_test.go
@@ -1,0 +1,69 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/harness9/internal/mission"
+)
+
+type recordingDispatcher struct {
+	calls []string
+	err   error
+}
+
+func (d *recordingDispatcher) Dispatch(ctx context.Context, task mission.Task) error {
+	d.calls = append(d.calls, task.ID)
+	return d.err
+}
+
+func TestRoutingDispatcherRoutesByContractKind(t *testing.T) {
+	impl := &recordingDispatcher{}
+	verify := &recordingDispatcher{}
+	router := NewRoutingDispatcher(map[string]Dispatcher{
+		mission.ContractImplementation: impl,
+		mission.ContractVerification:   verify,
+	})
+
+	if err := router.Dispatch(context.Background(), mission.Task{ID: "t1", ContractKind: mission.ContractImplementation}); err != nil {
+		t.Fatalf("Dispatch (implementation): %v", err)
+	}
+	if err := router.Dispatch(context.Background(), mission.Task{ID: "t2", ContractKind: mission.ContractVerification}); err != nil {
+		t.Fatalf("Dispatch (verification): %v", err)
+	}
+	if len(impl.calls) != 1 || impl.calls[0] != "t1" {
+		t.Fatalf("impl.calls = %v, want [t1]", impl.calls)
+	}
+	if len(verify.calls) != 1 || verify.calls[0] != "t2" {
+		t.Fatalf("verify.calls = %v, want [t2]", verify.calls)
+	}
+}
+
+func TestRoutingDispatcherDefaultsEmptyContractKindToImplementation(t *testing.T) {
+	impl := &recordingDispatcher{}
+	router := NewRoutingDispatcher(map[string]Dispatcher{mission.ContractImplementation: impl})
+
+	if err := router.Dispatch(context.Background(), mission.Task{ID: "t1", ContractKind: ""}); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(impl.calls) != 1 {
+		t.Fatalf("impl.calls = %v, want exactly one call", impl.calls)
+	}
+}
+
+func TestRoutingDispatcherRejectsUnknownContractKind(t *testing.T) {
+	router := NewRoutingDispatcher(map[string]Dispatcher{mission.ContractImplementation: &recordingDispatcher{}})
+	err := router.Dispatch(context.Background(), mission.Task{ID: "t1", ContractKind: "integration"})
+	if err == nil {
+		t.Fatal("Dispatch with unregistered contract kind = nil error, want an error")
+	}
+}
+
+func TestRoutingDispatcherPropagatesSubDispatcherError(t *testing.T) {
+	failing := &recordingDispatcher{err: errors.New("boom")}
+	router := NewRoutingDispatcher(map[string]Dispatcher{mission.ContractImplementation: failing})
+	if err := router.Dispatch(context.Background(), mission.Task{ID: "t1"}); err == nil {
+		t.Fatal("Dispatch = nil error, want the sub-dispatcher's error propagated")
+	}
+}

--- a/internal/verifier/adapter.go
+++ b/internal/verifier/adapter.go
@@ -3,9 +3,11 @@ package verifier
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 	"time"
 
+	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/mission"
 )
 
@@ -86,8 +88,82 @@ func verifyWorktreeFor(repoRoot string, task mission.Task) (path, branch string)
 	return path, branch
 }
 
-// run is deliberately a no-op in this task: Task 4's tests only assert on
-// Dispatch's synchronous bookkeeping, not on any asynchronous outcome. Task 5
-// replaces this body with real verification logic (and its own tests).
+// run executes independent verification and records the outcome. It always
+// runs on a's baseCtx, not the ctx Dispatch's caller passed in, so it
+// survives past the lifetime of any single Tick call.
 func (a *Adapter) run(verifierTask mission.Task, targetID string, lease mission.WorkspaceLease, attempt mission.TaskAttempt) {
+	report := runVerificationChecks(lease.Path)
+	a.complete(verifierTask, targetID, attempt, lease, report)
+}
+
+// complete records the result of one verification Attempt. A conclusive
+// verification result — pass or fail — always: (1) records Evidence tagged
+// with both the target's own AttemptID and this Attempt's ID as
+// VerifierAttemptID, (2) advances the TARGET Task (not this verification
+// Task) to succeeded or failed based on the report, and (3) advances this
+// verification Task itself to succeeded, since it did its job correctly
+// regardless of what it found. Only a process failure (couldn't load the
+// target's attempt, or a Store write itself failed) fails this verification
+// Task via failVerifierOnly, leaving the target Task untouched in verifying
+// for a future verification Attempt to retry — a broken verification
+// process must never be mistaken for a verified failure of the target.
+func (a *Adapter) complete(
+	verifierTask mission.Task,
+	targetID string,
+	attempt mission.TaskAttempt,
+	lease mission.WorkspaceLease,
+	report verificationReport,
+) {
+	defer func() {
+		if _, err := a.store.ReleaseLease(a.baseCtx, lease.ID); err != nil {
+			log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("释放 lease %s 失败: %v", lease.ID, err)))
+		}
+	}()
+
+	targetAttempt, err := a.store.GetLatestAttempt(a.baseCtx, targetID)
+	if err != nil {
+		a.failVerifierOnly(verifierTask, attempt, "load target attempt", err.Error())
+		return
+	}
+	if _, err := a.store.AddEvidence(a.baseCtx, mission.CreateEvidenceInput{
+		MissionID: verifierTask.MissionID, TaskID: targetID, AttemptID: targetAttempt.ID,
+		VerifierAttemptID: attempt.ID, Kind: "independent_verification",
+		Content: []byte(report.output), Passed: report.passed,
+	}); err != nil {
+		a.failVerifierOnly(verifierTask, attempt, "record evidence", err.Error())
+		return
+	}
+
+	targetNext := mission.TaskFailed
+	if report.passed {
+		targetNext = mission.TaskSucceeded
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, targetID, targetNext); err != nil {
+		a.failVerifierOnly(verifierTask, attempt, "transition target task", err.Error())
+		return
+	}
+
+	if _, err := a.store.TransitionAttempt(a.baseCtx, attempt.ID, mission.AttemptSucceeded); err != nil {
+		log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("推进 attempt %s 失败: %v", attempt.ID, err)))
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, verifierTask.ID, mission.TaskVerifying); err != nil {
+		log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("推进 verifier task %s 失败: %v", verifierTask.ID, err)))
+		return
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, verifierTask.ID, mission.TaskSucceeded); err != nil {
+		log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("推进 verifier task %s 失败: %v", verifierTask.ID, err)))
+	}
+}
+
+// failVerifierOnly marks the verification Task itself failed without
+// touching the target Task at all, so a future verification Attempt can
+// still retry it.
+func (a *Adapter) failVerifierOnly(verifierTask mission.Task, attempt mission.TaskAttempt, kind, detail string) {
+	if _, err := a.store.TransitionAttempt(a.baseCtx, attempt.ID, mission.AttemptFailed); err != nil {
+		log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("推进 attempt %s 失败: %v", attempt.ID, err)))
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, verifierTask.ID, mission.TaskFailed); err != nil {
+		log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("推进 verifier task %s 失败: %v", verifierTask.ID, err)))
+	}
+	log.Print(logfmt.FormatMsg("verifier", fmt.Sprintf("%s: %s", kind, detail)))
 }

--- a/internal/verifier/adapter.go
+++ b/internal/verifier/adapter.go
@@ -31,6 +31,12 @@ func NewAdapter(store *mission.Store, repoRoot string, baseCtx context.Context) 
 	return &Adapter{store: store, repoRoot: repoRoot, leaseTTL: 2 * time.Hour, baseCtx: baseCtx}
 }
 
+// var _ ... proves Adapter has the exact method shape scheduler.Dispatcher
+// requires, without importing internal/scheduler.
+var _ interface {
+	Dispatch(ctx context.Context, task mission.Task) error
+} = (*Adapter)(nil)
+
 // Dispatch implements scheduler.Dispatcher. On any failure it leaves no
 // partial state behind, mirroring internal/worker.Adapter.Dispatch: an
 // already-created worktree is removed, an already-acquired lease is

--- a/internal/verifier/adapter.go
+++ b/internal/verifier/adapter.go
@@ -1,0 +1,93 @@
+package verifier
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/harness9/internal/mission"
+)
+
+// Adapter implements scheduler.Dispatcher for mission.ContractVerification
+// Tasks. Dispatch requires task to depend on exactly one other Task — the
+// one it verifies. It looks up that Task's most recent Lease to find the
+// branch its Worker committed to, checks out an independent, detached
+// worktree from that branch, and asynchronously re-runs verification there —
+// bounded by the Adapter's own long-lived context, not the caller's per-Tick
+// ctx, the same pattern internal/worker.Adapter already established.
+type Adapter struct {
+	store    *mission.Store
+	repoRoot string
+	leaseTTL time.Duration
+	baseCtx  context.Context
+}
+
+// NewAdapter creates an Adapter. repoRoot is the harness9 repository root new
+// verification worktrees are created relative to.
+func NewAdapter(store *mission.Store, repoRoot string, baseCtx context.Context) *Adapter {
+	return &Adapter{store: store, repoRoot: repoRoot, leaseTTL: 2 * time.Hour, baseCtx: baseCtx}
+}
+
+// Dispatch implements scheduler.Dispatcher. On any failure it leaves no
+// partial state behind, mirroring internal/worker.Adapter.Dispatch: an
+// already-created worktree is removed, an already-acquired lease is
+// released, and (if StartAttempt itself is what failed) the Task is
+// explicitly requeued rather than left stuck in leased.
+func (a *Adapter) Dispatch(ctx context.Context, task mission.Task) error {
+	if len(task.DependsOn) != 1 {
+		return fmt.Errorf("verification task %s must depend on exactly one task, got %d", task.ID, len(task.DependsOn))
+	}
+	targetID := task.DependsOn[0]
+
+	targetLease, err := a.store.GetLatestLease(ctx, targetID)
+	if err != nil {
+		return fmt.Errorf("get target lease: %w", err)
+	}
+
+	path, branch := verifyWorktreeFor(a.repoRoot, task)
+	if err := CreateDetachedWorktree(a.repoRoot, path, targetLease.Branch); err != nil {
+		return fmt.Errorf("create detached worktree: %w", err)
+	}
+
+	lease, err := a.store.AcquireLease(ctx, task.ID, path, branch, "", a.leaseTTL)
+	if err != nil {
+		if removeErr := RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			return fmt.Errorf("acquire lease: %w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("acquire lease: %w", err)
+	}
+
+	attempt, err := a.store.StartAttempt(ctx, task.ID, "verifier-adapter")
+	if err != nil {
+		if _, transErr := a.store.TransitionTask(ctx, task.ID, mission.TaskQueued); transErr != nil {
+			err = fmt.Errorf("%w (requeue also failed: %v)", err, transErr)
+		}
+		if _, releaseErr := a.store.ReleaseLease(ctx, lease.ID); releaseErr != nil {
+			err = fmt.Errorf("%w (lease release also failed: %v)", err, releaseErr)
+		}
+		if removeErr := RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			err = fmt.Errorf("%w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("start attempt: %w", err)
+	}
+
+	go a.run(task, targetID, lease, attempt)
+	return nil
+}
+
+// verifyWorktreeFor computes a deterministic, collision-free path and an
+// informational (non-git, since the worktree is detached) branch label for
+// one verification Task, keyed off the verification Task's own ID — always
+// unique, for the same reason internal/worker.worktreeFor keys off Task.ID.
+func verifyWorktreeFor(repoRoot string, task mission.Task) (path, branch string) {
+	path = filepath.Join(repoRoot, ".harness9", "verify", task.MissionID, task.ID)
+	branch = fmt.Sprintf("verify:%s", task.ID)
+	return path, branch
+}
+
+// run is deliberately a no-op in this task: Task 4's tests only assert on
+// Dispatch's synchronous bookkeeping, not on any asynchronous outcome. Task 5
+// replaces this body with real verification logic (and its own tests).
+func (a *Adapter) run(verifierTask mission.Task, targetID string, lease mission.WorkspaceLease, attempt mission.TaskAttempt) {
+}

--- a/internal/verifier/adapter_test.go
+++ b/internal/verifier/adapter_test.go
@@ -1,0 +1,158 @@
+package verifier
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/harness9/internal/mission"
+)
+
+func newTestStore(t *testing.T) *mission.Store {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "mission.db") + "?_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := mission.NewStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+// newVerifiableTarget builds an approved Mission with one implementation Task
+// ("impl") and one verification Task ("verify") depending on it, then
+// simulates a completed Worker Adapter run on "impl" (a real Lease + Attempt
+// + a real commit in a real worktree, transitioned to verifying) so a
+// verifier.Adapter has something real to check out and re-verify.
+func newVerifiableTarget(t *testing.T, store *mission.Store, repoRoot string) (target, verifyTask mission.Task) {
+	t.Helper()
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, mission.CreateMissionInput{Goal: "ship a feature"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := store.CreateDraftPlan(ctx, m.ID, mission.PlanInput{Tasks: []mission.TaskInput{
+		{ClientID: "impl", Position: 1, Title: "Implement", Contract: "implement the thing", ContractKind: mission.ContractImplementation},
+		{ClientID: "verify", Position: 2, Title: "Verify", Contract: "verify the implementation", ContractKind: mission.ContractVerification, Dependencies: []string{"impl"}},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := mission.NewCommandService(store)
+	if _, err := svc.ApprovePlan(ctx, mission.ApprovePlanCommand{
+		MissionID: m.ID, Version: plan.Version, Actor: "user:zsa", Reason: "looks good", IdempotencyKey: "approve-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(ctx, m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "impl":
+			target = task
+		case "verify":
+			verifyTask = task
+		}
+	}
+	if target.ID == "" || verifyTask.ID == "" {
+		t.Fatal("newVerifiableTarget: expected both impl and verify tasks to exist")
+	}
+
+	implPath := filepath.Join(repoRoot, ".harness9", "missions", target.ID)
+	implBranch := "mission/" + target.ID
+	cmd := exec.Command("git", "worktree", "add", implPath, "-b", implBranch)
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add %s: %v\n%s", implPath, err, out)
+	}
+	if err := os.WriteFile(filepath.Join(implPath, "feature.go"), []byte("package main\n\n// Feature reports a fixed greeting for the fixture module.\nfunc Feature() string { return \"done\" }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, implPath, "add", "-A")
+	runGit(t, implPath, "commit", "-q", "-m", "feat: implementation work")
+
+	if _, err := store.AcquireLease(ctx, target.ID, implPath, implBranch, "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(ctx, target.ID, "worker-adapter"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(ctx, target.ID, mission.TaskVerifying); err != nil {
+		t.Fatal(err)
+	}
+	verifyTask, err = store.GetTask(ctx, verifyTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return target, verifyTask
+}
+
+func TestDispatchCreatesDetachedWorktreeLeaseAndAttempt(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	_, verifyTask := newVerifiableTarget(t, store, repoRoot)
+	adapter := NewAdapter(store, repoRoot, context.Background())
+
+	if err := adapter.Dispatch(context.Background(), verifyTask); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	path, _ := verifyWorktreeFor(repoRoot, verifyTask)
+	if _, err := os.Stat(filepath.Join(path, "feature.go")); err != nil {
+		t.Fatalf("verifier worktree missing the implementer's commit: %v", err)
+	}
+
+	updated, err := store.GetTask(context.Background(), verifyTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != mission.TaskRunning {
+		t.Fatalf("verify task status = %s, want running", updated.Status)
+	}
+}
+
+func TestDispatchRejectsTaskWithoutExactlyOneDependency(t *testing.T) {
+	store := newTestStore(t)
+	repoRoot := newTestRepo(t)
+	adapter := NewAdapter(store, repoRoot, context.Background())
+
+	err := adapter.Dispatch(context.Background(), mission.Task{ID: "orphan-verifier", ContractKind: mission.ContractVerification})
+	if err == nil {
+		t.Fatal("Dispatch on a verification task with zero dependencies = nil error, want an error")
+	}
+}
+
+func TestDispatchRollsBackWorktreeWhenLeaseAcquisitionFails(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	_, verifyTask := newVerifiableTarget(t, store, repoRoot)
+	// Force AcquireLease to fail: transition the verify task to a status from
+	// which no lease can legally be acquired. CreateDetachedWorktree still
+	// succeeds first, since the path is fresh.
+	if _, err := store.TransitionTask(context.Background(), verifyTask.ID, mission.TaskFailed); err != nil {
+		t.Fatalf("pre-transition verify task to failed: %v", err)
+	}
+	adapter := NewAdapter(store, repoRoot, context.Background())
+
+	err := adapter.Dispatch(context.Background(), verifyTask)
+	if err == nil {
+		t.Fatal("Dispatch error = nil, want an error since the task cannot acquire a lease")
+	}
+
+	path, _ := verifyWorktreeFor(repoRoot, verifyTask)
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree at %s still exists after a failed Dispatch, want it rolled back", path)
+	}
+}

--- a/internal/verifier/adapter_test.go
+++ b/internal/verifier/adapter_test.go
@@ -169,6 +169,49 @@ func TestDispatchRollsBackWorktreeWhenLeaseAcquisitionFails(t *testing.T) {
 	}
 }
 
+// TestDispatchRequeuesTaskWhenStartAttemptFails exercises the rollback branch
+// that runs after AcquireLease has already advanced the verification Task
+// from queued to leased but StartAttempt subsequently fails. Regression test
+// for the same class of bug internal/worker.Adapter guards against (see
+// worker's TestDispatchRevertsTaskToQueuedWhenStartAttemptFails): a rollback
+// that releases the lease and removes the worktree but never calls
+// TransitionTask would permanently strand the Task in mission.TaskLeased
+// (with no active lease and no attempt row), where ListSchedulableTasks would
+// never pick it up again. A near-zero lease TTL deterministically makes
+// StartAttempt observe an already-expired lease for the verification Task's
+// own lease (acquired via this Adapter's leaseTTL) — not the target's lease,
+// which newVerifiableTarget's fixture already acquired separately with a
+// full one-hour TTL and which StartAttempt never inspects.
+func TestDispatchRequeuesTaskWhenStartAttemptFails(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	_, verifyTask := newVerifiableTarget(t, store, repoRoot)
+	adapter := &Adapter{
+		store:    store,
+		repoRoot: repoRoot,
+		leaseTTL: time.Nanosecond,
+		baseCtx:  context.Background(),
+	}
+
+	err := adapter.Dispatch(context.Background(), verifyTask)
+	if err == nil {
+		t.Fatal("Dispatch error = nil, want an error since the lease is already expired by the time StartAttempt runs")
+	}
+
+	updated, getErr := store.GetTask(context.Background(), verifyTask.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if updated.Status != mission.TaskQueued {
+		t.Fatalf("verify task status = %s, want queued (Dispatch must revert the Task to queued when StartAttempt fails, per scheduler.Dispatcher's contract)", updated.Status)
+	}
+
+	path, _ := verifyWorktreeFor(repoRoot, verifyTask)
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("worktree at %s still exists after a failed Dispatch, want it rolled back", path)
+	}
+}
+
 func TestDispatchVerifiesSuccessfullyAndAdvancesTargetToSucceeded(t *testing.T) {
 	repoRoot := newTestRepo(t)
 	store := newTestStore(t)

--- a/internal/verifier/adapter_test.go
+++ b/internal/verifier/adapter_test.go
@@ -102,7 +102,7 @@ func newVerifiableTarget(t *testing.T, store *mission.Store, repoRoot string) (t
 func TestDispatchCreatesDetachedWorktreeLeaseAndAttempt(t *testing.T) {
 	repoRoot := newTestRepo(t)
 	store := newTestStore(t)
-	_, verifyTask := newVerifiableTarget(t, store, repoRoot)
+	target, verifyTask := newVerifiableTarget(t, store, repoRoot)
 	adapter := NewAdapter(store, repoRoot, context.Background())
 
 	if err := adapter.Dispatch(context.Background(), verifyTask); err != nil {
@@ -121,6 +121,18 @@ func TestDispatchCreatesDetachedWorktreeLeaseAndAttempt(t *testing.T) {
 	if updated.Status != mission.TaskRunning {
 		t.Fatalf("verify task status = %s, want running", updated.Status)
 	}
+
+	// Dispatch's synchronous bookkeeping above is this test's actual subject,
+	// but Dispatch also launches a.run on a background goroutine that now
+	// performs a real go build/vet/test against the worktree (Task 5),
+	// instead of Task 4's no-op. Returning before that goroutine finishes
+	// would let it keep running after t.Cleanup closes this test's store's
+	// DB, so wait for the verification Task it drives to reach a terminal
+	// status first. newVerifiableTarget's fixture is a valid, passing Go
+	// module and nothing in this test breaks it, so both the target and the
+	// verifier converge on succeeded.
+	waitForTaskStatus(t, store, target.ID, mission.TaskSucceeded, 30*time.Second)
+	waitForTaskStatus(t, store, verifyTask.ID, mission.TaskSucceeded, time.Second)
 }
 
 func TestDispatchRejectsTaskWithoutExactlyOneDependency(t *testing.T) {

--- a/internal/verifier/adapter_test.go
+++ b/internal/verifier/adapter_test.go
@@ -156,3 +156,93 @@ func TestDispatchRollsBackWorktreeWhenLeaseAcquisitionFails(t *testing.T) {
 		t.Fatalf("worktree at %s still exists after a failed Dispatch, want it rolled back", path)
 	}
 }
+
+func TestDispatchVerifiesSuccessfullyAndAdvancesTargetToSucceeded(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	target, verifyTask := newVerifiableTarget(t, store, repoRoot)
+	adapter := NewAdapter(store, repoRoot, context.Background())
+
+	if err := adapter.Dispatch(context.Background(), verifyTask); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	waitForTaskStatus(t, store, target.ID, mission.TaskSucceeded, 30*time.Second)
+	waitForTaskStatus(t, store, verifyTask.ID, mission.TaskSucceeded, time.Second)
+
+	evidence, err := store.ListEvidence(context.Background(), target.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || !evidence[0].Passed {
+		t.Fatalf("evidence = %+v, want exactly one passing record", evidence)
+	}
+	targetAttempt, err := store.GetLatestAttempt(context.Background(), target.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence[0].AttemptID != targetAttempt.ID {
+		t.Fatalf("evidence.AttemptID = %s, want the target's own attempt %s", evidence[0].AttemptID, targetAttempt.ID)
+	}
+	if evidence[0].VerifierAttemptID == "" || evidence[0].VerifierAttemptID == evidence[0].AttemptID {
+		t.Fatalf("evidence.VerifierAttemptID = %q, want a distinct non-empty verifier attempt ID", evidence[0].VerifierAttemptID)
+	}
+}
+
+func TestDispatchVerificationFailureFailsTargetButVerifierSucceeds(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	target, verifyTask := newVerifiableTarget(t, store, repoRoot)
+	// Break the implementation worktree's build so independent verification
+	// genuinely fails (rather than faking a failure path).
+	implLease, err := store.GetLatestLease(context.Background(), target.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	implPath := implLease.Path
+	if err := os.WriteFile(filepath.Join(implPath, "broken.go"), []byte("package main\nfunc broken( {\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, implPath, "add", "-A")
+	runGit(t, implPath, "commit", "-q", "-m", "feat: introduce a build break")
+
+	adapter := NewAdapter(store, repoRoot, context.Background())
+	if err := adapter.Dispatch(context.Background(), verifyTask); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	waitForTaskStatus(t, store, target.ID, mission.TaskFailed, 30*time.Second)
+	waitForTaskStatus(t, store, verifyTask.ID, mission.TaskSucceeded, time.Second)
+
+	evidence, err := store.ListEvidence(context.Background(), target.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || evidence[0].Passed {
+		t.Fatalf("evidence = %+v, want exactly one failing record", evidence)
+	}
+}
+
+// waitForTaskStatus polls the store until task reaches one of the wanted
+// statuses or the timeout elapses, failing the test on timeout. Dispatch's
+// completion runs in a background goroutine, so tests must poll rather than
+// assert immediately after Dispatch returns. A generous timeout is used for
+// the two tests above since they run a real `go build`/`go vet`/`go test`
+// against the small synthetic Go module newTestRepo creates.
+func waitForTaskStatus(t *testing.T, store *mission.Store, taskID string, want mission.TaskStatus, timeout time.Duration) mission.Task {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		task, err := store.GetTask(context.Background(), taskID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if task.Status == want {
+			return task
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %s status = %s after %s, want %s", taskID, task.Status, timeout, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/verifier/verify.go
+++ b/internal/verifier/verify.go
@@ -1,0 +1,37 @@
+package verifier
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// verificationReport is the outcome of one independent re-verification pass.
+type verificationReport struct {
+	passed bool
+	output string
+}
+
+// runVerificationChecks independently re-runs the checks every implementation
+// Task Contract already runs itself (build, vet, test) inside workDir,
+// stopping at the first failing step. No LLM is involved: an independent
+// deterministic rerun is a signal a self-reported success cannot fake, which
+// is exactly what Mission's "Verifier must not verify its own artifact"
+// invariant requires.
+func runVerificationChecks(workDir string) verificationReport {
+	var output strings.Builder
+	for _, args := range [][]string{
+		{"build", "./..."},
+		{"vet", "./..."},
+		{"test", "./...", "-timeout", "5m"},
+	} {
+		cmd := exec.Command("go", args...)
+		cmd.Dir = workDir
+		out, err := cmd.CombinedOutput()
+		fmt.Fprintf(&output, "$ go %s\n%s\n", strings.Join(args, " "), out)
+		if err != nil {
+			return verificationReport{passed: false, output: output.String()}
+		}
+	}
+	return verificationReport{passed: true, output: output.String()}
+}

--- a/internal/verifier/worktree.go
+++ b/internal/verifier/worktree.go
@@ -1,0 +1,38 @@
+// Package verifier implements the independent re-verification half of
+// Mission's execution loop: it re-runs a completed implementation Task's
+// build/test/vet checks from a fresh, detached checkout of the same commit,
+// and is the only component allowed to advance a Task from verifying to
+// succeeded or failed.
+package verifier
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// CreateDetachedWorktree creates a new git worktree at path checked out at
+// ref in detached HEAD state. Unlike a normal `git worktree add <path> <ref>`,
+// this does not require ref to be free — it works even when ref (typically a
+// branch name) is already checked out in another worktree, since detached
+// HEAD only resolves ref to a commit once and never claims the branch itself.
+func CreateDetachedWorktree(repoRoot, path, ref string) error {
+	cmd := exec.Command("git", "worktree", "add", "--detach", path, ref)
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree add --detach %s %s: %w: %s", path, ref, err, out)
+	}
+	return nil
+}
+
+// RemoveWorktree force-removes a git worktree previously created by
+// CreateDetachedWorktree.
+func RemoveWorktree(repoRoot, path string) error {
+	cmd := exec.Command("git", "worktree", "remove", path, "--force")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git worktree remove %s: %w: %s", path, err, out)
+	}
+	return nil
+}

--- a/internal/verifier/worktree_test.go
+++ b/internal/verifier/worktree_test.go
@@ -1,0 +1,93 @@
+package verifier
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// newTestRepo creates a fresh git repository in a temp dir with one initial
+// commit and local git identity configured. The initial commit is a minimal
+// but valid, self-contained Go module (own go.mod, not related to harness9's
+// own module) — Task 5's tests run real `go build`/`go vet`/`go test` inside
+// worktrees of this repo, so it must actually be a buildable, testable
+// module, not just arbitrary files. Reused by later tasks' tests.
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+	runGit(t, root, "config", "user.email", "verifier-test@example.com")
+	runGit(t, root, "config", "user.name", "verifier-test")
+	files := map[string]string{
+		"go.mod":       "module verifiertestfixture\n\ngo 1.25\n",
+		"main.go":      "package main\n\nfunc main() {}\n",
+		"main_test.go": "package main\n\nimport \"testing\"\n\nfunc TestMainOK(t *testing.T) {}\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m", "initial commit")
+	return root
+}
+
+// runGit runs a git command in dir and returns trimmed stdout, failing the
+// test with full output on error.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return trimTrailingNewline(string(out))
+}
+
+func trimTrailingNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func TestCreateDetachedWorktreeChecksOutRefEvenIfCheckedOutElsewhere(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	implPath := filepath.Join(repoRoot, ".harness9", "missions", "impl")
+	runGit(t, repoRoot, "worktree", "add", implPath, "-b", "impl-branch")
+	if err := os.WriteFile(filepath.Join(implPath, "output.txt"), []byte("done\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, implPath, "add", "-A")
+	runGit(t, implPath, "commit", "-q", "-m", "feat: implementation work")
+
+	verifyPath := filepath.Join(repoRoot, ".harness9", "verify", "task")
+	if err := CreateDetachedWorktree(repoRoot, verifyPath, "impl-branch"); err != nil {
+		t.Fatalf("CreateDetachedWorktree: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(verifyPath, "output.txt")); err != nil {
+		t.Fatalf("verifier worktree missing the implementer's commit: %v", err)
+	}
+	branch := runGit(t, verifyPath, "branch", "--show-current")
+	if branch != "" {
+		t.Fatalf("verifier worktree branch = %q, want detached (empty)", branch)
+	}
+}
+
+func TestRemoveWorktreeCleansUpVerifierWorktree(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	path := filepath.Join(repoRoot, ".harness9", "verify", "task")
+	if err := CreateDetachedWorktree(repoRoot, path, "HEAD"); err != nil {
+		t.Fatalf("CreateDetachedWorktree: %v", err)
+	}
+	if err := RemoveWorktree(repoRoot, path); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("worktree path still exists after RemoveWorktree: err = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements independent re-verification for harness9's Mission Control system (M2, Phase 3 groundwork, on top of this branch's base `feat/m2-worker-adapter`), plus the `ContractKind` routing needed to support it and a future Integration Task type.

- `internal/mission` — `Task.ContractKind`/`TaskInput.ContractKind` (implementation/verification/integration, defaulting to implementation), `Store.GetLatestLease`/`GetLatestAttempt` (so a Verifier can find what an implementation Task's Worker committed).
- `internal/scheduler/routing.go` — `RoutingDispatcher`: routes each Task to a different `Dispatcher` by `ContractKind`, so the Scheduler itself stays agnostic to how many Contract kinds exist.
- `internal/verifier` (new package) — `Adapter` implementing `scheduler.Dispatcher` for verification Tasks: checks out an independent, **detached** worktree from the implementation Task's already-committed branch (no new branch, `git worktree add --detach`, so it works even though that branch is still checked out elsewhere), then independently reruns `go build`/`go vet`/`go test` — deterministically, **no LLM involved**, since a self-reported success shouldn't be the thing that gets to grade itself. Records Evidence tagged with both the producing Attempt and the verifying Attempt, and is the only thing that advances the **target** Task from `verifying` to `succeeded`/`failed`.

**A real design gap found and fixed during implementation** (documented as a "Post-hoc note" directly in the plan, `docs/superpowers/plans/2026-07-27-m2-verifier.md`): Verifier Tasks depend on the implementation Task they verify, but `queueReadyDependents` only ever unblocked dependents once a dependency reached `succeeded` — and implementation Tasks now stop at `verifying` by design (only a Verifier can push them further). This was a genuine deadlock: the Verifier could never be scheduled, because it was waiting on a state only it could produce. Fixed by making `queueReadyDependents` `ContractKind`-aware — a `verification`-kind dependent unblocks as soon as its dependency reaches `verifying`; every other kind still requires `succeeded`, unchanged (proven by a dedicated regression test). A second, related gap surfaced once the code actually ran: `AddEvidence`'s existing `VerifierAttemptID` check required the verifier's Attempt to belong to the *same Task* as the Evidence — which a cross-Task Verifier's Attempt never does. Relaxed to a Mission-scoped check instead (still rejects Attempts from a different Mission).

**Scope note:** intentionally stops here — no Integration Task type, no Mission-level completion trigger (that's next), and (as with the two prior PRs in this stack) no `cmd/harness9/main.go` wiring or docs, since there's still no way to create a Mission with a real entry point yet.

Built via subagent-driven development (implementer + spec-compliance review + code-quality review per task, run through a Workflow), plus a final whole-branch review. Issues caught and fixed along the way:
- The two state-machine gaps described above (found via spec review reproducing the deadlock and the `ErrNotFound` failure with actual test runs, not by inspection alone).
- A test (`TestDispatchCreatesDetachedWorktreeLeaseAndAttempt`, originally written when `Adapter.run` was a stub) leaked a goroutine that wrote to a closed test DB once `run` became real — fixed by waiting for the goroutine's terminal state before the test returns.
- A missing regression test: `internal/worker`'s `StartAttempt`-failure requeue path already had a dedicated test from the prior PR, but the identical logic copied into `internal/verifier` didn't — added the equivalent test.

**Known, deliberately deferred gap** (flagged by final review, not blocking since nothing reaches this code yet): independent verification currently runs via a bare `exec.Command`, with no Sandbox isolation seam — unlike `internal/worker.RunnerExecutor`, which already threads an optional `sandbox.Manager` through. Worth closing before this is wired to a real entry point, since the Verifier's whole purpose is safely re-checking untrusted output.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages, whole repo)
- [x] `go test ./internal/mission ./internal/scheduler ./internal/verifier -race -count=3 -timeout 5m`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] Independent spec-compliance + code-quality review per task (6 tasks), plus a final holistic review across all 9 commits