### PR TITLE
feat: Integration Task 与 Mission 自动完成机制

### DIFF
--- a/internal/integration/adapter.go
+++ b/internal/integration/adapter.go
@@ -3,12 +3,15 @@ package integration
 import (
 	"context"
 	"fmt"
+	"log"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/mission"
+	"github.com/harness9/internal/verifier"
 	"github.com/harness9/internal/worker"
 )
 
@@ -107,8 +110,105 @@ func currentCommit(dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// run is deliberately a no-op in this task: Task 2's tests only assert on
-// Dispatch's synchronous bookkeeping, not on any asynchronous outcome. Task 3
-// replaces this body with real merge-and-verify logic (and its own tests).
+// run merges every dependency Task's branch into the integration worktree,
+// independently re-verifies the combined result, and records the outcome.
+// It always runs on a's baseCtx, not the ctx Dispatch's caller passed in, so
+// it survives past the lifetime of any single Tick call.
 func (a *Adapter) run(task mission.Task, lease mission.WorkspaceLease, attempt mission.TaskAttempt, baseSHA string) {
+	for _, depID := range task.DependsOn {
+		depLease, err := a.store.GetLatestLease(a.baseCtx, depID)
+		if err != nil {
+			a.complete(task, attempt, lease, baseSHA, verifier.VerificationReport{}, fmt.Errorf("load dependency lease: %w", err))
+			return
+		}
+		if err := MergeBranch(lease.Path, depLease.Branch); err != nil {
+			a.complete(task, attempt, lease, baseSHA, verifier.VerificationReport{}, fmt.Errorf("merge branch %s: %w", depLease.Branch, err))
+			return
+		}
+	}
+	report := verifier.RunVerificationChecks(lease.Path)
+	a.complete(task, attempt, lease, baseSHA, report, nil)
+}
+
+// complete records the result of one Integration Attempt. Success records a
+// Mission-level Artifact (the combined diff) and passing Evidence, advances
+// the Attempt to succeeded, and the Integration Task itself through
+// verifying to succeeded — which, via internal/mission's TransitionTask,
+// automatically completes the whole Mission once every other Task has also
+// succeeded. Any failure (a load/merge error, or a failing joint
+// verification) records failing Evidence, fails the Task, and escalates the
+// Mission to needs_attention: nothing in this increment can resolve a merge
+// conflict or a failing joint test suite automatically.
+func (a *Adapter) complete(
+	task mission.Task,
+	attempt mission.TaskAttempt,
+	lease mission.WorkspaceLease,
+	baseSHA string,
+	report verifier.VerificationReport,
+	runErr error,
+) {
+	defer func() {
+		if _, err := a.store.ReleaseLease(a.baseCtx, lease.ID); err != nil {
+			log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("释放 lease %s 失败: %v", lease.ID, err)))
+		}
+	}()
+
+	if runErr != nil {
+		a.fail(task, attempt, "integration process error", runErr.Error())
+		return
+	}
+	if !report.Passed {
+		a.fail(task, attempt, "joint verification failed", report.Output)
+		return
+	}
+
+	diff := captureDiff(lease.Path, baseSHA)
+	if _, err := a.store.AddArtifact(a.baseCtx, mission.CreateArtifactInput{
+		MissionID: task.MissionID, TaskID: task.ID, AttemptID: attempt.ID,
+		Kind: "integration_diff", Content: []byte(diff),
+	}); err != nil {
+		a.fail(task, attempt, "record artifact", err.Error())
+		return
+	}
+	if _, err := a.store.AddEvidence(a.baseCtx, mission.CreateEvidenceInput{
+		MissionID: task.MissionID, TaskID: task.ID, AttemptID: attempt.ID,
+		Kind: "integration", Content: []byte(report.Output), Passed: true,
+	}); err != nil {
+		a.fail(task, attempt, "record evidence", err.Error())
+		return
+	}
+	if _, err := a.store.TransitionAttempt(a.baseCtx, attempt.ID, mission.AttemptSucceeded); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("推进 attempt %s 失败: %v", attempt.ID, err)))
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, task.ID, mission.TaskVerifying); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("推进 task %s 失败: %v", task.ID, err)))
+		return
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, task.ID, mission.TaskSucceeded); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("推进 task %s 失败: %v", task.ID, err)))
+	}
+}
+
+// fail records failing Evidence against the Integration Task itself (there
+// is no separate "target" Task the way Verifier has one — Integration IS the
+// terminal Task for whatever it depends on), marks it failed, and escalates
+// the whole Mission to needs_attention. Called only from within complete,
+// whose own defer still handles releasing the lease — fail itself must not
+// touch the lease.
+func (a *Adapter) fail(task mission.Task, attempt mission.TaskAttempt, kind, detail string) {
+	if _, err := a.store.AddEvidence(a.baseCtx, mission.CreateEvidenceInput{
+		MissionID: task.MissionID, TaskID: task.ID, AttemptID: attempt.ID,
+		Kind: "integration", Content: []byte(fmt.Sprintf("%s: %s", kind, detail)), Passed: false,
+	}); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("记录失败 evidence 失败: %v", err)))
+	}
+	if _, err := a.store.TransitionAttempt(a.baseCtx, attempt.ID, mission.AttemptFailed); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("推进 attempt %s 失败: %v", attempt.ID, err)))
+	}
+	if _, err := a.store.TransitionTask(a.baseCtx, task.ID, mission.TaskFailed); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("推进 task %s 失败: %v", task.ID, err)))
+	}
+	if _, err := a.store.MarkMissionNeedsAttention(a.baseCtx, task.MissionID, fmt.Sprintf("%s: %s", kind, detail)); err != nil {
+		log.Print(logfmt.FormatMsg("integration", fmt.Sprintf("升级 mission %s 到 needs_attention 失败: %v", task.MissionID, err)))
+	}
 }

--- a/internal/integration/adapter.go
+++ b/internal/integration/adapter.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/harness9/internal/mission"
+	"github.com/harness9/internal/worker"
+)
+
+// Adapter implements scheduler.Dispatcher for mission.ContractIntegration
+// Tasks. Dispatch requires task to depend on at least one other Task — the
+// ones whose branches it merges. It provisions one Mission-level worktree
+// (not per-Task, since integration combines multiple Tasks' work into one
+// place, unlike internal/worker's and internal/verifier's per-Task
+// worktrees), then asynchronously merges every dependency's branch into it
+// and independently re-verifies the combined result — bounded by the
+// Adapter's own long-lived context, not the caller's per-Tick ctx, the same
+// pattern internal/worker.Adapter and internal/verifier.Adapter established.
+type Adapter struct {
+	store    *mission.Store
+	repoRoot string
+	leaseTTL time.Duration
+	baseCtx  context.Context
+}
+
+// NewAdapter creates an Adapter. repoRoot is the harness9 repository root new
+// integration worktrees are created relative to.
+func NewAdapter(store *mission.Store, repoRoot string, baseCtx context.Context) *Adapter {
+	return &Adapter{store: store, repoRoot: repoRoot, leaseTTL: 4 * time.Hour, baseCtx: baseCtx}
+}
+
+// var _ ... proves Adapter has the exact method shape scheduler.Dispatcher
+// requires, without importing internal/scheduler.
+var _ interface {
+	Dispatch(ctx context.Context, task mission.Task) error
+} = (*Adapter)(nil)
+
+// Dispatch implements scheduler.Dispatcher. On any failure it leaves no
+// partial state behind, mirroring internal/worker.Adapter and
+// internal/verifier.Adapter's Dispatch.
+func (a *Adapter) Dispatch(ctx context.Context, task mission.Task) error {
+	if len(task.DependsOn) == 0 {
+		return fmt.Errorf("integration task %s must depend on at least one task", task.ID)
+	}
+
+	path, branch := integrationWorktreeFor(a.repoRoot, task)
+	if err := worker.CreateWorktree(a.repoRoot, path, branch); err != nil {
+		return fmt.Errorf("create integration worktree: %w", err)
+	}
+	baseSHA, err := currentCommit(path)
+	if err != nil {
+		if removeErr := worker.RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			return fmt.Errorf("read base commit: %w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("read base commit: %w", err)
+	}
+
+	lease, err := a.store.AcquireLease(ctx, task.ID, path, branch, "", a.leaseTTL)
+	if err != nil {
+		if removeErr := worker.RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			return fmt.Errorf("acquire lease: %w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("acquire lease: %w", err)
+	}
+
+	attempt, err := a.store.StartAttempt(ctx, task.ID, "integration-adapter")
+	if err != nil {
+		if _, transErr := a.store.TransitionTask(ctx, task.ID, mission.TaskQueued); transErr != nil {
+			err = fmt.Errorf("%w (requeue also failed: %v)", err, transErr)
+		}
+		if _, releaseErr := a.store.ReleaseLease(ctx, lease.ID); releaseErr != nil {
+			err = fmt.Errorf("%w (lease release also failed: %v)", err, releaseErr)
+		}
+		if removeErr := worker.RemoveWorktree(a.repoRoot, path); removeErr != nil {
+			err = fmt.Errorf("%w (worktree cleanup also failed: %v)", err, removeErr)
+		}
+		return fmt.Errorf("start attempt: %w", err)
+	}
+
+	go a.run(task, lease, attempt, baseSHA)
+	return nil
+}
+
+// integrationWorktreeFor computes a deterministic, collision-free path and
+// branch name for one Integration Task, keyed off the Integration Task's own
+// ID — always unique, for the same reason internal/worker.worktreeFor and
+// internal/verifier.verifyWorktreeFor key off Task.ID.
+func integrationWorktreeFor(repoRoot string, task mission.Task) (path, branch string) {
+	path = filepath.Join(repoRoot, ".harness9", "integrate", task.MissionID, task.ID)
+	branch = fmt.Sprintf("integrate/%s", task.ID)
+	return path, branch
+}
+
+// currentCommit returns the commit currently checked out at dir.
+func currentCommit(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD: %w: %s", err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// run is deliberately a no-op in this task: Task 2's tests only assert on
+// Dispatch's synchronous bookkeeping, not on any asynchronous outcome. Task 3
+// replaces this body with real merge-and-verify logic (and its own tests).
+func (a *Adapter) run(task mission.Task, lease mission.WorkspaceLease, attempt mission.TaskAttempt, baseSHA string) {
+}

--- a/internal/integration/adapter_test.go
+++ b/internal/integration/adapter_test.go
@@ -69,31 +69,8 @@ func TestDispatchCreatesIntegrationWorktreeLeaseAndAttempt(t *testing.T) {
 		}
 	}
 
-	completeImplementation := func(task mission.Task, filename, content string) {
-		t.Helper()
-		path := filepath.Join(repoRoot, ".harness9", "missions", task.ID)
-		branch := "mission/" + task.ID
-		runGit(t, repoRoot, "worktree", "add", path, "-b", branch)
-		if err := os.WriteFile(filepath.Join(path, filename), []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		runGit(t, path, "add", "-A")
-		runGit(t, path, "commit", "-q", "-m", "feat: implement "+task.ClientID)
-		if _, err := store.AcquireLease(ctx, task.ID, path, branch, "", time.Hour); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := store.StartAttempt(ctx, task.ID, "worker-adapter"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := store.TransitionTask(ctx, task.ID, mission.TaskVerifying); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := store.TransitionTask(ctx, task.ID, mission.TaskSucceeded); err != nil {
-			t.Fatal(err)
-		}
-	}
-	completeImplementation(taskA, "feature_a.go", "package main\n\nfunc FeatureA() string { return \"a\" }\n")
-	completeImplementation(taskB, "feature_b.go", "package main\n\nfunc FeatureB() string { return \"b\" }\n")
+	completeImplementation(t, store, repoRoot, taskA, "feature_a.go", "package main\n\nfunc FeatureA() string { return \"a\" }\n")
+	completeImplementation(t, store, repoRoot, taskB, "feature_b.go", "package main\n\nfunc FeatureB() string { return \"b\" }\n")
 
 	integrateTask, err = store.GetTask(ctx, integrateTask.ID)
 	if err != nil {
@@ -119,6 +96,15 @@ func TestDispatchCreatesIntegrationWorktreeLeaseAndAttempt(t *testing.T) {
 	if updated.Status != mission.TaskRunning {
 		t.Fatalf("integrate task status = %s, want running", updated.Status)
 	}
+
+	// Dispatch's synchronous bookkeeping above is this test's actual subject,
+	// but Dispatch also launches a.run on a background goroutine that now
+	// performs a real merge and go build/vet/test against the worktree
+	// (Task 3), instead of Task 2's no-op. Returning before that goroutine
+	// finishes would let it keep running after t.Cleanup closes this test's
+	// store's DB, so wait for the integrate Task to reach a terminal status
+	// first.
+	waitForTaskStatus(t, store, integrateTask.ID, mission.TaskSucceeded, 30*time.Second)
 }
 
 func TestDispatchRejectsTaskWithNoDependencies(t *testing.T) {
@@ -129,5 +115,211 @@ func TestDispatchRejectsTaskWithNoDependencies(t *testing.T) {
 	err := adapter.Dispatch(context.Background(), mission.Task{ID: "orphan-integration", ContractKind: mission.ContractIntegration})
 	if err == nil {
 		t.Fatal("Dispatch on an integration task with zero dependencies = nil error, want an error")
+	}
+}
+
+func TestDispatchMergesAndVerifiesSuccessfullyCompletingTheMission(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, mission.CreateMissionInput{Goal: "ship a feature"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := store.CreateDraftPlan(ctx, m.ID, mission.PlanInput{Tasks: []mission.TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A", ContractKind: mission.ContractImplementation},
+		{ClientID: "b", Position: 2, Title: "B", Contract: "do B", ContractKind: mission.ContractImplementation},
+		{ClientID: "integrate", Position: 3, Title: "Integrate", Contract: "merge A and B", ContractKind: mission.ContractIntegration, Dependencies: []string{"a", "b"}},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := mission.NewCommandService(store)
+	if _, err := svc.ApprovePlan(ctx, mission.ApprovePlanCommand{
+		MissionID: m.ID, Version: plan.Version, Actor: "user:zsa", Reason: "looks good", IdempotencyKey: "approve-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MarkMissionRunning(ctx, m.ID); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(ctx, m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var taskA, taskB, integrateTask mission.Task
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "a":
+			taskA = task
+		case "b":
+			taskB = task
+		case "integrate":
+			integrateTask = task
+		}
+	}
+	completeImplementation(t, store, repoRoot, taskA, "feature_a.go", "package main\n\nfunc FeatureA() string { return \"a\" }\n")
+	completeImplementation(t, store, repoRoot, taskB, "feature_b.go", "package main\n\nfunc FeatureB() string { return \"b\" }\n")
+	integrateTask, err = store.GetTask(ctx, integrateTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewAdapter(store, repoRoot, context.Background())
+	if err := adapter.Dispatch(ctx, integrateTask); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	waitForTaskStatus(t, store, integrateTask.ID, mission.TaskSucceeded, 30*time.Second)
+	waitForMissionStatus(t, store, m.ID, mission.MissionSucceeded, time.Second)
+
+	evidence, err := store.ListEvidence(context.Background(), integrateTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || !evidence[0].Passed {
+		t.Fatalf("evidence = %+v, want exactly one passing record", evidence)
+	}
+	path, _ := integrationWorktreeFor(repoRoot, integrateTask)
+	if _, err := os.Stat(filepath.Join(path, "feature_a.go")); err != nil {
+		t.Fatalf("merged worktree missing feature_a.go: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(path, "feature_b.go")); err != nil {
+		t.Fatalf("merged worktree missing feature_b.go: %v", err)
+	}
+}
+
+func TestDispatchEscalatesMissionOnMergeConflict(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, mission.CreateMissionInput{Goal: "ship a feature"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := store.CreateDraftPlan(ctx, m.ID, mission.PlanInput{Tasks: []mission.TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A", ContractKind: mission.ContractImplementation},
+		{ClientID: "b", Position: 2, Title: "B", Contract: "do B", ContractKind: mission.ContractImplementation},
+		{ClientID: "integrate", Position: 3, Title: "Integrate", Contract: "merge A and B", ContractKind: mission.ContractIntegration, Dependencies: []string{"a", "b"}},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := mission.NewCommandService(store)
+	if _, err := svc.ApprovePlan(ctx, mission.ApprovePlanCommand{
+		MissionID: m.ID, Version: plan.Version, Actor: "user:zsa", Reason: "looks good", IdempotencyKey: "approve-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MarkMissionRunning(ctx, m.ID); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(ctx, m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var taskA, taskB, integrateTask mission.Task
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "a":
+			taskA = task
+		case "b":
+			taskB = task
+		case "integrate":
+			integrateTask = task
+		}
+	}
+	// Both A and B change the exact same line of main.go, guaranteeing a
+	// genuine merge conflict when Integration tries to combine them.
+	completeImplementation(t, store, repoRoot, taskA, "main.go", "package main\n\nfunc main() { println(\"from a\") }\n")
+	completeImplementation(t, store, repoRoot, taskB, "main.go", "package main\n\nfunc main() { println(\"from b\") }\n")
+	integrateTask, err = store.GetTask(ctx, integrateTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewAdapter(store, repoRoot, context.Background())
+	if err := adapter.Dispatch(ctx, integrateTask); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	waitForTaskStatus(t, store, integrateTask.ID, mission.TaskFailed, 30*time.Second)
+	waitForMissionStatus(t, store, m.ID, mission.MissionNeedsAttention, time.Second)
+
+	evidence, err := store.ListEvidence(context.Background(), integrateTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evidence) != 1 || evidence[0].Passed {
+		t.Fatalf("evidence = %+v, want exactly one failing record", evidence)
+	}
+}
+
+// completeImplementation simulates a completed Worker Adapter run on task: a
+// real worktree, a real commit, and a full Running->Verifying->Succeeded
+// transition — reused by both this task's tests and Task 2's.
+func completeImplementation(t *testing.T, store *mission.Store, repoRoot string, task mission.Task, filename, content string) {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(repoRoot, ".harness9", "missions", task.ID)
+	branch := "mission/" + task.ID
+	runGit(t, repoRoot, "worktree", "add", path, "-b", branch)
+	if err := os.WriteFile(filepath.Join(path, filename), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, path, "add", "-A")
+	runGit(t, path, "commit", "-q", "-m", "feat: implement "+task.ClientID)
+	if _, err := store.AcquireLease(ctx, task.ID, path, branch, "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(ctx, task.ID, "worker-adapter"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(ctx, task.ID, mission.TaskVerifying); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(ctx, task.ID, mission.TaskSucceeded); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitForTaskStatus polls the store until task reaches one of the wanted
+// statuses or the timeout elapses, failing the test on timeout. Dispatch's
+// completion runs in a background goroutine, so tests must poll rather than
+// assert immediately after Dispatch returns.
+func waitForTaskStatus(t *testing.T, store *mission.Store, taskID string, want mission.TaskStatus, timeout time.Duration) mission.Task {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		task, err := store.GetTask(context.Background(), taskID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if task.Status == want {
+			return task
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("task %s status = %s after %s, want %s", taskID, task.Status, timeout, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// waitForMissionStatus mirrors waitForTaskStatus for Mission-level status.
+func waitForMissionStatus(t *testing.T, store *mission.Store, missionID string, want mission.MissionStatus, timeout time.Duration) mission.Mission {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		m, err := store.GetMission(context.Background(), missionID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.Status == want {
+			return m
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("mission %s status = %s after %s, want %s", missionID, m.Status, timeout, want)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/internal/integration/adapter_test.go
+++ b/internal/integration/adapter_test.go
@@ -1,0 +1,133 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/harness9/internal/mission"
+)
+
+func newTestStore(t *testing.T) *mission.Store {
+	t.Helper()
+	dsn := filepath.Join(t.TempDir(), "mission.db") + "?_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	store, err := mission.NewStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func TestDispatchCreatesIntegrationWorktreeLeaseAndAttempt(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	store := newTestStore(t)
+	ctx := context.Background()
+	m, err := store.CreateMission(ctx, mission.CreateMissionInput{Goal: "ship a feature"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := store.CreateDraftPlan(ctx, m.ID, mission.PlanInput{Tasks: []mission.TaskInput{
+		{ClientID: "a", Position: 1, Title: "A", Contract: "do A", ContractKind: mission.ContractImplementation},
+		{ClientID: "b", Position: 2, Title: "B", Contract: "do B", ContractKind: mission.ContractImplementation},
+		{ClientID: "integrate", Position: 3, Title: "Integrate", Contract: "merge A and B", ContractKind: mission.ContractIntegration, Dependencies: []string{"a", "b"}},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := mission.NewCommandService(store)
+	if _, err := svc.ApprovePlan(ctx, mission.ApprovePlanCommand{
+		MissionID: m.ID, Version: plan.Version, Actor: "user:zsa", Reason: "looks good", IdempotencyKey: "approve-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MarkMissionRunning(ctx, m.ID); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(ctx, m.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var taskA, taskB, integrateTask mission.Task
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "a":
+			taskA = task
+		case "b":
+			taskB = task
+		case "integrate":
+			integrateTask = task
+		}
+	}
+
+	completeImplementation := func(task mission.Task, filename, content string) {
+		t.Helper()
+		path := filepath.Join(repoRoot, ".harness9", "missions", task.ID)
+		branch := "mission/" + task.ID
+		runGit(t, repoRoot, "worktree", "add", path, "-b", branch)
+		if err := os.WriteFile(filepath.Join(path, filename), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, path, "add", "-A")
+		runGit(t, path, "commit", "-q", "-m", "feat: implement "+task.ClientID)
+		if _, err := store.AcquireLease(ctx, task.ID, path, branch, "", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.StartAttempt(ctx, task.ID, "worker-adapter"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.TransitionTask(ctx, task.ID, mission.TaskVerifying); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.TransitionTask(ctx, task.ID, mission.TaskSucceeded); err != nil {
+			t.Fatal(err)
+		}
+	}
+	completeImplementation(taskA, "feature_a.go", "package main\n\nfunc FeatureA() string { return \"a\" }\n")
+	completeImplementation(taskB, "feature_b.go", "package main\n\nfunc FeatureB() string { return \"b\" }\n")
+
+	integrateTask, err = store.GetTask(ctx, integrateTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if integrateTask.Status != mission.TaskQueued {
+		t.Fatalf("integrate task status = %s, want queued once both dependencies succeeded", integrateTask.Status)
+	}
+
+	adapter := NewAdapter(store, repoRoot, context.Background())
+	if err := adapter.Dispatch(context.Background(), integrateTask); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	path, _ := integrationWorktreeFor(repoRoot, integrateTask)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("integration worktree was not created: %v", err)
+	}
+	updated, err := store.GetTask(context.Background(), integrateTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != mission.TaskRunning {
+		t.Fatalf("integrate task status = %s, want running", updated.Status)
+	}
+}
+
+func TestDispatchRejectsTaskWithNoDependencies(t *testing.T) {
+	store := newTestStore(t)
+	repoRoot := newTestRepo(t)
+	adapter := NewAdapter(store, repoRoot, context.Background())
+
+	err := adapter.Dispatch(context.Background(), mission.Task{ID: "orphan-integration", ContractKind: mission.ContractIntegration})
+	if err == nil {
+		t.Fatal("Dispatch on an integration task with zero dependencies = nil error, want an error")
+	}
+}

--- a/internal/integration/merge.go
+++ b/internal/integration/merge.go
@@ -1,0 +1,32 @@
+// Package integration implements the multi-Task consolidation half of
+// Mission's execution loop: it merges every dependency Task's completed
+// branch into one Mission-level worktree, independently re-verifies the
+// combined result, and is the only component allowed to advance an
+// Integration Task (and, indirectly, its whole Mission) to succeeded.
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// MergeBranch merges branch into the repository checked out at worktreePath,
+// using a non-fast-forward merge so multiple independent branches can be
+// combined in sequence without losing their individual commit history. On
+// conflict, it aborts the merge — restoring worktreePath to the clean state
+// it was in before this call — and returns an error describing the conflict.
+func MergeBranch(worktreePath, branch string) error {
+	cmd := exec.Command("git", "merge", "--no-ff", "--no-edit", branch)
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		mergeErr := fmt.Errorf("git merge %s: %w: %s", branch, err, out)
+		abortCmd := exec.Command("git", "merge", "--abort")
+		abortCmd.Dir = worktreePath
+		if abortOut, abortErr := abortCmd.CombinedOutput(); abortErr != nil {
+			return fmt.Errorf("%w (merge --abort also failed: %v: %s)", mergeErr, abortErr, abortOut)
+		}
+		return mergeErr
+	}
+	return nil
+}

--- a/internal/integration/merge_test.go
+++ b/internal/integration/merge_test.go
@@ -1,0 +1,102 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// newTestRepo creates a fresh git repository in a temp dir with one initial
+// commit — a minimal but valid, self-contained Go module (own go.mod, not
+// harness9's own module). Reused by later tasks' tests, which run real `go
+// build`/`go vet`/`go test` against worktrees of this repo.
+func newTestRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+	runGit(t, root, "config", "user.email", "integration-test@example.com")
+	runGit(t, root, "config", "user.name", "integration-test")
+	files := map[string]string{
+		"go.mod":       "module integrationtestfixture\n\ngo 1.25\n",
+		"main.go":      "package main\n\nfunc main() {}\n",
+		"main_test.go": "package main\n\nimport \"testing\"\n\nfunc TestMainOK(t *testing.T) {}\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m", "initial commit")
+	return root
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return trimTrailingNewline(string(out))
+}
+
+func trimTrailingNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func TestMergeBranchMergesNonConflictingChange(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	integratePath := filepath.Join(repoRoot, ".harness9", "integrate", "task")
+	runGit(t, repoRoot, "worktree", "add", integratePath, "-b", "integrate/task")
+
+	branchPath := filepath.Join(repoRoot, ".harness9", "missions", "a")
+	runGit(t, repoRoot, "worktree", "add", branchPath, "-b", "mission/a")
+	if err := os.WriteFile(filepath.Join(branchPath, "feature_a.go"), []byte("package main\n\nfunc FeatureA() string { return \"a\" }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, branchPath, "add", "-A")
+	runGit(t, branchPath, "commit", "-q", "-m", "feat: add feature a")
+
+	if err := MergeBranch(integratePath, "mission/a"); err != nil {
+		t.Fatalf("MergeBranch: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(integratePath, "feature_a.go")); err != nil {
+		t.Fatalf("merged worktree missing feature_a.go: %v", err)
+	}
+}
+
+func TestMergeBranchAbortsOnConflictAndLeavesCleanState(t *testing.T) {
+	repoRoot := newTestRepo(t)
+	integratePath := filepath.Join(repoRoot, ".harness9", "integrate", "task")
+	runGit(t, repoRoot, "worktree", "add", integratePath, "-b", "integrate/task")
+	// Change main.go in the integration worktree itself.
+	if err := os.WriteFile(filepath.Join(integratePath, "main.go"), []byte("package main\n\nfunc main() { println(\"from integrate\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, integratePath, "add", "-A")
+	runGit(t, integratePath, "commit", "-q", "-m", "feat: change main from integrate")
+
+	branchPath := filepath.Join(repoRoot, ".harness9", "missions", "conflict")
+	runGit(t, repoRoot, "worktree", "add", branchPath, "-b", "mission/conflict")
+	// Change the exact same line of main.go on a diverging branch.
+	if err := os.WriteFile(filepath.Join(branchPath, "main.go"), []byte("package main\n\nfunc main() { println(\"from conflict\") }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, branchPath, "add", "-A")
+	runGit(t, branchPath, "commit", "-q", "-m", "feat: change main from conflict")
+
+	err := MergeBranch(integratePath, "mission/conflict")
+	if err == nil {
+		t.Fatal("MergeBranch on a genuine conflict = nil error, want an error")
+	}
+	status := runGit(t, integratePath, "status", "--porcelain")
+	if status != "" {
+		t.Fatalf("worktree status after aborted merge = %q, want a clean tree (merge --abort should have restored it)", status)
+	}
+}

--- a/internal/integration/verify.go
+++ b/internal/integration/verify.go
@@ -1,0 +1,20 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// captureDiff returns the full combined diff between baseSHA and HEAD inside
+// worktreePath, for storage as the Integration Task's Artifact. If git
+// itself fails, the error text is captured as the artifact content instead
+// of losing the failure silently.
+func captureDiff(worktreePath, baseSHA string) string {
+	cmd := exec.Command("git", "diff", baseSHA, "HEAD")
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Sprintf("git diff %s HEAD failed: %v\n%s", baseSHA, err, out)
+	}
+	return string(out)
+}

--- a/internal/mission/completion_store.go
+++ b/internal/mission/completion_store.go
@@ -1,0 +1,60 @@
+package mission
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// MarkMissionNeedsAttention transitions a running (or verifying) Mission to
+// needs_attention, signaling that a human must intervene — e.g. an
+// Integration Task hit a merge conflict or a failing joint test suite that
+// nothing in this increment can resolve automatically. It is a no-op if the
+// Mission is already needs_attention, and an error for any other status.
+func (s *Store) MarkMissionNeedsAttention(ctx context.Context, missionID, reason string) (Mission, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return Mission{}, fmt.Errorf("begin mission attention transition: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	mission, err := scanMission(tx.QueryRowContext(ctx, `
+		SELECT id, goal, acceptance_contract, budget_cents, policy_json,
+		       current_plan_version, status, created_at, updated_at
+		FROM missions WHERE id = ?`, missionID))
+	if err != nil {
+		return Mission{}, wrapMissionNotFound(missionID, err)
+	}
+	if mission.Status == MissionNeedsAttention {
+		return mission, nil
+	}
+	if !mission.Status.CanTransitionTo(MissionNeedsAttention) {
+		return Mission{}, fmt.Errorf(
+			"%w: mission %s cannot move from %s to %s",
+			ErrInvalidTransition, missionID, mission.Status, MissionNeedsAttention,
+		)
+	}
+	now := s.currentTime()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE missions SET status = ?, updated_at = ? WHERE id = ?`,
+		MissionNeedsAttention, unixMillis(now), missionID,
+	); err != nil {
+		return Mission{}, fmt.Errorf("mark mission needs attention: %w", err)
+	}
+	payload, err := json.Marshal(map[string]any{"reason": reason})
+	if err != nil {
+		return Mission{}, fmt.Errorf("marshal mission.needs_attention event: %w", err)
+	}
+	if err := insertEvent(ctx, tx, Event{
+		ID: newID(), MissionID: missionID, Type: "mission.needs_attention",
+		Payload: payload, CreatedAt: now,
+	}); err != nil {
+		return Mission{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Mission{}, fmt.Errorf("commit mission attention transition: %w", err)
+	}
+	mission.Status = MissionNeedsAttention
+	mission.UpdatedAt = now
+	return mission, nil
+}

--- a/internal/mission/completion_store_test.go
+++ b/internal/mission/completion_store_test.go
@@ -1,0 +1,44 @@
+package mission
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestMarkMissionNeedsAttentionTransitionsRunningMissionIdempotently(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, samplePlanInput(), "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MarkMissionRunning(context.Background(), mission.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.MarkMissionNeedsAttention(context.Background(), mission.ID, "integration merge conflict")
+	if err != nil {
+		t.Fatalf("MarkMissionNeedsAttention: %v", err)
+	}
+	if got.Status != MissionNeedsAttention {
+		t.Fatalf("status = %s, want needs_attention", got.Status)
+	}
+
+	again, err := store.MarkMissionNeedsAttention(context.Background(), mission.ID, "integration merge conflict")
+	if err != nil {
+		t.Fatalf("MarkMissionNeedsAttention (repeat): %v", err)
+	}
+	if again.Status != MissionNeedsAttention {
+		t.Fatalf("status on repeat = %s, want needs_attention", again.Status)
+	}
+}
+
+func TestMarkMissionNeedsAttentionRejectsMissionNotYetRunning(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	if _, err := store.MarkMissionNeedsAttention(context.Background(), mission.ID, "too early"); !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("MarkMissionNeedsAttention on draft mission: err = %v, want ErrInvalidTransition", err)
+	}
+}

--- a/internal/mission/store.go
+++ b/internal/mission/store.go
@@ -810,6 +810,11 @@ func (s *Store) TransitionTask(ctx context.Context, id string, next TaskStatus) 
 			return Task{}, err
 		}
 	}
+	if next == TaskSucceeded {
+		if err := tryCompleteMission(ctx, tx, current.MissionID, now); err != nil {
+			return Task{}, err
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		return Task{}, fmt.Errorf("commit task transition: %w", err)
 	}
@@ -1061,6 +1066,59 @@ func queueReadyDependents(ctx context.Context, tx *sql.Tx, dependencyID string, 
 		}
 	}
 	return nil
+}
+
+// tryCompleteMission checks whether every Task in a Mission's current Plan
+// version has reached succeeded, and if so advances the Mission itself from
+// running through verifying to succeeded. It is called automatically every
+// time any Task transitions to succeeded — whichever Task happens to be
+// last (an implementation Task with no Verifier, a Verifier, or an
+// Integration Task) triggers it the same way, so a Mission with no
+// Integration Task at all still completes correctly once its Tasks are done.
+// It is a no-op unless the Mission is currently running, so it cannot fire
+// prematurely (e.g. before the Plan is even approved) or twice (once the
+// Mission leaves running, later succeeded transitions no longer match).
+func tryCompleteMission(ctx context.Context, tx *sql.Tx, missionID string, now time.Time) error {
+	var status MissionStatus
+	var planVersion int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT status, current_plan_version FROM missions WHERE id = ?`, missionID,
+	).Scan(&status, &planVersion); err != nil {
+		return fmt.Errorf("load mission for completion check: %w", err)
+	}
+	if status != MissionRunning {
+		return nil
+	}
+	var incomplete int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM tasks WHERE mission_id = ? AND plan_version = ? AND status != ?`,
+		missionID, planVersion, TaskSucceeded,
+	).Scan(&incomplete); err != nil {
+		return fmt.Errorf("count incomplete tasks: %w", err)
+	}
+	if incomplete > 0 {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE missions SET status = ?, updated_at = ? WHERE id = ?`,
+		MissionVerifying, unixMillis(now), missionID,
+	); err != nil {
+		return fmt.Errorf("mark mission verifying: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE missions SET status = ?, updated_at = ? WHERE id = ?`,
+		MissionSucceeded, unixMillis(now), missionID,
+	); err != nil {
+		return fmt.Errorf("mark mission succeeded: %w", err)
+	}
+	payload, err := json.Marshal(map[string]any{"reason": "all tasks succeeded"})
+	if err != nil {
+		return fmt.Errorf("marshal mission.succeeded event: %w", err)
+	}
+	return insertEvent(ctx, tx, Event{
+		ID: newID(), MissionID: missionID, Type: "mission.succeeded",
+		Payload: payload, CreatedAt: now,
+	})
 }
 
 func uniqueIDs(ids []string) []string {

--- a/internal/mission/store_test.go
+++ b/internal/mission/store_test.go
@@ -521,3 +521,106 @@ func TestTransitionTaskToVerifyingDoesNotUnblockImplementationDependent(t *testi
 		t.Fatalf("regression: b task status = %s, want still blocked — an implementation dependent must wait for succeeded, not verifying", got.Status)
 	}
 }
+
+func TestTransitionTaskCompletesMissionWhenAllTasksSucceed(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, samplePlanInput(), "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.MarkMissionRunning(context.Background(), mission.ID); err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.ListTasks(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var specID, codeID string
+	for _, task := range tasks {
+		switch task.ClientID {
+		case "spec":
+			specID = task.ID
+		case "code":
+			codeID = task.ID
+		}
+	}
+	if specID == "" || codeID == "" {
+		t.Fatal("expected both spec and code tasks to exist")
+	}
+
+	completeTask := func(taskID, path, branch string) {
+		t.Helper()
+		if _, err := store.AcquireLease(context.Background(), taskID, path, branch, "", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.StartAttempt(context.Background(), taskID, "test-worker"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.TransitionTask(context.Background(), taskID, TaskVerifying); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.TransitionTask(context.Background(), taskID, TaskSucceeded); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	completeTask(specID, "/tmp/spec", "branch/spec")
+	got, err := store.GetMission(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != MissionRunning {
+		t.Fatalf("mission status after only spec succeeds = %s, want still running", got.Status)
+	}
+
+	completeTask(codeID, "/tmp/code", "branch/code")
+	got, err = store.GetMission(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != MissionSucceeded {
+		t.Fatalf("mission status = %s, want succeeded once every task has", got.Status)
+	}
+}
+
+func TestTransitionTaskDoesNotCompleteMissionThatIsNotRunning(t *testing.T) {
+	store, mission := newStoreWithMission(t)
+	plan, err := store.CreateDraftPlan(context.Background(), mission.ID, PlanInput{Tasks: []TaskInput{
+		{ClientID: "solo", Position: 1, Title: "Solo", Contract: "do it"},
+	}}, "coordinator")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := markPlanApprovedForTest(context.Background(), store, mission.ID, plan.Version); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately do NOT call MarkMissionRunning — mission stays "ready".
+	tasks, err := store.ListTasks(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskID := tasks[0].ID
+	if _, err := store.AcquireLease(context.Background(), taskID, "/tmp/solo", "branch/solo", "", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), taskID, "test-worker"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(context.Background(), taskID, TaskVerifying); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.TransitionTask(context.Background(), taskID, TaskSucceeded); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetMission(context.Background(), mission.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != MissionReady {
+		t.Fatalf("mission status = %s, want still ready (never marked running, so completion must not fire)", got.Status)
+	}
+}

--- a/internal/verifier/adapter.go
+++ b/internal/verifier/adapter.go
@@ -98,7 +98,7 @@ func verifyWorktreeFor(repoRoot string, task mission.Task) (path, branch string)
 // runs on a's baseCtx, not the ctx Dispatch's caller passed in, so it
 // survives past the lifetime of any single Tick call.
 func (a *Adapter) run(verifierTask mission.Task, targetID string, lease mission.WorkspaceLease, attempt mission.TaskAttempt) {
-	report := runVerificationChecks(lease.Path)
+	report := RunVerificationChecks(lease.Path)
 	a.complete(verifierTask, targetID, attempt, lease, report)
 }
 
@@ -118,7 +118,7 @@ func (a *Adapter) complete(
 	targetID string,
 	attempt mission.TaskAttempt,
 	lease mission.WorkspaceLease,
-	report verificationReport,
+	report VerificationReport,
 ) {
 	defer func() {
 		if _, err := a.store.ReleaseLease(a.baseCtx, lease.ID); err != nil {
@@ -134,14 +134,14 @@ func (a *Adapter) complete(
 	if _, err := a.store.AddEvidence(a.baseCtx, mission.CreateEvidenceInput{
 		MissionID: verifierTask.MissionID, TaskID: targetID, AttemptID: targetAttempt.ID,
 		VerifierAttemptID: attempt.ID, Kind: "independent_verification",
-		Content: []byte(report.output), Passed: report.passed,
+		Content: []byte(report.Output), Passed: report.Passed,
 	}); err != nil {
 		a.failVerifierOnly(verifierTask, attempt, "record evidence", err.Error())
 		return
 	}
 
 	targetNext := mission.TaskFailed
-	if report.passed {
+	if report.Passed {
 		targetNext = mission.TaskSucceeded
 	}
 	if _, err := a.store.TransitionTask(a.baseCtx, targetID, targetNext); err != nil {

--- a/internal/verifier/verify.go
+++ b/internal/verifier/verify.go
@@ -6,19 +6,20 @@ import (
 	"strings"
 )
 
-// verificationReport is the outcome of one independent re-verification pass.
-type verificationReport struct {
-	passed bool
-	output string
+// VerificationReport is the outcome of one independent re-verification pass.
+type VerificationReport struct {
+	Passed bool
+	Output string
 }
 
-// runVerificationChecks independently re-runs the checks every implementation
+// RunVerificationChecks independently re-runs the checks every implementation
 // Task Contract already runs itself (build, vet, test) inside workDir,
 // stopping at the first failing step. No LLM is involved: an independent
 // deterministic rerun is a signal a self-reported success cannot fake, which
 // is exactly what Mission's "Verifier must not verify its own artifact"
-// invariant requires.
-func runVerificationChecks(workDir string) verificationReport {
+// invariant requires. Exported so internal/integration can reuse it for
+// joint verification after merging multiple Tasks' branches together.
+func RunVerificationChecks(workDir string) VerificationReport {
 	var output strings.Builder
 	for _, args := range [][]string{
 		{"build", "./..."},
@@ -30,8 +31,8 @@ func runVerificationChecks(workDir string) verificationReport {
 		out, err := cmd.CombinedOutput()
 		fmt.Fprintf(&output, "$ go %s\n%s\n", strings.Join(args, " "), out)
 		if err != nil {
-			return verificationReport{passed: false, output: output.String()}
+			return VerificationReport{Passed: false, Output: output.String()}
 		}
 	}
-	return verificationReport{passed: true, output: output.String()}
+	return VerificationReport{Passed: true, Output: output.String()}
 }


### PR DESCRIPTION
## Summary

M2 Agent OS 里程碑的第四个增量：Integration Task 机制 + Mission 自动完成触发。

- **Mission 自动完成**：`internal/mission/store.go` 的 `TransitionTask` 新增 `tryCompleteMission`——任意 Task 转到 `succeeded` 时自动检查所在 Mission 当前 Plan 版本下是否全部 Task 已完成，是则推进 `running → verifying → succeeded`（两跳，复用既有 Mission 状态机规则）。没有 Integration Task 的 Mission（只有 implementation + verification）也能借此自动收尾，不需要为"没有 Integration Task"的场景单独写路径。
- **`Store.MarkMissionNeedsAttention`**：新增方法，把 Mission 升级到 `needs_attention`，供 Integration 失败时使用；对已是该状态的 Mission 幂等。
- **`internal/integration` 新包**：`Adapter` 实现 `scheduler.Dispatcher`，处理 `mission.ContractIntegration` Task——同步半段创建 Mission 级 worktree（复用 `worker.CreateWorktree`/`RemoveWorktree`）+ lease/attempt 簿记（失败自动回滚，与 `worker`/`verifier` 的 Dispatch 模式一致）；异步半段依次合并每个依赖 Task 的分支（`MergeBranch`，冲突自动 `git merge --abort` 复原），合并成功后跑联合验证（复用 `verifier.RunVerificationChecks`，为此把它从包内私有导出），记录 Mission 级 Artifact/Evidence，成功推进 Integration Task 到 `succeeded`（间接触发 Mission 完成），失败则把 Task 转 `failed` 并将 Mission 升级到 `needs_attention`。
- `internal/verifier/verify.go` 的 `runVerificationChecks`/`verificationReport` 改名导出为 `RunVerificationChecks`/`VerificationReport`，纯改名不改行为，供 `internal/integration` 复用。

## Test Plan

- [x] `go test ./internal/mission ./internal/verifier ./internal/integration -count=1 -v -timeout 5m` 全部通过（含 Mission 自动完成的正向/回归测试、Integration 合并成功/冲突两条端到端路径）
- [x] `go build ./...` / `go test ./... -timeout 10m` / `go vet ./...` / `gofmt -l .` 全部通过
- [x] 独立复审确认：`tryCompleteMission` 不会提前触发或重复触发（仅在 Mission `running` 且当前 Plan 版本全部 Task `succeeded` 时才生效，完成后状态永久离开 `running`）；异步 `Dispatch` 无 goroutine 泄漏（测试正确等待 Task 终态后才返回，复刻了 Verifier 计划 Task 4 复审踩过的坑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)