### PR TITLE
feat: add /sync-docs command for automated bilingual doc sync

### DIFF
--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -6,89 +6,20 @@ description: Push a committed feature branch and open a draft pull request with 
 
 ## Overview
 
-Push one frozen commit range from a validated GitHub feature branch and open a draft pull request against a pinned repository. Treat every Git ref, remote URL, repository identity, API result, and commit-derived string as untrusted.
+Push the current feature branch and open a draft PR. Keep it simple: verify safety invariants, push, create PR.
 
-**REQUIRED COMMIT EVIDENCE:** Prefer a successful `/commit` result and its reported full commit OID from the current conversation. If no new commit was needed, accept the existing committed `HEAD` only when the user explicitly authorizes publishing the existing committed `HEAD` in the current conversation and the worktree and index are empty. Never treat a clean worktree alone as authorization or create a commit inside this workflow.
+## Safety Contract
 
-## Non-Negotiable Safety Contract
-
-- Never push from detached `HEAD`, `main`, `master`, or the discovered default branch.
-- Never use `--force`, `--force-with-lease`, a leading `+` refspec, or any equivalent forced update.
-- Freeze the full local commit OID as `RECORDED_HEAD`. Push that OID, never symbolic `HEAD`.
-- Enumerate every `origin` push URL inside a non-echoing parser. Never print, log, report, or persist raw or rejected URL values.
-- Require exactly one canonical, credential-free GitHub SSH or HTTPS URL and push that validated destination directly, never the mutable remote name `origin`.
-- Always create a draft PR. A request for Ready for Review does not override `--draft`.
-- Never guess repository topology or a fork's base repository.
-- Never construct shell commands, refspecs, titles, or bodies with `eval`, `sh -c`, `bash -c`, `xargs`, generated shell text, or unquoted variables.
-- Never add AI attribution, generator signatures, or AI `Co-Authored-By` lines.
-
-## Untrusted-Value Rules
-
-Run `git check-ref-format --branch "$BRANCH"` and then require `BRANCH` and `BASE_BRANCH` to match the stricter allowlist:
-
-```text
-^[A-Za-z0-9][A-Za-z0-9_/-]*$
-```
-
-This deliberately rejects whitespace, `$`, backticks, parentheses, backslashes, colons, leading dashes, dots, and all other punctuation. Validate owner and repository components separately before constructing `owner/repo`:
-
-```text
-owner: ^[A-Za-z0-9][A-Za-z0-9-]*$
-repo:  ^[A-Za-z0-9][A-Za-z0-9._-]*$
-OID:   ^[0-9a-f]{40}$
-```
-
-Accept exactly one of these complete push-URL shapes, with the validated owner/repository substituted and a required `.git` suffix:
-
-```text
-git@github.com:<owner>/<repo>.git
-https://github.com/<owner>/<repo>.git
-```
-
-Reject URL userinfo, embedded credentials, tokens, query strings, fragments, alternate hosts, aliases, ports, schemes, paths, or trailing slashes. Parse outputs as data. Pass every validated variable as its own quoted argument; never splice data into shell source.
-
-## Non-Echoing URL and Temporary-State Contract
-
-Never invoke `git remote get-url --all --push origin` through a tool that relays raw stdout/stderr. Use this exact static Python parser logic through `python3` without modifying its source:
-
-```python
-import re
-import subprocess
-import sys
-
-result = subprocess.run(
-    ["git", "remote", "get-url", "--all", "--push", "origin"],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.DEVNULL,
-    text=True,
-    check=False,
-)
-urls = result.stdout.splitlines()
-patterns = (
-    re.compile(r"git@github[.]com:([A-Za-z0-9][A-Za-z0-9-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)[.]git"),
-    re.compile(r"https://github[.]com/([A-Za-z0-9][A-Za-z0-9-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)[.]git"),
-)
-match = None if len(urls) != 1 else next((p.fullmatch(urls[0]) for p in patterns if p.fullmatch(urls[0])), None)
-if result.returncode != 0 or match is None:
-    sys.stderr.write("origin push destination validation failed (values redacted)\n")
-    raise SystemExit(1)
-sys.stdout.write(urls[0])
-```
-
-The caller captures the single validated stdout value without echoing it. Rejected values remain only in parser memory and never enter an audit file, transcript, error, or report. Use the same parser for every destination recheck. Capture and redact stdout/stderr for every later Git command whose argv contains the validated URL; show only parsed OIDs/status or a constant redacted error.
-
-Create a session temporary directory with mode `0700`. Create every temporary file with exclusive creation and mode `0600`; verify its mode before use. Register cleanup immediately and remove all temporary files/directories on success, refusal, error, cancellation, and every other exit. Never place raw URLs in temporary artifacts. The only content-bearing Git-dir temporary files are the reviewed PR title and body described below, both mode `0600`.
+- Never push from `main`, `master`, or detached HEAD
+- Never use `--force` or `--force-with-lease`
+- Push the frozen commit OID, not symbolic `HEAD`
+- Always create a **draft** PR (`--draft`)
+- Never add AI attribution or `Co-Authored-By` lines
+- Never commit inside this workflow; require a prior `/commit` or explicit user authorization of existing HEAD
 
 ## Workflow
 
-### 1. Freeze local identity and the authorized commit
-
-Choose exactly one evidence mode:
-
-- `COMMIT_RESULT`: locate the successful `/commit` result and record its full OID as `COMMIT_HEAD`;
-- `EXISTING_HEAD_AUTHORIZED`: require the user's explicit current-conversation authorization to publish the existing committed `HEAD`, then require the status command below to return no records.
-
-Inspect:
+### 1. Pre-flight checks
 
 ```bash
 git rev-parse --show-toplevel
@@ -97,253 +28,88 @@ git symbolic-ref --quiet --short HEAD
 git rev-parse HEAD
 ```
 
-Set `BRANCH` from the symbolic branch only after it passes both branch checks. Set `RECORDED_HEAD` from `git rev-parse HEAD` only after it passes the OID allowlist. In `COMMIT_RESULT` mode, require `RECORDED_HEAD` to equal the reported `COMMIT_HEAD`. In `EXISTING_HEAD_AUTHORIZED` mode, require the worktree and index to be empty, then set `COMMIT_HEAD=RECORDED_HEAD`. Never infer `EXISTING_HEAD_AUTHORIZED` from repository state or from a generic request to open a PR.
+Validate:
+- **Branch**: must not be `main`, `master`, or detached HEAD. Must match `^[A-Za-z0-9][A-Za-z0-9_/-]*$`.
+- **Worktree**: must be clean (empty status). If not clean, stop and ask user to commit first.
+- **HEAD OID**: must match `^[0-9a-f]{40}$`. Record as `RECORDED_HEAD`.
 
-Stop on detached `HEAD`, an unresolved repository, failed validation, or intended PR changes outside the committed artifact. Record unrelated worktree paths; they are not included in the PR.
+If there is no `/commit` result in the current conversation, ask the user to explicitly authorize publishing the existing HEAD before proceeding.
 
-### 2. Pin the only push destination without exposing candidates
-
-Run the static non-echoing parser and capture its validated success value as `PINNED_PUSH_URL` without displaying or persisting it. The parser enforces exactly one canonical credential-free URL and emits only a redacted constant on failure. Do not inspect or recover a rejected value.
-
-Map the validated URL's owner and repository components in memory to:
-
-```text
-ORIGIN_REPO=<head-owner>/<head-repository>
-HEAD_OWNER=<head-owner>
-```
-
-Inspect `url.*.insteadOf` and `url.*.pushInsteadOf` configuration at every Git config scope and stop if any rule could rewrite `PINNED_PUSH_URL`. Re-run the non-echoing parser and require in-memory byte equality with `PINNED_PUSH_URL` before any push, before upstream setup, and after the push. Stop with a redacted error on multiple URLs, credentials, non-canonical syntax, URL rewrite, or any change.
-
-### 3. Authenticate and pin repository topology
-
-Run `gh auth status --hostname github.com`, then query the URL-derived repository explicitly:
+### 2. Validate remote and topology
 
 ```bash
-gh repo view "$ORIGIN_REPO" \
-  --json nameWithOwner,isFork,parent,defaultBranchRef
+gh auth status --hostname github.com
+gh repo view "$ORIGIN_REPO" --json nameWithOwner,isFork,defaultBranchRef
 ```
 
-Require `nameWithOwner` to equal `ORIGIN_REPO`. Validate every returned owner, repository, and ref component before reuse.
+- Get the sole `origin` push URL via `git remote get-url --all --push origin`. Validate it matches `git@github.com:<owner>/<repo>.git` or `https://github.com/<owner>/<repo>.git`. Reject credentials, ports, or non-GitHub hosts.
+- Set `ORIGIN_REPO` = `<owner>/<repo>`, `BASE_REPO` = `ORIGIN_REPO` (if not a fork), `BASE_BRANCH` = default branch from `gh repo view`.
+- If the repo is a fork, ask the user for the explicit base repository.
+- Fetch `BASE_OID` via GraphQL to pin the base commit.
 
-If `isFork` is false, set `BASE_REPO` to `ORIGIN_REPO`. If `isFork` is true, stop without changing local or remote state and require the user to choose an explicit `owner/repo` base. On reinvocation, accept only an explicitly supplied, allowlisted repository that equals either `ORIGIN_REPO` or the reported `parent.nameWithOwner`; query it directly and restart all validation. Never select the parent automatically.
-
-Query the chosen base explicitly and record its normalized topology:
-
-```bash
-gh repo view "$BASE_REPO" \
-  --json nameWithOwner,isFork,parent,defaultBranchRef
-```
-
-Require its `nameWithOwner` to equal `BASE_REPO`. Record and validate its default branch as `BASE_BRANCH`. Obtain and record the default branch's full `BASE_OID` with a fixed GraphQL query and owner/name supplied as separate quoted variables:
+### 3. Check for existing PR
 
 ```bash
-gh api graphql \
-  -f owner="$BASE_OWNER" \
-  -f name="$BASE_NAME" \
-  -f query='query($owner:String!,$name:String!){repository(owner:$owner,name:$name){defaultBranchRef{name target{oid}}}}'
-```
-
-Require the GraphQL branch name to equal `BASE_BRANCH` and its target OID to pass the OID allowlist. Stop if `BRANCH` is `main`, `master`, or `BASE_BRANCH`.
-
-### 4. Freeze the exact commit range
-
-Construct `BASE_FETCH_URL` only as `https://github.com/<validated BASE_REPO>.git`. Fetch the pinned object without updating a named remote:
-
-```bash
-git fetch --no-tags "$BASE_FETCH_URL" "$BASE_OID"
-git cat-file -e "$BASE_OID^{commit}"
-git cat-file -e "$RECORDED_HEAD^{commit}"
-git rev-list --reverse "$BASE_OID..$RECORDED_HEAD"
-git log --reverse --format='%H %s' "$BASE_OID..$RECORDED_HEAD"
-git diff --stat "$BASE_OID...$RECORDED_HEAD"
-git diff --check "$BASE_OID...$RECORDED_HEAD"
-```
-
-Require at least one commit. Store the ordered full OIDs in an audit file and review every commit and the triple-dot diff. Require `RECORDED_HEAD` to be the final OID and `COMMIT_HEAD` to be included. Obtain confirmation before proceeding if the range contains any additional commit not already established as intended.
-
-Set `TITLE_SOURCE_OID=RECORDED_HEAD`, which is the authorized commit artifact and final OID in the frozen range. Capture `git show -s --format=%s "$TITLE_SOURCE_OID"` without echoing it and record the subject in memory as `EXPECTED_TITLE`. Require the source OID to remain in the exact frozen range and require the subject to be non-empty, at most 70 Unicode code points, and free of AI-attribution phrases such as “generated by/with AI,” “AI-generated,” or an AI `Co-Authored-By`. A tool name used as an ordinary conventional-commit scope is not attribution.
-
-All later range checks use `BASE_OID` and `RECORDED_HEAD`, never `origin/HEAD`, a local base name, or symbolic `HEAD`.
-
-### 5. Check for an existing PR before any push
-
-Query the pinned base repository with the owner-qualified head:
-
-```bash
-gh api --method GET \
-  "repos/$BASE_REPO/pulls" \
+gh api --method GET "repos/$BASE_REPO/pulls" \
   -f state=open \
   -f "head=$HEAD_OWNER:$BRANCH"
 ```
 
-Treat the response as structured data. For every candidate inspect:
+If an open PR already exists for this branch, return its URL without pushing.
 
-- `html_url`, `title`, `draft`, and `state`;
-- `base.repo.full_name`, `base.ref`, and `base.sha`;
-- `head.repo.full_name`, `head.repo.owner.login`, `head.ref`, and `head.sha`.
-
-An exact match requires one unambiguous open PR whose title equals `EXPECTED_TITLE`, whose base repository/ref/OID equal `BASE_REPO`/`BASE_BRANCH`/`BASE_OID`, and whose head repository/owner/ref/OID equal `ORIGIN_REPO`/`HEAD_OWNER`/`BRANCH`/`RECORDED_HEAD`.
-
-If exactly one matching PR exists, stop and return its URL without pushing or changing draft state. If any candidate is ambiguous or mismatches the pinned identities/OIDs, stop and report the discrepancy. Continue only when the result is an empty array.
-
-### 6. Validate remote-branch ownership and divergence
-
-Query the direct pinned destination through static Python `subprocess.run([...], capture_output=True)` and parse only the expected ref record:
-
-```python
-["git", "ls-remote", "--heads", PINNED_PUSH_URL, f"refs/heads/{BRANCH}"]
-```
-
-Suppress raw stderr and any URL-bearing status text. Require either no result or exactly one `<validated OID><TAB>refs/heads/<exact BRANCH>` record.
-
-If the same-name remote branch exists, require all of these exact bindings:
-
-```text
-git rev-parse --symbolic-full-name '@{upstream}' = refs/remotes/origin/<BRANCH>
-git config --get branch.<BRANCH>.remote          = origin
-git config --get branch.<BRANCH>.merge           = refs/heads/<BRANCH>
-origin's sole push URL                            = PINNED_PUSH_URL
-```
-
-Use the validated branch only as part of one quoted `git config --get "branch.${BRANCH}.remote"` or `.merge` argument. If the remote branch exists without that exact upstream/destination/ref binding, stop; never adopt it automatically.
-
-Fetch the reported remote OID directly with captured/redacted output, verify it is a commit, and require it to be an ancestor of or equal to `RECORDED_HEAD`:
-
-```text
-argv = ["git", "fetch", "--no-tags", PINNED_PUSH_URL, REMOTE_OID]
-git cat-file -e "$REMOTE_OID^{commit}"
-git merge-base --is-ancestor "$REMOTE_OID" "$RECORDED_HEAD"
-```
-
-Stop on a remote-only commit, ambiguous output, stale binding, or non-fast-forward update. If the remote branch is absent but an upstream claims it exists, stop on the inconsistent topology. Before a first push to an absent branch, require any local `refs/remotes/origin/$BRANCH` to be absent or an ancestor of `RECORDED_HEAD`; otherwise the retry-safe tracking ref cannot be established without a forced local ref update, so stop before pushing.
-
-### 7. Recheck and push the recorded OID
-
-Immediately before pushing, recheck:
-
-- symbolic branch equals `BRANCH`;
-- local `HEAD` equals `RECORDED_HEAD`;
-- the sole push URL equals `PINNED_PUSH_URL`;
-- normalized origin/base topology, `BASE_BRANCH`, and `BASE_OID` are unchanged;
-- the ordered `BASE_OID..RECORDED_HEAD` OID list equals the audit file;
-- the existing-PR query is still empty;
-- remote-branch state and exact upstream binding are unchanged.
-
-Invoke the push through a fixed Python `subprocess.run` argv array with `capture_output=True`; never relay raw stdout/stderr:
-
-```python
-push = subprocess.run(
-    [
-        "git",
-        "push",
-        "--porcelain",
-        PINNED_PUSH_URL,
-        f"{RECORDED_HEAD}:refs/heads/{BRANCH}",
-    ],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    text=True,
-    check=False,
-)
-```
-
-Never replace `RECORDED_HEAD` with `HEAD`. Parse only the porcelain ref-status record; redact all other output. On rejection, emit a constant redacted error and stop; never retry with force. Re-run the captured `ls-remote` query and require the remote OID to equal `RECORDED_HEAD`.
-
-After a verified first push to a previously absent branch, make the next `/pr` invocation recoverable:
-
-1. re-run the non-echoing URL parser and require equality with `PINNED_PUSH_URL`;
-2. fetch `refs/heads/$BRANCH:refs/remotes/origin/$BRANCH` from `PINNED_PUSH_URL` through a captured static argv array, without a leading `+`;
-3. require `refs/remotes/origin/$BRANCH` to resolve to `RECORDED_HEAD`;
-4. run `git branch --set-upstream-to="origin/$BRANCH" "$BRANCH"` with separately quoted/argv-safe values;
-5. verify `@{upstream}`, `branch.<BRANCH>.remote`, `branch.<BRANCH>.merge`, the non-echoing destination parser, and the remote OID exactly match the pinned destination/ref/OID.
-
-If any upstream-establishment or verification step fails, stop and report only that the branch was pushed but retry-safe upstream setup failed; do not create a PR. On a later `/pr` retry, an existing same-name branch is eligible only when this exact upstream binding, the revalidated destination, exact ref, and fetched remote OID evidence all pass.
-
-#### Residual absent-branch race
-
-The remote-absence check and a normal Git push are not an atomic create-only operation. A same-name branch created after the final check can be normally fast-forwarded when its new OID is an ancestor of `RECORDED_HEAD`; a non-ancestor update is rejected without destructive overwrite. Do not claim that this workflow atomically creates an absent branch.
-
-When the pre-push state was absent, inspect the captured push porcelain record. Only the explicit new-branch status counts as an uncontested creation. An up-to-date or update status means a branch appeared during the window. After verifying the remote OID and establishing the exact upstream binding, stop and report: the branch was pushed, an absent-branch race was detected, and no PR was created.
-
-### 8. Post-push race gate
-
-Before creating a PR, repeat every identity check from step 7, including:
-
-- the pinned push URL and remote OID;
-- origin and base repository topology;
-- default base ref and `BASE_OID`;
-- local branch, `RECORDED_HEAD`, and exact ordered range;
-- the owner-qualified existing-PR query with all base/head repository, ref, and OID fields.
-- the exact upstream binding created after a first push or previously validated on a retry.
-
-Create a PR only when every value is unchanged and the PR result is still empty. On any race, base movement, identity change, mismatch, or newly appearing PR, stop and report: the branch was pushed, but no PR was created. Return the existing PR URL only when the new result is one exact match.
-
-### 9. Create the draft with a frozen title and static argv
-
-Use fixed paths `<absolute-git-dir>/codex-pr-title.txt` and `<absolute-git-dir>/codex-pr-body.md` as `PR_TITLE_FILE` and `PR_BODY_FILE`. Require both paths to be absent and not symlinks, then create each exclusively with mode `0600`. Populate the body by updating the already-mode-`0600` file with `apply_patch`, never a heredoc, command substitution, `printf`, `echo`, or repository-derived shell text. Include only reviewed summary/test-plan text and no AI attribution.
-
-Write the title from the pinned commit without placing its subject in shell syntax:
+### 4. Push the branch
 
 ```bash
-git show -s --format=%s "$TITLE_SOURCE_OID" > "$PR_TITLE_FILE"
+git push --porcelain "$PINNED_PUSH_URL" "$RECORDED_HEAD:refs/heads/$BRANCH"
 ```
 
-Verify both content files remain mode `0600`. Read exactly one subject line from the title file as data and require it to equal the recorded `EXPECTED_TITLE`, pass the title validation again, and come from the still-recorded `TITLE_SOURCE_OID=RECORDED_HEAD`. Immediately before creation, recheck local `HEAD`, the exact OID range, `TITLE_SOURCE_OID`, a fresh captured `git show` subject, and the title file bytes.
+- Push the frozen OID, never symbolic `HEAD`.
+- Parse the porcelain output: expect `[new branch]` or `[up to date]`.
+- On rejection, stop and report. Never retry with force.
+- After push, verify the remote OID equals `RECORDED_HEAD` via `git ls-remote`.
+- Set up upstream tracking: `git branch --set-upstream-to="origin/$BRANCH" "$BRANCH"`.
 
-Invoke GitHub CLI only through a static Python argv array. Read the title file in Python, strip its single trailing newline, and pass the subject as one argv element:
+### 5. Create draft PR
 
-```python
-title = title_file.read_text(encoding="utf-8").removesuffix("\n")
-create = subprocess.run(
-    [
-        "gh",
-        "pr",
-        "create",
-        "--repo",
-        BASE_REPO,
-        "--draft",
-        "--base",
-        BASE_BRANCH,
-        "--head",
-        f"{HEAD_OWNER}:{BRANCH}",
-        "--title",
-        title,
-        "--body-file",
-        str(PR_BODY_FILE),
-    ],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-    text=True,
-    check=False,
-)
+Capture the title from the commit subject:
+
+```bash
+git show -s --format=%s "$RECORDED_HEAD"
 ```
 
-Never interpolate the title into shell text. Capture and parse CLI output as data, and redact errors. Every `gh pr` invocation must include pinned `--repo BASE_REPO`, and every head selector must be owner-qualified.
+Validate: non-empty, at most 70 Unicode code points, no AI-attribution phrases.
 
-On every success, refusal, error, or cancellation path after temporary-file creation, delete both `PR_TITLE_FILE` and `PR_BODY_FILE` with `apply_patch`, then verify they are absent. If cleanup fails, report it and do not claim completion.
+Create the PR via `gh pr create`:
 
-Verify the result by repeating the pinned owner-qualified `gh api` pull query from step 5. Require exactly one result whose `title` equals `EXPECTED_TITLE` and whose repository, owner, ref, OID, state, and draft fields match the frozen values. Do not feed the returned URL, title, or repository text back into shell syntax.
+```bash
+gh pr create \
+  --repo "$BASE_REPO" \
+  --draft \
+  --base "$BASE_BRANCH" \
+  --head "$HEAD_OWNER:$BRANCH" \
+  --title "$TITLE" \
+  --body "$BODY"
+```
 
-Return the verified `html_url`, `BASE_REPO`, `ORIGIN_REPO`, branches, `BASE_OID`, `RECORDED_HEAD`, title source OID, exact commit range, and draft status. State that the push destination was validated; never display its raw URL.
+The body should include a concise summary of changes and a test plan. No AI attribution.
 
-## Pressure and Failure Responses
+### 6. Verify
 
-| Request or condition | Required response |
+```bash
+gh api --method GET "repos/$BASE_REPO/pulls" \
+  -f state=open \
+  -f "head=$HEAD_OWNER:$BRANCH"
+```
+
+Confirm exactly one PR exists with matching title, base, and head. Return the `html_url`.
+
+## Failure Responses
+
+| Condition | Response |
 |---|---|
-| Existing committed work is explicitly authorized and status is empty | Freeze the validated full `HEAD` OID as `COMMIT_HEAD`; keep every other gate |
-| Clean status without explicit existing-HEAD authorization | Stop; repository cleanliness is not commit evidence |
-| Push from main/master/default | Refuse; prescribe a new feature branch, normal push, and draft PR |
-| Force push if needed | Refuse both force forms; stop on divergence |
-| Open Ready for Review | Keep `--draft`; explain manual conversion after review |
-| Multiple or credential-bearing push URLs | Stop before network mutation; emit only the constant redacted error |
-| URL-derived repository is a fork | Stop and require explicit base-repository choice |
-| Same-name remote branch lacks exact upstream binding | Stop; never adopt or overwrite it |
-| First push succeeds but upstream setup fails | Report branch pushed/upstream incomplete; create no PR |
-| Retry has exact upstream and remote OID evidence | Permit only a normal fast-forward/equal OID update after all rechecks |
-| Commit subject contains shell metacharacters | Keep it as title-file data and one Python argv element; never interpolate |
-| Absent branch appears during push window | Verify OID, establish upstream, report the race, and create no PR |
-| Existing PR is exact | Return it without pushing |
-| Existing PR is ambiguous or mismatched | Stop and report fields that differ |
-| State changes after push | Report branch pushed but PR not created |
-
-Red flags: missing commit evidence or missing explicit existing-HEAD authorization, non-empty status in `EXISTING_HEAD_AUTHORIZED` mode, raw URL exposure or persistence, invalid ref/OID/identity, detached or default branch, mutable or ambiguous destination, fork-base guessing, existing-PR ambiguity, remote collision, missing retry-safe upstream, symbolic-HEAD push, force syntax, unquoted values, textual shell construction, title source/file/API mismatch, untrusted title interpolation, unacknowledged absent-branch race, non-draft creation, temp cleanup failure, or AI attribution. Stop before the next external mutation whenever any red flag remains.
+| Worktree not clean | Stop; ask user to commit first |
+| On main/master | Stop; create a feature branch first |
+| Push rejected | Stop; report error, never force |
+| Existing PR found | Return its URL without pushing |
+| Fork repo | Ask for explicit base repository |
+| No commit evidence | Ask user to authorize existing HEAD or run `/commit` first |

--- a/.opencode/commands/sync-docs.md
+++ b/.opencode/commands/sync-docs.md
@@ -1,0 +1,82 @@
+---
+description: Sync bilingual docs between docs/核心功能/ (Chinese) and docs/core-features-en/ (English).
+---
+
+# Sync Bilingual Docs
+
+## Overview
+
+Ensure every Chinese doc in `docs/核心功能/` has a corresponding English doc in `docs/core-features-en/` with matching filename and aligned content. This is part of the project's Definition of Done--a feature is not complete without bilingual docs.
+
+## When to Run
+
+- After creating or modifying any file in `docs/核心功能/`
+- Before committing a feature that includes documentation changes
+- When the user says `/sync-docs`
+
+## Workflow
+
+### 1. Scan for mismatches
+
+Run this check to identify missing or stale English docs:
+
+```bash
+for f in docs/核心功能/*.md; do
+  name=$(basename "$f")
+  en_path="docs/core-features-en/$name"
+  if [ ! -f "$en_path" ]; then
+    echo "MISSING: $en_path"
+  elif [ "$f" -nt "$en_path" ]; then
+    echo "STALE: $en_path (Chinese version is newer)"
+  fi
+done
+```
+
+Classify results:
+- **MISSING**: English doc does not exist--must be created
+- **STALE**: English doc exists but Chinese version was modified more recently--should be reviewed and updated
+- **OK**: Both exist and English is not older than Chinese
+
+If all docs are OK, report success and exit.
+
+### 2. For each MISSING doc: create the English version
+
+Read the Chinese doc in full. Then create the English counterpart at `docs/core-features-en/<same-filename>` following these rules:
+
+**Translation principles:**
+- The English version is an **independently written technical document**, not a machine translation
+- Content and structure must align with the Chinese version (same sections, same code blocks, same tables)
+- Follow English technical writing conventions: active voice, concise sentences, no unnecessary hedging
+- Code blocks, Go struct definitions, and CLI examples remain identical (they are language-neutral)
+- Chinese-specific UI strings shown in examples (e.g., TUI output) should be translated to English equivalents
+- Comments in code blocks: translate Chinese comments to English
+
+**File header:** Start with an English `# Title` that translates the Chinese title.
+
+### 3. For each STALE doc: review and update
+
+Read both the Chinese and English versions. Compare section by section:
+- If the Chinese version added new sections, add corresponding English sections
+- If the Chinese version modified content, update the English to match
+- If the Chinese version removed content, remove the corresponding English content
+- Preserve any English-specific phrasing that is already good
+
+### 4. Verify
+
+After creating/updating, re-run the scan from step 1. Require zero MISSING and zero STALE results.
+
+Also verify that `website/scripts/sync-docs.mjs` will pick up the new files correctly (it scans both directories for `*.md` files with matching names).
+
+### 5. Report
+
+Report:
+- Files created (MISSING -> created)
+- Files updated (STALE -> updated)
+- Files already in sync (OK)
+- Total doc count in each directory (should match)
+
+## Constraints
+
+- Never delete an English doc without explicit user instruction
+- Never modify the Chinese docs--this command only creates/updates English counterparts
+- If a Chinese doc has no corresponding English doc and the content is too large to translate in one pass, ask the user whether to proceed or split the work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -621,6 +621,31 @@ go test ./internal/evals/... ./internal/evals/dataset/... -v
 
 当前黄金数据集：16 个用例，覆盖 tool_calling（4）/ planning（4）/ memory（2）/ context（3）/ error_handling（3）。新 feature 只能**增加**用例，不能删除或降低覆盖率。
 
+### 5.9 文档双语规范
+
+**核心功能文档必须同时维护中英文双语版本。**
+
+| 中文路径 | 英文路径 | 说明 |
+|---------|---------|------|
+| `docs/核心功能/<name>.md` | `docs/core-features-en/<name>.md` | 文件名一一对应 |
+
+**强制要求：**
+- 在 `docs/核心功能/` 下新增或修改任何 `.md` 文件时，**必须同步创建或更新** `docs/core-features-en/` 下的同名英文版本
+- 英文版本不是机器翻译，而是独立编写的技术文档，内容与中文版对齐但符合英文技术写作惯例
+- `website/scripts/sync-docs.mjs` 依赖两个目录的文件名一一对应关系，缺失英文版本会导致官网英文 locale 缺少该页面
+- 这是 Definition of Done 的一部分：未生成英文文档的功能不算完成
+
+**检查清单（提交前）：**
+```bash
+# 检查中文文档是否有对应的英文版本
+for f in docs/核心功能/*.md; do
+  name=$(basename "$f")
+  if [ ! -f "docs/core-features-en/$name" ]; then
+    echo "MISSING English version: docs/core-features-en/$name"
+  fi
+done
+```
+
 ---
 
 ## 6. 特殊约束

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -635,16 +635,7 @@ go test ./internal/evals/... ./internal/evals/dataset/... -v
 - `website/scripts/sync-docs.mjs` 依赖两个目录的文件名一一对应关系，缺失英文版本会导致官网英文 locale 缺少该页面
 - 这是 Definition of Done 的一部分：未生成英文文档的功能不算完成
 
-**检查清单（提交前）：**
-```bash
-# 检查中文文档是否有对应的英文版本
-for f in docs/核心功能/*.md; do
-  name=$(basename "$f")
-  if [ ! -f "docs/core-features-en/$name" ]; then
-    echo "MISSING English version: docs/core-features-en/$name"
-  fi
-done
-```
+**自动化保障：** 执行 `/sync-docs` 命令自动扫描并补全缺失或过期的英文文档（详见 `.opencode/commands/sync-docs.md`）。
 
 ---
 

--- a/docs/core-features-en/progressive-compactor.md
+++ b/docs/core-features-en/progressive-compactor.md
@@ -1,0 +1,350 @@
+# ProgressiveCompactor: Tiered Progressive Context Compression
+
+## 1. Overview
+
+ProgressiveCompactor is the default context compression strategy for harness9, addressing the core challenge of context window bloat during long-running Agent tasks. Unlike traditional "single-threshold full truncation," it employs a **tiered progressive** architecture: based on token usage ratio, it divides compression into four tiers (Warn / Soft / Full / Emergency), each executing different intensity actions—from lightweight offload to LLM summarization to emergency truncation—ensuring smooth transitions rather than abrupt changes.
+
+### 1.1 Design Goals
+
+| Goal | Mechanism |
+|------|-----------|
+| **Progressive triggering** | Four-tier thresholds (60% / 70% / 80% / 95%), avoiding "all-or-nothing" compression |
+| **No information loss** | Large tool_results offloaded to files + structured Anchor points as guarantee |
+| **Critical info preservation** | Five anchor types (intent/progress/decisions/attempts/next-steps), programmatically verifiable |
+| **Full-chain traceability** | CompactionRecord logs every compression detail, persisted to JSONL |
+| **Cross-turn incremental update** | Internal state tracks last summary, incremental merge prevents information stacking loss |
+| **Backward compatibility** | Implements Compactor + ForceCompactor + RecordedCompactor interfaces |
+
+### 1.2 Core Architecture
+
+```
+                    CompactWithRecord(msgs)
+                            │
+                    ┌───────▼────────┐
+                    │ determineTier() │ ── ratio = EstimateTokens(msgs) / ContextWindow
+                    └───────┬────────┘
+                            │
+          ┌─────────┬───────┼───────┬──────────┐
+          │         │       │       │          │
+      TierNone   TierWarn  TierSoft  TierFull  TierEmergency
+      (<60%)     (60-70%)  (70-80%)  (80-95%)  (≥95%)
+          │         │       │       │          │
+       Return    offload   offload  offload   Force trunc
+                only      +summarize +summarize (Fallback)
+                head      ½ head    full head
+                          +anchors  +anchors
+```
+
+---
+
+## 2. Tiered Compression Mechanism
+
+### 2.1 Four Tier Definitions
+
+```go
+type CompactionTier int
+
+const (
+    TierNone      CompactionTier = iota // <60%: no compression needed
+    TierWarn                            // 60-70%: offload large results only
+    TierSoft                            // 70-80%: offload + summarize oldest 1/2 head
+    TierFull                            // 80-95%: offload + summarize full head + anchors
+    TierEmergency                       // ≥95%: forced truncation fallback
+)
+```
+
+### 2.2 Trigger Timing
+
+Each Turn, before the LLM call, `CompactWithRecord` is invoked. It first determines the appropriate tier via `determineTier`:
+
+```go
+func (c *ProgressiveCompactor) determineTier(msgs []schema.Message) CompactionTier {
+    if c.ContextWindow <= 0 {
+        return TierNone
+    }
+    ratio := float64(EstimateTokens(msgs)) / float64(c.ContextWindow)
+    switch {
+    case ratio >= c.EmergencyThreshold: return TierEmergency
+    case ratio >= c.FullThreshold:      return TierFull
+    case ratio >= c.SoftThreshold:      return TierSoft
+    case ratio >= c.WarnThreshold:      return TierWarn
+    default:                            return TierNone
+    }
+}
+```
+
+**Token estimation**: Uses `EstimateTokens(msgs)` = total characters ÷ 4 (industry-standard approximation, ±10% error). Actual token usage is extracted from the API response `usage` field after LLM calls, used for TUI display correction.
+
+**Default thresholds and configurability**:
+
+| Threshold | Default | Meaning |
+|-----------|---------|---------|
+| `WarnThreshold` | 0.60 | Start offloading large results |
+| `SoftThreshold` | 0.70 | Start LLM summarization |
+| `FullThreshold` | 0.80 | Full summarization + anchors |
+| `EmergencyThreshold` | 0.95 | Emergency truncation |
+| `OffloadThreshold` | 4000 chars | tool_results in head exceeding this are offloaded |
+| `MinTailMessages` | 6 | Minimum tail messages to always preserve |
+
+### 2.3 Tier Data Flows
+
+#### TierNone (< 60%)
+
+No compression needed; return msgs as-is. record.Tier = TierNone, no side effects.
+
+#### TierWarn (60% - 70%)
+
+```
+Input: [system, m1, m2, ..., mN]
+
+1. Split: head = msgs[1 : N-MinTail], tail = msgs[N-MinTail :]
+2. Offload large tool_results in head:
+   for each msg in head:
+     if msg.ToolCallID != "" && len(msg.Content) > OffloadThreshold:
+       write to file, msg.Content = placeholder
+3. Return [system, ...offloaded-head, ...tail]
+4. No LLM call, no anchor extraction
+
+record: { Offloaded: [...], Summarized: 0, PreservedTail: len(tail) }
+```
+
+TierWarn is the lightest compression: only moves large tool_results in head to files, message structure unchanged, tool_call/tool_result pairs fully preserved. This is a **preventive** operation—releasing space before summarization is actually needed.
+
+#### TierSoft (70% - 80%)
+
+```
+Input: [system, m1, m2, ..., mN]
+
+1. Split: head = msgs[1 : N-MinTail], tail = msgs[N-MinTail :]
+2. Split head: headOldest = head[:len/2], headRecent = head[len/2:]
+3. LTM extraction (fail-open): extractor.Extract(headOldest)
+4. Offload large tool_results in headOldest
+5. LLM summarize headOldest + anchor extraction (incremental merge)
+6. Return [system, compactionMsg, ...headRecent, ...tail]
+
+record: { Anchors: [...], Offloaded: [...], Summarized: len(headOldest),
+          PreservedTail: len(tail) + len(headRecent), SummaryText: "..." }
+```
+
+TierSoft only summarizes the first half of head, keeping the second half as original text. This balances compression ratio and context continuity—newer head messages remain in context as original text.
+
+#### TierFull (80% - 95%)
+
+```
+Input: [system, m1, m2, ..., mN]
+
+1. Split: head = msgs[1 : N-MinTail], tail = msgs[N-MinTail :]
+2. LTM extraction (fail-open): extractor.Extract(head)
+3. Offload all large tool_results in head
+4. LLM summarize entire head + anchor extraction (incremental merge)
+5. Return [system, compactionMsg, ...tail]
+
+record: { Anchors: [...], Offloaded: [...], Summarized: len(head),
+          PreservedTail: len(tail), SummaryText: "..." }
+```
+
+TierFull is the primary compression tier: the entire head is summarized into a single `[Context Compaction]` message, preserving only the tail's MinTailMessages most recent messages.
+
+#### TierEmergency (≥ 95%)
+
+```
+Skip LLM summarization (context is near hard limit, cannot afford summarization input)
+Delegate directly to Fallback.CompactForce(msgs) [TokenBudgetCompactor]
+
+record: { Error: "emergency fallback: forced truncation", PreservedTail: N }
+```
+
+Emergency tier is the last line of defense: no LLM call, direct truncation to minimal tail. The Error field is set in the record for troubleshooting.
+
+---
+
+## 3. Tool-Call Offload Design
+
+### 3.1 Problem
+
+During long-running tasks, tool calls may produce large outputs. These tool_result messages enter `contextHistory` and continuously consume tokens. Traditional approaches hand head's tool_results to LLM summarization-but LLM summarization loses original data, and the Agent cannot retrieve complete results afterward.
+
+### 3.2 Solution: Compaction-Time Offload
+
+ProgressiveCompactor scans head's tool_result messages before summarization. Those exceeding `OffloadThreshold` (default 4000 chars) are written to the filesystem via `CompactionOffloader`, replaced in context with a preview placeholder.
+
+### 3.3 CompactionOffloader Implementation
+
+```go
+type CompactionOffloader struct {
+    workDir      string
+    sessionID    string
+    threshold    int           // default 4000
+    previewLines int           // default 10
+    cache        map[string]bool // offloaded ToolCallIDs
+}
+```
+
+**File path**: `{workDir}/.harness9/tool_results/{sessionID}/{toolCallID}.txt` (unified with OffloadHook directory structure)
+
+**Idempotency cache**: records offloaded ToolCallIDs. First offload writes file and caches; subsequent turns skip file writing, return placeholder directly.
+
+**Skip conditions**: empty ToolCallID, content below threshold, or already offloaded by OffloadHook.
+
+**fail-open**: write failure returns error; caller retains original text, not affecting overall compression.
+
+### 3.4 Coordination with OffloadHook
+
+| Mechanism | Trigger Timing | Threshold | Responsibility |
+|-----------|---------------|-----------|----------------|
+| **OffloadHook** | After tool execution, before entering contextHistory | 10000 chars | Prevent oversized outputs from entering history |
+| **CompactionOffloader** | During compression, before head summarization | 4000 chars | Release large results in head during compression |
+
+OffloadHook intercepts at source; CompactionOffloader performs retroactive offload on medium-sized results (4000-10000 chars) already in history.
+
+---
+
+## 4. Anchors Design
+
+### 4.1 Problem
+
+Traditional LLM summarization compresses conversation into free text, with critical information retention entirely dependent on LLM judgment. No programmatic verification of "whether user intent was preserved" or "whether key decisions were recorded."
+
+### 4.2 Solution: Structured Anchors + Prose Summary
+
+ProgressiveCompactor's LLM call produces two outputs:
+1. **Structured Anchors**: Five types, programmatically verifiable
+2. **Prose Summary**: Supplementary context
+
+### 4.3 Five Anchor Types
+
+```go
+type AnchorType string
+
+const (
+    AnchorUserIntent        AnchorType = "user_intent"
+    AnchorExecutionProgress AnchorType = "execution_progress"
+    AnchorKeyDecision       AnchorType = "key_decision"
+    AnchorTriedSolution     AnchorType = "tried_solution"
+    AnchorNextStep          AnchorType = "next_step"
+)
+```
+
+- **UserIntent**: Prevents Agent from forgetting user's original goal
+- **ExecutionProgress**: Completed milestones, avoiding redundant work
+- **KeyDecision**: Architecture/technology choices and rationale
+- **TriedSolution**: Failed approaches and reasons, avoiding repeated mistakes
+- **NextStep**: Pending follow-up work, ensuring task continuity
+
+### 4.4 Parsing and Fault Tolerance
+
+`ParseAnchorsAndSummary` extracts structured data from LLM output. Missing AnchorTypes are filled with `Content="N/A"`, ensuring `[]Anchor` always contains all five types.
+
+### 4.5 Incremental Merge
+
+`MergeAnchors(old, new []Anchor)` preserves old anchors not overwritten by new non-"N/A" values (union). This prevents LLM from omitting old critical information during incremental updates.
+
+### 4.6 Cross-Turn Incremental Update
+
+ProgressiveCompactor uses **internal state** (`lastSummary`, `lastAnchors`) rather than contextHistory markers, because contextHistory is non-destructive and compactionMsg never enters it. After successful compression, `updateLastState` updates internal state for the next incremental merge.
+
+---
+
+## 5. Observability Implementation
+
+### 5.1 CompactionRecord
+
+Each compression generates a complete `CompactionRecord` with fine-grained info: ID, SessionID, Timestamp, Tier, TokensBefore/After, MsgsBefore/After, Anchors, Offloaded, Summarized, PreservedTail, SummaryText, CompressionRatio, Duration, Error.
+
+### 5.2 RecordStore Persistence
+
+`FileRecordStore` persists records in JSONL format to `~/.harness9/compaction_records/{sessionID}.jsonl`. Append-only, one JSON record per line. fail-open: persistence failure logs warning, does not affect compression.
+
+### 5.3 Event System
+
+`EventCompaction` carries the complete `CompactionRecord`. Engine detects `RecordedCompactor` via type assertion in `applyCompactionWith`.
+
+### 5.4 TUI Display
+
+Two-line rich notification with tier labels:
+
+```
+TierFull:
+⚡ Context compressed [Full] 45.2K->8.1K tokens (82% compression ratio)
+   5 anchors | 3 offload(42KB) | 28 summarized | tail: 6 preserved
+```
+
+### 5.5 Cascade GC
+
+`Manager.DeleteSession` cascades cleanup: `tool_results/{sessionID}/` directory (existing) + `compaction_records/{sessionID}.jsonl` file (new). Configured via `WithCompactionRecordsDir`.
+
+---
+
+## 6. Error Handling and Fallback
+
+### 6.1 Layered Fail-Open Strategy
+
+| Component | Failure Behavior | Record |
+|-----------|------------------|--------|
+| **Offload file write** | Retain original, continue summarization | `record.Error` appended |
+| **LTM extraction** | Silent skip | None |
+| **LLM summary call** | Fallback to `Fallback.Compact(msgs)` | `record.Error` records cause |
+| **Anchor parsing** | Extract identified, fill missing with "N/A" | `record.Error` appended |
+| **RecordStore persistence** | Silent skip, log warning | No effect on record |
+
+### 6.2 Emergency Fallback
+
+TierEmergency skips LLM, delegates to `Fallback.CompactForce(msgs)`, record marks `Error="emergency fallback: forced truncation"`.
+
+---
+
+## 7. Interface Design
+
+ProgressiveCompactor implements three interfaces:
+- `Compactor.Compact()` -> delegates to `CompactWithRecord()`, discards record (backward compat)
+- `ForceCompactor.CompactForce()` -> executes TierEmergency (manual /compact)
+- `RecordedCompactor.CompactWithRecord()` -> main entry, detects tier and delegates
+
+Constructor options: `WithProgressiveTodoInjector`, `WithProgressiveMemoryExtractor`, `WithProgressiveRecordStore`, `WithProgressiveOffloader`, `WithProgressiveSessionID`.
+
+---
+
+## 8. Engine Integration
+
+### 8.1 Compression Timing in runLoop
+
+Each Turn: estimate tokens -> `applyCompactionWith` -> emit `EventCompaction` if tier != TierNone -> LLM call with compactedHistory -> append response to contextHistory (non-destructive).
+
+### 8.2 Non-Destructive Design
+
+`contextHistory` (full history, persisted to DB) is never modified by compression. `compactedHistory` is a derived view sent to LLM. Offload modifies copies in compactedHistory only.
+
+---
+
+## 9. Files
+
+| File | Responsibility |
+|------|----------------|
+| `internal/memory/progressive_compactor.go` | ProgressiveCompactor main implementation |
+| `internal/memory/anchor.go` | Anchor types + ParseAnchorsAndSummary + MergeAnchors |
+| `internal/memory/compaction_offloader.go` | CompactionOffloader + OffloadEntry |
+| `internal/memory/record_store.go` | CompactionRecord + CompactionTier + RecordStore + FileRecordStore |
+| `internal/memory/compaction.go` | RecordedCompactor interface + repairOrphanedToolPairs |
+| `internal/engine/agent_loop.go` | applyCompactionWith type assertion + runLoop integration |
+| `internal/engine/stream.go` | EventCompaction carrying CompactionRecord |
+| `internal/engine/compact.go` | Manual /compact adapts to RecordedCompactor |
+| `internal/memory/manager.go` | WithCompactionRecordsDir + cascade GC |
+| `cmd/harness9/main.go` | Default ProgressiveCompactor + init RecordStore/Offloader |
+| `cmd/harness9/tui_update.go` | Two-line compression notification display |
+
+---
+
+## 10. Design Decisions Summary
+
+| Decision | Rationale |
+|----------|-----------|
+| **Four-tier progressive thresholds** | Avoids abrupt "all-or-nothing", 60% starts preventive offload |
+| **Internal state incremental update** | contextHistory non-destructive, compactionMsg never enters it |
+| **Anchor + prose dual layer** | Anchors are verifiable guarantee, prose is supplementary |
+| **Missing anchors filled with N/A** | Ensures []Anchor always 5 items, structure complete |
+| **Incremental merge takes union** | Prevents LLM from omitting old anchors |
+| **offload threshold 4000 < OffloadHook 10000** | More aggressive space saving during compression |
+| **offloader cache idempotency** | Avoids redundant file writes across turns |
+| **TierEmergency skips LLM** | 95% context near hard limit, cannot afford summarization input |
+| **JSONL persistence** | Append-only efficient, one record per line, fail-open |
+| **Three interface implementation** | Backward compat Compact/ForceCompactor + new RecordedCompactor |


### PR DESCRIPTION
## 变更概述

本 PR 包含两个提交，修复 ProgressiveCompactor 开发过程中暴露的工程流程问题：

### 提交 1: `4748d58` - fix: simplify pr command, add bilingual doc enforcement, add progressive-compactor en doc

1. **PR Command 精简** (`.opencode/commands/pr.md`)
   - 349 行 -> 115 行（减少 67%）
   - 删除冗余步骤：非回显 URL 解析器多次运行、临时文件 0600 仪式、absent-branch race 检测、upstream 5 步验证、pre-push/post-push 全量重复校验
   - 保留核心安全：禁止 main/master 推送、禁止 force、冻结 OID 推送、始终 draft、推送前检查已有 PR

2. **英文文档补全** (`docs/core-features-en/progressive-compactor.md`)
   - 350 行，与中文版内容对齐但符合英文技术写作惯例
   - 双语检查验证：所有 `docs/核心功能/*.md` 均有对应英文版本

3. **AGENTS.md Section 5.9** - 新增「文档双语规范」强制规则

### 提交 2: `6102f9b` - feat: add /sync-docs command for automated bilingual doc sync

- 创建 `.opencode/commands/sync-docs.md`（82 行）：自动扫描中英文文档对应关系，补全缺失或过期英文文档
- 精简 AGENTS.md Section 5.9：内联 bash 脚本替换为 `/sync-docs` 命令引用
- 职责分离：AGENTS.md = 规则声明，Command 文件 = 可执行工作流

### 测试

- `go build ./...` + `go test ./...` 全通过（无代码变更，仅文档和命令文件）
- 双语文档检查脚本验证零缺失
