### PR TITLE
fix: 修复并行工具记录竞争、Anthropic 流式 token 统计等 5 处问题

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ harness9 是一款基于 Go 语言构建的**轻量级、功能完备、生产�
 - **Shell 执行（`!` 前缀）**: 输入框以 `!` 开头进入 Shell 模式，命令通过 `bash -c` 异步执行（30s 超时），输出 inline 追加到对话流，并在下次 LLM dispatch 时前置注入为上下文；已知交互式命令（vim/ssh 等）自动拦截
 - **Human-in-the-Loop 权限控制**: HookDecision（allow/deny/ask）三级决策 + DangerHook（19 条高危模式）+ PermissionHook（JSON 白名单，按需重载）+ 敏感路径硬保护（~/.ssh、~/.aws 等）+ TUI 五选项审批对话框 + PermissionMode 枚举
 - **Long-Term Memory（跨会话长期记忆）**: `internal/ltm/` 包；SQLite `long_term_memories` + standalone FTS5 `memories_fts`，复用 `state.db` 连接；MEMORY.md 物化视图（top-N 有界注入，≤5KB，规避 token bomb）+ `memory_search` 按需 FTS5 检索；三路触发：显式 `memory_write`/`memory_search` 工具 + 压缩前 `Extractor`（LLM 提取，fail-open）+ `WithMemoryNudge`（每 N 轮注入提示，防御性副本，不持久化）；SHA256 内容签名去重 + TTL 过期 + 软删除（signature=NULL 释放槽位）+ 命中强化（use_count/last_used_at）+ 陈旧识别（`StaleCandidates`）；Phase 3 接缝：Provider/Embedder/Consolidator 接口 + noopProvider
-- **Sandbox（Docker 容器级隔离）**: `internal/sandbox/` 包；`Environment` 接口（LocalEnvironment 进程级 / DockerEnvironment 容器级）+ `Container` 五状态生命周期（Pending→Running→Stopping→Terminated/Failed）+ `Manager`（Create/Destroy/DestroyAll/ReapOrphans/ListAll，并发安全）；工具透明路由（bash 命令通过 docker exec 进容器，文件工具通过 bind mount 共享 workDir）；安全加固：`--cap-drop all` + `--cap-add DAC_OVERRIDE/SETUID/SETGID`（包管理器所需最小能力）+ `--security-opt no-new-privileges:true` + `--pids-limit 256` + tmpfs nosuid/noexec/nodev；Agent 级隔离（主 Agent 和每个 Sub-Agent 各自拥有独立容器）；TUI SandboxBar 实时展示状态（颜色编码）；`label=harness9=1` 标记 + 启动时孤儿回收；`SANDBOX_ENABLED=true` 启用，关闭时行为与引入前完全一致（向后兼容）
+- **Sandbox（Docker 容器级隔离）**: `internal/sandbox/` 包；`Environment` 接口（LocalEnvironment 进程级 / DockerEnvironment 容器级）+ `Container` 五状态生命周期（Pending→Running→Stopping→Terminated/Failed）+ `Manager`（Create/Destroy/DestroyAll/ReapOrphans/ListAll，并发安全）；工具透明路由（bash 命令通过 docker exec 进容器，文件工具通过 bind mount 共享 workDir）；安全加固：`--cap-drop all` + `--cap-add DAC_OVERRIDE/SETUID/SETGID`（包管理器所需最小能力）+ `--security-opt no-new-privileges:true` + `--pids-limit 256` + tmpfs nosuid/noexec/nodev；Agent 级隔离（主 Agent 和每个 Sub-Agent 各自拥有独立容器）；TUI SandboxBar 实时展示状态（颜色编码）；`label=harness9=1` 标记 + 启动时孤儿回收；`SANDBOX_ENABLED=false` 时关闭（默认启用，Docker 不可用自动降级为本地进程模式），关闭时行为与引入前完全一致（向后兼容）
 - **Observability（OpenTelemetry 可观测性）**: `internal/observability/` 包；三条非侵入式接入路径——`OTELEngineObserver`（实现 `EngineObserver` 接口，管理 Interaction Span + Turn Span）+ `TracingProvider`（包装 `LLMProvider`，为每次 LLM 调用创建 Span + Token Metrics）+ `ObservabilityHook`（实现 `ToolHook`，为每次工具调用创建 Span）；Span 四层嵌套：`harness9.interaction → harness9.turn → harness9.llm_request / harness9.tool`；6 个关键 Metrics（LLM 延迟/Token 消耗/工具调用次数/工具执行耗时/Turn 总数）；`langfuse.trace.input`（trace 根节点 prompt）/ `langfuse.observation.input/output`（observation 层 LLM 消息与回复 + 工具参数与结果）/ `gen_ai.usage.*`（Token 用量，Langfuse 自动换算费用）；非法 UTF-8 字节自动净化，防止 OTLP 序列化失败；三种 Exporter：`noop`（默认零开销）/ `stdout`（开发调试）/ `otlp`（生产接入 Langfuse / Grafana / Jaeger）；通过环境变量 `OTEL_ENABLED` / `OTEL_EXPORTER_TYPE` / `OTEL_EXPORTER_OTLP_ENDPOINT` 驱动，默认关闭向后兼容
 - **网页搜索与抓取**: `internal/tools/web_search.go` / `web_fetch.go` / `web_safety.go` / `web_content.go`；`web_search` 工具（DuckDuckGo HTML 端点 POST，无 API Key，20s 超时 + 10s dial 超时，`golang.org/x/net/html` DOM 解析，`decodeUDDG` 还原真实 URL）+ `web_fetch` 工具（HTTP GET，15s 超时，5 次重定向上限，`text/html` → `go-readability` 提取主内容 → `html-to-markdown` 转 Markdown，`text/*` → 原始文本，其他 → 不支持提示）；`isSafeURL` 共享 SSRF 安全门（scheme + userinfo + DNS 解析 + 9 个 IP 段检查（含 IPv6 ULA `fc00::/7` 和链路本地 `fe80::/10`）+ IPv4-mapped IPv6 规范化 + IPv6 loopback，DNS 失败 fail-closed，重定向链每跳复检）；`DefaultPromptBuilder` 实时注入 `当前日期：YYYY-MM-DD`，防止 LLM 因训练截止日期偏差产生陈旧搜索词；主 Agent + 所有 Sub-Agent 均可使用，零额外配置
-- **Test & Eval（自动化测试与评估）**: `internal/evals/` 包；`ScriptedProvider`（确定性 LLM mock，按预设 Turn 序列返回回复，不发起真实 API 调用）+ `Assertion` 接口（Hard 断言：ToolCalled/ToolNotCalled/OutputContains/OutputExcludes/NoError/Error；Soft 断言：MaxTurns/MaxToolCalls，仅记警告不影响通过率）+ `EvalHarness`（`RunCase` 构建最小化隔离引擎 + `recordingHook` 记录工具调用轨迹 + `Suite` 批量运行）+ `SetupHermeticEnv`（清除所有 API Key，标准 Hermetic 隔离环境（密封测试，防止 eval 调用真实 API），本地与 CI 环境一致）+ `BuildReport`/`WriteJSON`/`WriteMarkdown`（JSON + Markdown 评估报告生成）；`internal/evals/dataset/` 黄金数据集（16 个用例：工具调用准确性 × 4 + Planning 完成率 × 4 + Context Engineering × 3 + Error Handling/Self-Healing × 3 + Memory 持久化 × 2）；`.github/workflows/eval.yml` CI Quality Gate（PR 触发 hermetic eval，失败则阻断合并）
+- **Test & Eval（自动化测试与评估）**: `internal/evals/` 包；`ScriptedProvider`（确定性 LLM mock，按预设 Turn 序列返回回复，不发起真实 API 调用）+ `Assertion` 接口（Hard 断言：ToolCalled/ToolNotCalled/OutputContains/OutputExcludes/NoError/Error；Soft 断言：MaxTurns/MaxToolCalls，仅记警告不影响通过率）+ `EvalHarness`（`RunCase` 构建最小化隔离引擎 + `recordingHook` 记录工具调用轨迹 + `Suite` 批量运行）+ `SetupHermeticEnv`（清除所有 API Key，标准 Hermetic 隔离环境（密封测试，防止 eval 调用真实 API），本地与 CI 环境一致）+ `BuildReport`/`WriteJSON`/`WriteMarkdown`（JSON + Markdown 评估报告生成）；`internal/evals/dataset/` 黄金数据集（22 个用例：工具调用准确性 × 6 + Planning 完成率 × 4 + Context Engineering × 4 + Error Handling/Self-Healing × 3 + Memory 持久化 × 2 + Context Compaction × 3）；`.github/workflows/eval.yml` CI Quality Gate（PR 触发 hermetic eval，失败则阻断合并）
 - **MCP 工具集成（Model Context Protocol）**: `internal/mcp/` 包；JSON-RPC 2.0 over stdio/HTTP；`Config`（`.mcp.json` 加载，file-not-found 静默返回空）+ `StdioTransport`（subprocess + NDJSON async reader goroutine + pending map ID 关联 + 三路 select ctx/done/response；`transport_proc_unix.go` 独立进程组 + SIGKILL 终止 npx 孤儿 node 子进程，`transport_proc_windows.go` stub 回退单进程 kill）+ `HTTPTransport`（无状态 POST）+ `Client`（initialize → notifications/initialized → tools/list → tools/call 握手与调用）+ `Manager`（并发 Start 30s per-server timeout，fail-soft，`ServerStatus` + `ToolDetails` TUI 通知链，`InjectTools` 闭包捕获避免循环变量 bug，`WithNotify` channel 回调；`Start` 始终返回 nil，失败状态通过 `Statuses()` 的 `StatusFailed` 暴露）+ `MCPToolAdapter`（实现 `BaseTool` 接口，`mcp__{server}__{tool}` 双下划线命名，对 Engine 完全透明）；TUI MCPBar（状态栏实时展示）+ `/mcp` 模态工具面板（工具列表，`e` 键 `tea.ExecProcess` 打开 `$EDITOR` 编辑 `.mcp.json`；鼠标滚轮 + ↑↓/jk 双支持）；`.mcp.json` 配置文件驱动，main.go 中异步启动不阻塞 TUI 渲染；`defer mcpMgr.Stop()` Session 级生命周期；`mcpPanelOverhead=4` 与 `contentH=m.height-4` 保持一致，确保面板撑满屏幕不遮挡对话区
 - **AutoDev（自举开发闭环）**: `skills/autodev/SKILL.md`（`/autodev` AgentSkill，三阶段：需求澄清→Spec 生成与强制确认关卡→委派 dev sub-agent）+ `.harness9/agents/dev.md`（dev sub-agent 定义：读规范→探索→实现→`go build/test` 迭代循环（≤3次）→gofmt→commit→push→`gh pr create`）；git worktree（`.autodev/<slug>/`，代码隔离）+ Docker Sandbox（执行隔离，需 `SANDBOX_IMAGE=golang:1.25-bookworm`）；零新 Go 代码，完全由 Skill 文件 + Agent 定义文件驱动，复用现有 Skills 系统、Sub-Agent 系统、Sandbox 基础设施
 
@@ -168,15 +168,24 @@ harness9 是一款基于 Go 语言构建的**轻量级、功能完备、生产�
 ```
 harness9/
 ├── cmd/
-│   └── harness9/
-│       ├── main.go                  # 程序入口：TUI（TTY）/ CLI（管道）；--version / --help flag；upgrade 子命令分发
-│       ├── tui.go                   # TUI 核心：tuiModel struct、样式变量、Init、RunTUI
-│       ├── tui_update.go            # Update 逻辑：事件处理、键盘、滚动、Tab 补全、Markdown 渲染、Thinking 块、Shell 执行
-│       ├── tui_view.go              # View 渲染：renderConversation/ToolProgress/StatusBar/Input/Footer
-│       ├── tui_banner.go            # WelcomeBanner：HARNESS9 ASCII Art + bannerContent()
-│       ├── tui_test.go              # TUI Update 逻辑单元测试（含 thinking block 测试、Shell 执行测试、truncateUTF8 测试）
-│       ├── cli.go                   # 交互式 CLI REPL 实现
-│       └── upgrade.go               # 自动升级：GitHub Releases API + SHA256 校验 + 原子替换
+│   ├── harness9/
+│   │   ├── main.go                  # 程序入口：TUI（TTY）/ CLI（管道）；--version / --help flag；upgrade 子命令分发
+│   │   ├── tui.go                   # TUI 核心：tuiModel struct、样式变量、Init、RunTUI
+│   │   ├── tui_update.go            # Update 逻辑：事件处理、键盘、滚动、Tab 补全、Markdown 渲染、Thinking 块、Shell 执行
+│   │   ├── tui_view.go              # View 渲染：renderConversation/ToolProgress/StatusBar/Input/Footer
+│   │   ├── tui_banner.go            # WelcomeBanner：HARNESS9 ASCII Art + bannerContent()
+│   │   ├── tui_test.go              # TUI Update 逻辑单元测试（含 thinking block 测试、Shell 执行测试、truncateUTF8 测试）
+│   │   ├── cli.go                   # 交互式 CLI REPL 实现
+│   │   └── upgrade.go               # 自动升级：GitHub Releases API + SHA256 校验 + 原子替换
+│   ├── swebench/                    # SWE-bench Lite benchmark runner（评估真实 Issue 修复能力）
+│   │   ├── main.go                  # CLI 入口：--dataset / --work-dir / --instance 等 flag
+│   │   ├── dataset.go               # SWE-bench 数据集加载与实例解析（HuggingFace JSON）
+│   │   ├── runner.go                # 运行器：构建隔离引擎 + 执行修复 + 收集轨迹
+│   │   ├── prompt.go                # 实例 prompt 组装（注入 repo 结构 / 问题描述 / patch 提示）
+│   │   └── report.go                # 评分与报告生成（apply_patch 校验 + 汇总输出）
+│   └── starhistory/                 # GitHub Star History 图表生成（写入本地 SVG）
+│       ├── main.go                  # CLI 入口：仓库名 / 输出路径 / 颜色参数
+│       └── render.go                # SVG 渲染：时间序列曲线 + 标注 + 主题
 ├── internal/
 │   ├── engine/                      # Agent 核心引擎 — 标准 ReAct 主循环
 │   │   ├── agent_loop.go            # 共享 runLoop 主循环内核 + 阻塞式 Run
@@ -226,6 +235,10 @@ harness9/
 │   │   ├── mem_session.go           # MemorySession：纯内存实现（测试用）
 │   │   ├── compaction.go            # Compactor 接口 + TokenBudgetCompactor + SlidingWindowCompactor
 │   │   ├── summarization.go         # SummarizationCompactor：LLM 摘要压缩 + Summarizer 接口 + 增量更新；MemoryExtractor 接口 + WithMemoryExtractor
+│   │   ├── progressive_compactor.go # ProgressiveCompactor：按 token 占用比例分级压缩（Warn/Soft/Full/Emergency）+ RecordedCompactor
+│   │   ├── anchor.go                # Anchor 类型 + ParseAnchorsAndSummary + MergeAnchors（五类结构化锚点系统）
+│   │   ├── compaction_offloader.go  # CompactionOffloader：压缩期超大 tool_result 外存到文件系统
+│   │   ├── record_store.go          # CompactionRecord + CompactionTier + FileRecordStore（JSONL 压缩审计持久化）
 │   │   ├── token.go                 # EstimateTokens/EstimateToolTokens（字符数÷4 估算）+ FormatTokenCount
 │   │   ├── sqlite_session_test.go   # SQLiteSession 集成测试
 │   │   ├── mem_session_test.go      # MemorySession 单元测试
@@ -247,6 +260,7 @@ harness9/
 │   │   ├── interface.go             # LLMProvider 接口定义（Generate + GenerateStream）
 │   │   ├── openai.go                # OpenAI 兼容 API 适配器（支持 OpenRouter / Azure）；WithIncludeReasoning + extractReasoningContent
 │   │   ├── anthropic.go             # Anthropic 兼容 API 适配器（Messages API）；WithThinkingBudget（extended thinking）
+│   │   ├── model_limits.go          # 已知模型上下文窗口注册表 + GetModelLimits（剥离前缀，未知回退 256K）
 │   │   ├── tool_call_accumulator.go # OpenAI/Anthropic 共享的流式工具调用累积器
 │   │   ├── anthropic_thinking_test.go # WithThinkingBudget 单元测试（含 clamp 测试）
 │   │   ├── openai_reasoning_test.go # WithIncludeReasoning + extractReasoningContent + auto-detect 测试
@@ -262,13 +276,14 @@ harness9/
 │   │   ├── safe_path.go             # 共享路径沙箱校验（防 Path Traversal 攻击）
 │   │   ├── path_locker.go           # 路径级 RWMutex + 引用计数，并发文件操作保护
 │   │   ├── bash.go                  # bash 工具（Shell 命令执行，YOLO 哲学）
-│   │   ├── read_file.go             # read_file 工具（沙箱保护，offset/limit 分页，4096 字节默认上限）
+│   │   ├── read_file.go             # read_file 工具（沙箱保护，offset/limit 分页，8192 字节默认上限）
 │   │   ├── write_file.go            # write_file 工具（沙箱保护，Auto-Mkdir）
 │   │   ├── edit_file.go             # edit_file 工具（多级模糊匹配文件编辑，沙箱保护）
 │   │   ├── todo_write.go            # todo_write 工具（读写 TodoStore + 状态转换校验 + WithPlanWriter 注入）
 │   │   ├── todo_write_test.go       # todo_write 工具单元测试（含状态校验测试）
 │   │   ├── memory_write.go          # memory_write 工具（add/update[merge]/remove 三动作 + Precis 重建）
 │   │   ├── memory_search.go         # memory_search 工具（FTS5 全文检索 + 命中强化）
+│   │   ├── mcp_adapter.go           # MCPToolAdapter：MCP 工具包装为 BaseTool（mcp__{server}__{tool} 命名 + SanitizeMCPName）
 │   │   ├── web_safety.go            # SSRF 防护（isSafeURL：scheme/userinfo/DNS/9 个 IP 段检查，含 IPv6 ULA/链路本地）
 │   │   ├── web_safety_test.go       # 19 个用例（IP 段 / scheme / DNS fail-closed / IPv6 loopback / ULA / 链路本地）
 │   │   ├── web_content.go           # HTML→Markdown 管线（go-readability + html-to-markdown + tokenizer fallback，UTF-8 安全截断）
@@ -292,6 +307,7 @@ harness9/
 │   │   ├── observer.go              # OTELEngineObserver：Interaction Span + Turn Span
 │   │   ├── provider.go              # TracingProvider：LLM Request Span + Token Metrics
 │   │   ├── hook.go                  # ObservabilityHook：Tool Execution Span + Tool Metrics
+│   │   ├── helpers.go               # truncateAttr / serializeMessages / serializeOutput（Span 属性净化与序列化）
 │   │   └── *_test.go                # 各组件单元测试（noop tracer）
 │   ├── evals/                       # 自动化评估框架 — Test & Eval
 │   │   ├── provider.go              # ScriptedProvider：确定性 LLM mock（按脚本序列返回回复）
@@ -299,12 +315,13 @@ harness9/
 │   │   ├── harness.go               # RunCase / Suite / recordingHook / extractFinalOutput
 │   │   ├── testenv.go               # SetupHermeticEnv：标准 Hermetic 隔离环境（清除 API Key，禁止真实 LLM 调用）
 │   │   ├── report.go                # BuildReport / WriteJSON / WriteMarkdown（评估报告生成）
-│   │   └── dataset/                 # 黄金数据集（go test 可直接运行，16 个用例）
-│   │       ├── tool_calling_test.go # 工具调用准确性（4 用例：bash/read_file/write+read/纯对话）
+│   │   └── dataset/                 # 黄金数据集（go test 可直接运行，22 个用例）
+│   │       ├── tool_calling_test.go # 工具调用准确性（6 用例：bash/read_file/write+read/L4 模糊匹配/并行工具/纯对话）
 │   │       ├── planning_test.go     # Planning 完成率（4 用例：生成计划/不写文件/先规划后执行/只读探索）
 │   │       ├── memory_test.go       # Memory 持久化（2 用例：memory_write/memory_search）
-│   │       ├── context_test.go      # Context Engineering（3 用例：多步工具链/多轮对话/工具错误观察）
-│   │       └── error_handling_test.go # Error Handling（3 用例：工具失败降级/写入失败停止/MaxTurns 保护）
+│   │       ├── context_test.go      # Context Engineering（4 用例：多步工具链/多轮对话/工具错误观察/停滞 nudge）
+│   │       ├── error_handling_test.go # Error Handling（3 用例：工具失败降级/写入失败停止/MaxTurns 保护）
+│   │       └── compaction_test.go   # Context Compaction（3 用例：锚点保留/offload 检索/渐进式分层压缩）
 │   ├── mcp/                         # MCP Client 集成 — 外部工具服务器接入
 │   │   ├── config.go                # ServerConfig + Config 类型 + LoadConfig（读 .mcp.json，file-not-found 静默返回空）
 │   │   ├── transport.go             # Transport 接口 + StdioTransport（subprocess + NDJSON async reader goroutine + pending map + 三路 select）+ HTTPTransport
@@ -321,6 +338,12 @@ harness9/
 │   ├── env/                         # 环境配置
 │   │   ├── env.go                   # 零依赖 .env 文件加载器（系统变量优先）
 │   │   └── env_test.go              # 配置加载单元测试
+│   ├── permission/                  # 工具权限规则系统（JSON 配置驱动）
+│   │   ├── rules.go                 # Rules：有序规则列表 + Evaluate/matchPattern（glob 匹配）+ LoadRules/SaveRules
+│   │   └── hook.go                  # Hook：实现 hooks.ToolHook（NewHook 内存 / NewFileHook 每次调用重载配置文件）
+│   ├── mission/                     # Mission Control 持久化领域（协调长期运行的 Agent 工作，不依赖单个会话）
+│   │   ├── types.go                 # MissionStatus/TaskStatus 枚举 + Mission/Task/TaskAttempt/Artifact/Evidence 类型 + validTaskTransition
+│   │   └── store.go                 # Store：SQLite 事实源（CreateMission/CreateTask/TransitionTask/AddArtifact/AddEvidence，含依赖就绪排队与不可变触发器）
 │   └── logfmt/                      # 跨模块共享的块状日志格式化工具
 │       ├── format.go                # 块状日志格式化（FormatMsg/ToolStart/LoopStart 等）
 │       └── format_test.go           # 格式化函数单元测试
@@ -429,9 +452,11 @@ harness9/
 | **tools** | 工具注册表 + 内置工具（bash / read_file（offset/limit 分页）/ write_file / edit_file / todo_write / memory_write（add/update/remove + Precis 重建）/ memory_search（FTS5 检索 + 命中强化）/ web_search（DuckDuckGo，无 API Key）/ web_fetch（go-readability + html-to-markdown，Markdown 输出））+ 路径沙箱（safe_path.go）+ SSRF 防护（web_safety.go） | ✅ |
 | **env** | 零依赖 `.env` 配置加载器（系统变量优先） | ✅ |
 | **logfmt** | 跨模块共享的块状日志渲染（FormatMsg/ToolStart/LoopStart 等 11 个格式函数） | ✅ |
-| **sandbox** | Docker 容器级 Sandbox：Environment 接口（LocalEnvironment 进程级 / DockerEnvironment 容器级）、Container 五状态机（Pending/Running/Stopping/Terminated/Failed）、Manager（Create/Destroy/DestroyAll/ReapOrphans/ListAll，并发安全）、工具透明路由（bash via docker exec，文件 via bind mount）、安全加固（cap-drop all + security-opt no-new-privileges + pids-limit + tmpfs）、Agent 级隔离（主 Agent + 每个 Sub-Agent 独立容器）、TUI SandboxBar、孤儿容器回收、向后兼容（`SANDBOX_ENABLED=true` 才启用） | ✅ |
+| **sandbox** | Docker 容器级 Sandbox：Environment 接口（LocalEnvironment 进程级 / DockerEnvironment 容器级）、Container 五状态机（Pending/Running/Stopping/Terminated/Failed）、Manager（Create/Destroy/DestroyAll/ReapOrphans/ListAll，并发安全）、工具透明路由（bash via docker exec，文件 via bind mount）、安全加固（cap-drop all + security-opt no-new-privileges + pids-limit + tmpfs）、Agent 级隔离（主 Agent + 每个 Sub-Agent 独立容器）、TUI SandboxBar、孤儿容器回收、向后兼容（默认启用，`SANDBOX_ENABLED=false` 才关闭，行为与引入前完全一致） | ✅ |
 | **observability** | OpenTelemetry 可观测层：`Config`/`Setup`（noop/stdout/otlp 三种 Exporter）、`OTELEngineObserver`（Interaction + Turn Span）、`TracingProvider`（LLM Request Span + Token Metrics）、`ObservabilityHook`（Tool Execution Span + Tool Metrics）；默认 noop 零开销，`OTEL_ENABLED=true` 激活 | ✅ |
-| **evals** | 自动化评估框架：`ScriptedProvider`（确定性 mock）、`Assertion`（Hard/Soft 断言，8 种实现）、`RunCase`/`Suite`（最小化隔离引擎 + `recordingHook`）、`SetupHermeticEnv`（Hermetic CI 隔离）、`BuildReport`/`WriteJSON`/`WriteMarkdown`（评估报告）；`dataset/` 黄金数据集 16 用例（tool_calling/planning/context/error_handling/memory）；`.github/workflows/eval.yml` Quality Gate | ✅ |
+| **evals** | 自动化评估框架：`ScriptedProvider`（确定性 mock）、`Assertion`（Hard/Soft 断言，8 种实现）、`RunCase`/`Suite`（最小化隔离引擎 + `recordingHook`）、`SetupHermeticEnv`（Hermetic CI 隔离）、`BuildReport`/`WriteJSON`/`WriteMarkdown`（评估报告）；`dataset/` 黄金数据集 22 用例（tool_calling/planning/context/error_handling/memory/compaction）；`.github/workflows/eval.yml` Quality Gate | ✅ |
+| **permission** | 工具权限规则系统（JSON 配置驱动）：`Rules`（有序规则列表，glob 模式匹配，无匹配默认 ask）、`LoadRules`/`SaveRules`（配置文件重载，TUI "总是允许"动态生效）、`Hook`（实现 hooks.ToolHook，`NewHook` 内存 / `NewFileHook` 每次调用重载） | ✅ |
+| **mission** | Mission Control 持久化领域：`MissionStatus`/`TaskStatus` 枚举 + `Mission`/`Task`/`TaskAttempt`/`Artifact`/`Evidence` 类型 + `validTaskTransition` 状态机校验；`Store`（SQLite 事实源：CreateMission/CreateTask/TransitionTask/AddArtifact/AddEvidence，依赖就绪自动排队 + evidence/artifact 不可变触发器 + workspace lease 唯一索引） | ✅ |
 | **mcp** | MCP Client 集成：`Config`（`.mcp.json` 加载，file-not-found 静默返回空）、`StdioTransport`（subprocess + NDJSON async reader goroutine + pending map ID 关联 + 三路 select）、`HTTPTransport`（无状态 POST）、`Client`（initialize/notifications-initialized/tools-list/tools-call）、`Manager`（并发 Start 30s per-server timeout fail-soft、`ServerStatus`+`ToolDetails` TUI 通知、`InjectTools` 无循环变量 bug 闭包捕获、`WithNotify` channel 回调）；`MCPToolAdapter` 实现 `BaseTool` 接口、`mcp__{server}__{tool}` 双下划线命名、对 Engine 完全透明；TUI MCPBar + `/mcp` 模态面板（`e` 键 `tea.ExecProcess` 编辑配置） | ✅ |
 | **autodev** | 自举开发闭环：`skills/autodev/SKILL.md`（`/autodev` AgentSkill，三阶段工作流：需求澄清→Spec 强制确认→委派）+ `.harness9/agents/dev.md`（dev sub-agent：读规范→探索→实现→go build/test 循环≤3次→gofmt→commit→push→gh pr create）；git worktree（`.autodev/<slug>/`）+ Docker Sandbox（`SANDBOX_IMAGE=golang:1.25-bookworm`）；零新 Go 代码，复用 Skills/Sub-Agent/Sandbox 基础设施 | ✅ |
 | **provider/providertest** | 测试基础设施（mock provider），不进入生产二进制 | ✅ |
@@ -553,11 +578,12 @@ func (t *XxxTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 | 功能维度 | 对应 dataset 文件 | 核心验证点 |
 |---------|----------------|-----------|
-| Tool Calling | `tool_calling_test.go` | 工具被调用、工具不被调用、多工具顺序调用 |
+| Tool Calling | `tool_calling_test.go` | 工具被调用、工具不被调用、多工具顺序/并行调用 |
 | Planning | `planning_test.go` | todo_write 生成计划、Plan Mode 不写文件、先规划后执行 |
 | Memory | `memory_test.go` | memory_write/memory_search 工具调用 |
 | Context Engineering | `context_test.go` | 多轮工具链、工具结果被观察后调整行为 |
 | Error Handling | `error_handling_test.go` | 工具失败后 self-healing、MaxTurns 受控终止 |
+| Context Compaction | `compaction_test.go` | 压缩后锚点保留、offload 检索、渐进式分层压缩 |
 
 **编写用例的强制要求**
 
@@ -599,7 +625,7 @@ go test ./internal/evals/... ./internal/evals/dataset/... -v
 # 见 .github/workflows/eval.yml —— eval 失败则阻断合并
 ```
 
-当前黄金数据集：16 个用例，覆盖 tool_calling（4）/ planning（4）/ memory（2）/ context（3）/ error_handling（3）。新 feature 只能**增加**用例，不能删除或降低覆盖率。
+当前黄金数据集：22 个用例，覆盖 tool_calling（6）/ planning（4）/ memory（2）/ context（4）/ error_handling（3）/ compaction（3）。新 feature 只能**增加**用例，不能删除或降低覆盖率。
 
 ### 5.9 文档双语规范
 
@@ -651,7 +677,7 @@ Provider 实现者需注意：`convertMessages()` 方法应负责将 `schema.Mes
 
 #### 工具结果的截断
 - 日志输出截断至 512 字节（`maxLogOutputLen`）
-- `read_file` 工具截断至 4096 字节
+- `read_file` 工具截断至 8192 字节
 - 截断时应在返回文本末尾添加明确的截断标记
 
 ### 6.3 引擎约束

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,7 @@ harness9 --version
 - **[文件系统能力](https://zhangshenao.github.io/harness9/zh/docs/file-system)** —— OffloadHook 把超大工具输出转存到磁盘，FilePlanWriter 把计划持久化为 markdown。
 - **[Sub-Agent 子代理委派](https://zhangshenao.github.io/harness9/zh/docs/sub-agent)** —— 把边界清晰的子任务委派给受限工具集的独立子代理。
 - **[Observability](https://zhangshenao.github.io/harness9/zh/docs/eval)** —— OpenTelemetry Span + Metrics 贯穿引擎、LLM 调用与工具执行，开箱支持接入 Langfuse/Grafana/Jaeger。
-- **[Test & Eval](https://zhangshenao.github.io/harness9/zh/docs/eval)** —— 确定性 `ScriptedProvider` + 断言体系 + 16 用例黄金数据集，CI 质量门禁。
+- **[Test & Eval](https://zhangshenao.github.io/harness9/zh/docs/eval)** —— 确定性 `ScriptedProvider` + 断言体系 + 22 用例黄金数据集，CI 质量门禁。
 - **[Sandbox](https://zhangshenao.github.io/harness9/zh/docs/sandbox)** —— 默认在加固过的 Docker 容器内执行所有工具调用，Docker 不可用时自动降级为本地执行。
 - **[AutoDev（`/autodev`）](https://zhangshenao.github.io/harness9/zh/docs/autodev)** —— 自举开发闭环：需求澄清 → Spec 确认 → 委派 dev sub-agent 编码、测试、创建 PR。
 - **[MCP 工具集成](https://zhangshenao.github.io/harness9/zh/docs/mcp)** —— 通过 `.mcp.json` 接入任意 Model Context Protocol Server，工具透明注入注册表。

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -163,14 +163,19 @@ Flags:
 
 	// SandboxBar 通知 channel 必须在 Create 之前创建并注册，
 	// 否则 Create 内部触发的 notify() 因 onUpdate==nil 而丢失，TUI 永远不会收到初始状态。
-	sandboxNotifyCh := make(chan []sandbox.SandboxInfo, 8)
+	// 仅在 Sandbox 启用时才创建并传给 TUI：禁用时保持 nil，
+	// 使 TUI 的 waitSandboxUpdate 不会在无发送方的 channel 上永久阻塞（goroutine 泄漏）。
+	var sandboxNotifyCh <-chan []sandbox.SandboxInfo
 
 	if sandboxCfg.Enabled {
+		// 内部使用可写 channel，仅将只读方向（<-chan）传给 TUI，避免 TUI 误写。
+		sandboxCh := make(chan []sandbox.SandboxInfo, 8)
+		sandboxNotifyCh = sandboxCh
 		sandboxMgr = sandbox.NewManager(sandboxCfg)
 		// WithUpdateNotify 必须在 Create 之前调用，确保初始创建通知能送达 TUI
 		sandboxMgr.WithUpdateNotify(func(infos []sandbox.SandboxInfo) {
 			select {
-			case sandboxNotifyCh <- infos:
+			case sandboxCh <- infos:
 			default: // 丢弃：buffer 满时 TUI 仍持有旧快照，下次更新会覆盖
 			}
 		})
@@ -262,7 +267,9 @@ Flags:
 
 	// ---- MCP 接线 ----
 	// 加载 .mcp.json 配置（文件不存在时静默返回空配置）。
-	mcpNotifyCh := make(chan []mcppkg.ServerStatus, 8)
+	// 与 sandboxNotifyCh 同理：仅在配置了 MCP Server 时才创建通知 channel 并传给 TUI，
+	// 未配置时保持 nil，避免 waitMCPUpdate 在无发送方的 channel 上永久阻塞。
+	var mcpNotifyCh <-chan []mcppkg.ServerStatus
 	mcpCfgPath := filepath.Join(workDir, ".mcp.json")
 	mcpCfg, mcpCfgErr := mcppkg.LoadConfig(mcpCfgPath)
 	if mcpCfgErr != nil {
@@ -270,10 +277,12 @@ Flags:
 	}
 	var mcpMgr *mcppkg.Manager
 	if len(mcpCfg.Servers) > 0 {
+		mcpCh := make(chan []mcppkg.ServerStatus, 8)
+		mcpNotifyCh = mcpCh
 		mcpMgr = mcppkg.NewManager(mcpCfg)
 		mcpMgr.WithNotify(func(statuses []mcppkg.ServerStatus) {
 			select {
-			case mcpNotifyCh <- statuses:
+			case mcpCh <- statuses:
 			default:
 			}
 		})

--- a/docs/core-features-en/context-engineering.md
+++ b/docs/core-features-en/context-engineering.md
@@ -512,7 +512,7 @@ Generate(ctx context.Context, messages []schema.Message, availableTools []schema
 - **OpenAI (non-streaming)**: extracted from `resp.Usage.PromptTokens` / `resp.Usage.CompletionTokens`
 - **OpenAI (streaming)**: sets `StreamOptions.IncludeUsage = true` on the request, extracted from `Usage.PromptTokens` in the final chunk
 - **Anthropic (non-streaming)**: extracted from `resp.Usage.InputTokens` / `resp.Usage.OutputTokens`
-- **Anthropic (streaming)**: extracted from `Message.Usage.InputTokens` in the `message_start` event
+- **Anthropic (streaming)**: `InputTokens` extracted from `Message.Usage.InputTokens` in the `message_start` event; cumulative `OutputTokens` extracted from `Usage.OutputTokens` in the trailing `message_delta` event
 - **Mock Provider**: returns `nil` (test stubs do not simulate the API call)
 
 **Update timing in the engine:**

--- a/docs/core-features-en/eval.md
+++ b/docs/core-features-en/eval.md
@@ -4,7 +4,7 @@ harness9's quality assurance system consists of three mutually independent but c
 
 ```
 Development stage ──→ Test (deterministic testing)      ScriptedProvider + Assertion
-CI stage           ──→ Eval (golden dataset evaluation)  16 cases + Quality Gate
+CI stage           ──→ Eval (golden dataset evaluation)  22 cases + Quality Gate
 Production stage   ──→ Observability (tracing)           OTEL Traces + Metrics → Langfuse
 ```
 
@@ -33,7 +33,7 @@ Traditional software unit testing assumes: given the same input, you always get 
                              │
           ┌───────────────────▼──────────────────┐
           │ Eval                                 │  ← CI/CD: golden dataset Quality Gate
-          │ Quantify Agent capability boundaries │    16 cases, PR-triggered, failure blocks merge
+          │ Quantify Agent capability boundaries │    22 cases, PR-triggered, failure blocks merge
           └───────────────────┬──────────────────┘
                              │
           ┌───────────────────▼──────────────────┐
@@ -192,13 +192,15 @@ func TestMyFeature(t *testing.T) {
 
 ## III. Eval Subsystem: Golden Dataset
 
-### 3.1 Current Golden Dataset (16 cases)
+### 3.1 Current Golden Dataset (22 cases)
 
 | Category | Case | Verification target |
 |------|------|---------|
 | `tool_calling` | `bash_basic` | bash tool is correctly called |
 | `tool_calling` | `read_file` | read_file tool is correctly called |
 | `tool_calling` | `write_then_read` | Multiple tools called in sequence (write → read) |
+| `tool_calling` | `edit_file_fuzzy_indent` | edit_file L4 fuzzy match with mismatched indentation works end-to-end without breaking the loop |
+| `tool_calling` | `parallel_tools` | Multiple tools called in parallel in the same Turn, all recorded (also a regression test for the concurrent race under `-race`) |
 | `tool_calling` | `no_tool_conversation` | Pure conversation does not trigger a tool call |
 | `planning` | `plan_generated` | todo_write writes a plan |
 | `planning` | `no_write_in_plan_mode` | write_file/edit_file are not called during the planning stage |
@@ -207,16 +209,20 @@ func TestMyFeature(t *testing.T) {
 | `context` | `sequential_tool_chain` | Multi-step tool calls depend on the previous step's Observation |
 | `context` | `multi_turn_conversation` | Multi-turn pure-conversation coherence |
 | `context` | `tool_error_observation` | Tool failure Observation drives the LLM to change strategy |
+| `context` | `stall_nudge_preserves_loop` | WithStallNudge injected hint does not break ReAct loop correctness |
 | `error_handling` | `bash_fallback_on_error` | LLM switches to an alternative approach after a tool failure (Self-Healing) |
 | `error_handling` | `write_failure_graceful_stop` | Graceful degradation without retry after a write failure |
 | `error_handling` | `max_turns_protection` | MaxTurns triggers controlled engine termination (no panic) |
 | `memory` | `write_memory` | memory_write tool is called |
 | `memory` | `search_memory` | memory_search tool is called |
+| `compaction` | `anchor_preservation` | After compaction the LLM can still answer questions about the user's intent (anchor preservation) |
+| `compaction` | `offload_retrieval` | After compaction the LLM can retrieve offloaded content via tools |
+| `compaction` | `progressive_tiers` | LLM behavior stays coherent after compressing a long conversation (progressive tiers) |
 
 ### 3.2 Running Eval
 
 ```bash
-# Run the full golden dataset (16 cases, no API Key required)
+# Run the full golden dataset (22 cases, no API Key required)
 go test ./internal/evals/... ./internal/evals/dataset/... -v
 
 # Run only a specific category
@@ -225,6 +231,7 @@ go test ./internal/evals/dataset/... -v -run TestPlanning
 go test ./internal/evals/dataset/... -v -run TestContextEngineering
 go test ./internal/evals/dataset/... -v -run TestErrorHandling
 go test ./internal/evals/dataset/... -v -run TestMemory
+go test ./internal/evals/dataset/... -v -run TestCompaction
 
 # Generate JSON + Markdown reports
 results := suite.Run(ctx)
@@ -240,7 +247,7 @@ Once feature development is complete, a corresponding golden case **must** be ad
 - Every feature must cover at least a **positive case** (the feature works correctly) and a **negative case** (the constraint is correctly enforced)
 - `SetupHermeticEnv` must be called first; `NoErrorAssertion` or `ErrorAssertion` is mandatory
 - Extending the dataset only requires adding a new `_test.go` file — no framework code changes needed
-- The current 16 cases are the baseline; they may only be added to, never removed or have coverage reduced
+- The current 22 cases are the baseline; they may only be added to, never removed or have coverage reduced
 
 ---
 

--- a/docs/core-features-en/file-system.md
+++ b/docs/core-features-en/file-system.md
@@ -115,8 +115,8 @@ To support the LLM retrieving offload files in segments, the `read_file` tool ad
 ```json
 {
   "path": "relative or absolute path",
-  "offset": 4096,   // starting byte (optional, default 0)
-  "limit": 4096     // number of bytes to read (optional, default 4096)
+  "offset": 8192,   // starting byte (optional, default 0)
+  "limit": 8192     // number of bytes to read (optional, default 8192 = read_file's maxReadLen)
 }
 ```
 
@@ -136,8 +136,8 @@ To support the LLM retrieving offload files in segments, the `read_file` tool ad
 When a tool's output exceeds the threshold, the full content is automatically saved to the file system, and only a path reference and preview are shown in context.
 To view the full output, use the read_file tool with offset/limit parameters for paginated reading:
 - offset: starting byte position (default 0)
-- limit: number of bytes to read (default 4096)
-Example: read_file({"path": "/path/to/offload/file.txt", "offset": 4096, "limit": 4096})
+- limit: number of bytes to read (default 8192)
+Example: read_file({"path": "/path/to/offload/file.txt", "offset": 8192, "limit": 8192})
 ```
 
 ---

--- a/docs/core-features-en/tool-calling.md
+++ b/docs/core-features-en/tool-calling.md
@@ -335,7 +335,7 @@ Implementation highlights:
 | Name | `read_file` |
 | Parameters | `path` (string, required) — file path relative to the workspace |
 | Output | File content text |
-| Truncation policy | Truncated with an appended notice when exceeding `maxReadLen = 4096` bytes |
+| Truncation policy | Truncated with an appended notice when exceeding `maxReadLen = 8192` bytes |
 
 **Security measures**:
 - The path is validated through the shared `safePath` (Sandbox Boundary)

--- a/docs/核心功能/context-engineering.md
+++ b/docs/核心功能/context-engineering.md
@@ -532,7 +532,7 @@ Generate(ctx context.Context, messages []schema.Message, availableTools []schema
 - **OpenAI（非流式）**：从 `resp.Usage.PromptTokens` / `resp.Usage.CompletionTokens` 提取
 - **OpenAI（流式）**：请求时设置 `StreamOptions.IncludeUsage = true`，从末尾 chunk 的 `Usage.PromptTokens` 提取
 - **Anthropic（非流式）**：从 `resp.Usage.InputTokens` / `resp.Usage.OutputTokens` 提取
-- **Anthropic（流式）**：从 `message_start` 事件的 `Message.Usage.InputTokens` 提取
+- **Anthropic（流式）**：`message_start` 事件提取 `Message.Usage.InputTokens`；流末尾 `message_delta` 事件提取累计 `Usage.OutputTokens`
 - **Mock Provider**：返回 `nil`（测试桩不模拟 API 调用）
 
 **引擎中的更新时序：**

--- a/docs/核心功能/eval.md
+++ b/docs/核心功能/eval.md
@@ -4,7 +4,7 @@ harness9 的质量保障体系由三个相互独立但协同工作的子系统�
 
 ```
 开发阶段 ──→ Test（确定性测试）      ScriptedProvider + Assertion
-CI 阶段  ──→ Eval（黄金数据集评估）  16 个用例 + Quality Gate
+CI 阶段  ──→ Eval（黄金数据集评估）  22 个用例 + Quality Gate
 生产阶段 ──→ Observability（追踪）  OTEL Traces + Metrics → Langfuse
 ```
 
@@ -33,7 +33,7 @@ CI 阶段  ──→ Eval（黄金数据集评估）  16 个用例 + Quality Gat
                          │
           ┌──────────────▼──────────────┐
           │   Eval（评估）               │  ← CI/CD：黄金数据集 Quality Gate
-          │   量化 Agent 能力边界        │    16 个用例，PR 触发，失败阻断合并
+          │   量化 Agent 能力边界        │    22 个用例，PR 触发，失败阻断合并
           └──────────────┬──────────────┘
                          │
           ┌──────────────▼──────────────┐
@@ -191,13 +191,15 @@ func TestMyFeature(t *testing.T) {
 
 ## 三、Eval 子系统：黄金数据集
 
-### 3.1 当前黄金数据集（16 个用例）
+### 3.1 当前黄金数据集（22 个用例）
 
 | 类别 | 用例 | 验证目标 |
 |------|------|---------|
 | `tool_calling` | `bash_basic` | bash 工具被正确调用 |
 | `tool_calling` | `read_file` | read_file 工具被正确调用 |
 | `tool_calling` | `write_then_read` | 多工具顺序调用（write → read） |
+| `tool_calling` | `edit_file_fuzzy_indent` | 缩进不一致时 edit_file L4 模糊匹配端到端不破坏循环 |
+| `tool_calling` | `parallel_tools` | 同一 Turn 并行调用多工具，结果均被记录（`-race` 下兼为并发竞争回归） |
 | `tool_calling` | `no_tool_conversation` | 纯对话不触发工具调用 |
 | `planning` | `plan_generated` | todo_write 写入计划 |
 | `planning` | `no_write_in_plan_mode` | 规划阶段不调用 write_file/edit_file |
@@ -206,16 +208,20 @@ func TestMyFeature(t *testing.T) {
 | `context` | `sequential_tool_chain` | 多步工具调用依赖上一步 Observation |
 | `context` | `multi_turn_conversation` | 多轮纯对话连贯性 |
 | `context` | `tool_error_observation` | 工具失败 Observation 驱动 LLM 改变策略 |
+| `context` | `stall_nudge_preserves_loop` | WithStallNudge 注入提示不破坏 ReAct 循环正确性 |
 | `error_handling` | `bash_fallback_on_error` | 工具失败后 LLM 切换替代方案（Self-Healing） |
 | `error_handling` | `write_failure_graceful_stop` | 写入失败后优雅降级不重试 |
 | `error_handling` | `max_turns_protection` | MaxTurns 触发引擎受控终止（不 panic） |
 | `memory` | `write_memory` | memory_write 工具被调用 |
 | `memory` | `search_memory` | memory_search 工具被调用 |
+| `compaction` | `anchor_preservation` | 压缩后 LLM 仍能回答关于用户意图的问题（锚点保留） |
+| `compaction` | `offload_retrieval` | 压缩后 LLM 可通过工具检索 offloaded 内容 |
+| `compaction` | `progressive_tiers` | 大量对话压缩后 LLM 行为仍连贯（渐进式分层） |
 
 ### 3.2 运行 Eval
 
 ```bash
-# 运行全量黄金数据集（16 个用例，无需 API Key）
+# 运行全量黄金数据集（22 个用例，无需 API Key）
 go test ./internal/evals/... ./internal/evals/dataset/... -v
 
 # 只运行特定类别
@@ -224,6 +230,7 @@ go test ./internal/evals/dataset/... -v -run TestPlanning
 go test ./internal/evals/dataset/... -v -run TestContextEngineering
 go test ./internal/evals/dataset/... -v -run TestErrorHandling
 go test ./internal/evals/dataset/... -v -run TestMemory
+go test ./internal/evals/dataset/... -v -run TestCompaction
 
 # 生成 JSON + Markdown 报告
 results := suite.Run(ctx)
@@ -239,7 +246,7 @@ Feature 开发完成后，**必须**在 `internal/evals/dataset/` 下新增对�
 - 每个功能至少覆盖**正向用例**（功能正常工作）和**反向用例**（约束被正确执行）
 - `SetupHermeticEnv` 首行调用，`NoErrorAssertion` 或 `ErrorAssertion` 必选
 - 扩展数据集只需新增 `_test.go` 文件，无需修改框架代码
-- 当前 16 个用例是 baseline，只能增加，不能删除或降低覆盖率
+- 当前 22 个用例是 baseline，只能增加，不能删除或降低覆盖率
 
 ---
 

--- a/docs/核心功能/file-system.md
+++ b/docs/核心功能/file-system.md
@@ -115,8 +115,8 @@ type OffloadHook struct {
 ```json
 {
   "path": "相对或绝对路径",
-  "offset": 4096,   // 起始字节（可选，默认 0）
-  "limit": 4096     // 读取字节数（可选，默认 4096）
+  "offset": 8192,   // 起始字节（可选，默认 0）
+  "limit": 8192     // 读取字节数（可选，默认 8192，即 read_file 的 maxReadLen）
 }
 ```
 
@@ -136,8 +136,8 @@ type OffloadHook struct {
 当工具输出超过阈值时，完整内容会自动保存到文件系统，context 中仅显示路径引用和预览。
 如需查看完整输出，使用 read_file 工具并指定 offset/limit 参数分页读取：
 - offset：起始字节位置（默认 0）
-- limit：读取字节数（默认 4096）
-示例：read_file({"path": "/path/to/offload/file.txt", "offset": 4096, "limit": 4096})
+- limit：读取字节数（默认 8192）
+示例：read_file({"path": "/path/to/offload/file.txt", "offset": 8192, "limit": 8192})
 ```
 
 ---

--- a/docs/核心功能/tool-calling.md
+++ b/docs/核心功能/tool-calling.md
@@ -335,7 +335,7 @@ func safePath(workDir, inputPath string) (string, error)
 | 名称 | `read_file` |
 | 参数 | `path` (string, 必需) — 相对工作区的文件路径 |
 | 输出 | 文件内容文本 |
-| 截断策略 | 超过 `maxReadLen = 4096` 字节时截断并附加提示信息 |
+| 截断策略 | 超过 `maxReadLen = 8192` 字节时截断并附加提示信息 |
 
 **安全措施**：
 - 路径通过共享 `safePath` 校验（沙箱边界 / Sandbox Boundary）

--- a/internal/context/builder.go
+++ b/internal/context/builder.go
@@ -125,8 +125,8 @@ func (b *DefaultPromptBuilder) Build() string {
 				"当工具输出超过阈值时，完整内容会自动保存到文件系统，context 中仅显示路径引用和预览。\n"+
 				"如需查看完整输出，使用 read_file 工具并指定 offset/limit 参数分页读取：\n"+
 				"- offset：起始字节位置（默认 0）\n"+
-				"- limit：读取字节数（默认 4096）\n"+
-				"示例：read_file({\"path\": \".harness9/tool_results/{sessionID}/{toolCallID}.txt\", \"offset\": 4096, \"limit\": 4096})",
+				"- limit：读取字节数（默认 8192，即 read_file 工具的 maxReadLen）\n"+
+				"示例：read_file({\"path\": \".harness9/tool_results/{sessionID}/{toolCallID}.txt\", \"offset\": 8192, \"limit\": 8192})",
 		)
 	}
 

--- a/internal/evals/dataset/tool_calling_test.go
+++ b/internal/evals/dataset/tool_calling_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/harness9/internal/schema"
 )
 
-// TestToolCalling 运行工具调用准确性评估（5 个黄金用例）。
+// TestToolCalling 运行工具调用准确性评估（6 个黄金用例）。
 func TestToolCalling(t *testing.T) {
 	evals.SetupHermeticEnv(t)
 
@@ -123,6 +123,29 @@ func TestToolCalling(t *testing.T) {
 				&evals.ToolNotCalledAssertion{ToolName: "write_file"},
 				&evals.OutputContainsAssertion{Expected: "harness9"},
 				&evals.NoErrorAssertion{},
+			},
+		},
+		// 用例6：同一 Turn 内并行调用两个工具。
+		// 引擎会并发执行这两个工具调用（preallocated slice + index write 保证结果顺序），
+		// 该用例在 go test -race 下同时是 recordingHook 并发写竞争的回归测试。
+		{
+			ID:       "tool_calling/parallel_tools",
+			Category: "tool_calling",
+			Prompt:   "同时运行 ls 和 pwd 两个命令，汇报结果。",
+			Provider: evals.NewScriptedProvider(
+				evals.ScriptedTurn{
+					ToolCalls: []schema.ToolCall{
+						evals.MakeToolCall("tc1", "bash", `{"command":"ls"}`),
+						evals.MakeToolCall("tc2", "bash", `{"command":"pwd"}`),
+					},
+				},
+				evals.ScriptedTurn{Text: "已同时执行两个命令。"},
+			),
+			Assertions: []evals.Assertion{
+				// 两个并行工具调用都必须被记录（MinTimes=2 验证并发记录不丢项）
+				&evals.ToolCalledAssertion{ToolName: "bash", MinTimes: 2},
+				&evals.NoErrorAssertion{},
+				&evals.MaxTurnsAssertion{Max: 3},
 			},
 		},
 	}

--- a/internal/evals/harness.go
+++ b/internal/evals/harness.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/harness9/internal/engine"
@@ -129,11 +130,17 @@ type recordingHook struct {
 	// names 是外部传入的切片指针，所有 BeforeExecute 调用均追加到此切片。
 	// 使用指针而非直接持有切片，确保 goroutine 中的 append 反映到外部变量。
 	names *[]string
+	// mu 保护 names 切片：引擎在同一 Turn 内并发执行多个工具调用时，
+	// 各工具 goroutine 会并发进入 BeforeExecute，若无锁保护则发生切片并发写竞争
+	// （go test -race 可复现）。顺序无严格要求，此处仅保证写入原子性。
+	mu sync.Mutex
 }
 
 // BeforeExecute 记录工具调用名称，始终返回 HookActionAllow（不拦截任何工具）。
 func (h *recordingHook) BeforeExecute(ctx context.Context, tc schema.ToolCall) (context.Context, hooks.HookDecision, error) {
+	h.mu.Lock()
 	*h.names = append(*h.names, tc.Name)
+	h.mu.Unlock()
 	return ctx, hooks.Allow(), nil
 }
 

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -56,8 +56,11 @@ func NewManager(config Config) *Manager {
 }
 
 // WithNotify 注册状态变更回调（用于 TUI 实时更新）。调用线程不限。
+// notify 字段由 m.mu 保护，与 Start 各连接 goroutine 中的 sendNotify 读取并发安全。
 func (m *Manager) WithNotify(fn func([]ServerStatus)) {
+	m.mu.Lock()
 	m.notify = fn
+	m.mu.Unlock()
 }
 
 // Start 并发连接所有已配置的 MCP Server，超时时间为每个 server 30 秒。
@@ -208,9 +211,12 @@ func (m *Manager) Statuses() []ServerStatus {
 
 // sendNotify 在持有锁之外调用通知回调，避免死锁。
 func (m *Manager) sendNotify() {
-	if m.notify == nil {
+	m.mu.RLock()
+	fn := m.notify
+	m.mu.RUnlock()
+	if fn == nil {
 		return
 	}
 	statuses := m.Statuses()
-	m.notify(statuses)
+	fn(statuses)
 }

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -181,11 +181,16 @@ func (p *AnthropicProvider) GenerateStream(ctx context.Context, msgs []schema.Me
 			switch event.Type {
 			case "message_start":
 				// message_start 携带本次请求的实际 InputTokens（在响应开始时即可获得）。
+				// OutputTokens 此时仍为 0——输出 token 只在 message_delta 事件（流末尾）才被填充。
 				ms := event.AsMessageStart()
-				actualUsage = &schema.Usage{
-					InputTokens:  int(ms.Message.Usage.InputTokens),
-					OutputTokens: int(ms.Message.Usage.OutputTokens),
-				}
+				actualUsage = applyStreamUsage(actualUsage, ms.Message.Usage.InputTokens, ms.Message.Usage.OutputTokens)
+
+			case "message_delta":
+				// message_delta 在流末尾（所有 content 增量之后）上报累计的 OutputTokens。
+				// 不处理此事件会导致流式场景下 actualUsage.OutputTokens 恒为 0，
+				// 使 TUI 的 token 用量展示与实际不符。
+				md := event.AsMessageDelta()
+				actualUsage = applyStreamUsage(actualUsage, md.Usage.InputTokens, md.Usage.OutputTokens)
 
 			case "content_block_start":
 				cb := event.AsContentBlockStart()
@@ -339,6 +344,28 @@ func (p *AnthropicProvider) convertTools(availableTools []schema.ToolDefinition)
 		anthropicTools = append(anthropicTools, anthropic.ToolUnionParam{OfTool: &tp})
 	}
 	return anthropicTools, nil
+}
+
+// applyStreamUsage 将单个流式事件携带的 token 用量合并进 actualUsage，返回更新后的用量。
+//
+// 覆盖 Anthropic 流式中的两种用法来源：
+//   - message_start：携带 InputTokens（OutputTokens 此时恒为 0）
+//   - message_delta：流末尾上报累计 OutputTokens（InputTokens 字段为 0）
+//
+// 合并规则：仅当某字段 > 0 时才覆盖（message_delta 场景下保留 message_start
+// 已记录的 InputTokens）。actualUsage 为 nil 时新建，供 StreamChunkDone 携带。
+// 独立为纯函数便于单元测试，无需构造 SDK 流式事件对象。
+func applyStreamUsage(actualUsage *schema.Usage, inputTokens, outputTokens int64) *schema.Usage {
+	if actualUsage == nil {
+		actualUsage = &schema.Usage{}
+	}
+	if inputTokens > 0 {
+		actualUsage.InputTokens = int(inputTokens)
+	}
+	if outputTokens > 0 {
+		actualUsage.OutputTokens = int(outputTokens)
+	}
+	return actualUsage
 }
 
 // extractMessage 从 Anthropic SDK 的 ContentBlockUnion 切片中提取 schema.Message。

--- a/internal/provider/anthropic_usage_test.go
+++ b/internal/provider/anthropic_usage_test.go
@@ -1,0 +1,75 @@
+// Package provider — Anthropic 流式 token 用量合并逻辑单元测试。
+package provider
+
+import (
+	"testing"
+
+	"github.com/harness9/internal/schema"
+)
+
+// TestApplyStreamUsage 表驱动测试 applyStreamUsage 的合并规则：
+//   - 仅覆盖 > 0 的字段（message_delta 场景保留 message_start 已记录的 InputTokens）
+//   - actualUsage 为 nil 时自动新建
+//   - 两条事件先后到达时用量正确累积
+func TestApplyStreamUsage(t *testing.T) {
+	cases := []struct {
+		name        string
+		initial     *schema.Usage // 传 nil 表示"尚无用量（首个事件之前）"
+		inputTokens int64
+		outTokens   int64
+		wantIn      int
+		wantOut     int
+	}{
+		{
+			// message_start：仅 InputTokens 有效，OutputTokens 为 0
+			name:        "message_start sets input tokens",
+			initial:     nil,
+			inputTokens: 1500,
+			outTokens:   0,
+			wantIn:      1500,
+			wantOut:     0,
+		},
+		{
+			// message_delta：仅 OutputTokens 有效，保留已记录的 InputTokens
+			name:        "message_delta merges output tokens keeping input",
+			initial:     &schema.Usage{InputTokens: 1500, OutputTokens: 0},
+			inputTokens: 0,
+			outTokens:   320,
+			wantIn:      1500,
+			wantOut:     320,
+		},
+		{
+			// 防御：消息段未携带任何用量时不应破坏既有值
+			name:        "zero values keep existing usage",
+			initial:     &schema.Usage{InputTokens: 100, OutputTokens: 50},
+			inputTokens: 0,
+			outTokens:   0,
+			wantIn:      100,
+			wantOut:     50,
+		},
+		{
+			// 边界：所有字段为 0 且 initial 为 nil → 返回非 nil 空用量（避免 nil 引用）
+			name:        "nil usage with zero values returns empty non-nil usage",
+			initial:     nil,
+			inputTokens: 0,
+			outTokens:   0,
+			wantIn:      0,
+			wantOut:     0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyStreamUsage(tc.initial, tc.inputTokens, tc.outTokens)
+			if got == nil {
+				t.Fatal("applyStreamUsage returned nil")
+			}
+			if got.InputTokens != tc.wantIn {
+				t.Errorf("InputTokens = %d, want %d", got.InputTokens, tc.wantIn)
+			}
+			if got.OutputTokens != tc.wantOut {
+				t.Errorf("OutputTokens = %d, want %d", got.OutputTokens, tc.wantOut)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 变更摘要

harness9 全仓库质量提升（harness-enhancer 全量体检），修复 5 处真实缺陷：

- **evals**：`recordingHook.BeforeExecute` 并发 append 加 `sync.Mutex`，消除 `go test -race` 下的切片写竞争；新增 `tool_calling/parallel_tools` 黄金用例回归
- **provider**：Anthropic 流式补处理 `message_delta` 事件，修复 `OutputTokens` 恒为 0（TUI token 用量展示与实际不符）；提取纯函数 `applyStreamUsage`，新增表驱动单测
- **main**：Sandbox/MCP 未启用时不再创建无发送方的 notify channel，修复 TUI `waitSandboxUpdate`/`waitMCPUpdate` 永久阻塞导致的 goroutine 泄漏
- **mcp**：`Manager.notify` 读写加 RWMutex，消除 `WithNotify` 与 `sendNotify` 的并发竞争
- **context**：read_file 注入指令默认上限 4096 对齐实际 `maxReadLen` 8192，避免误导 LLM 分页策略

同步更新中英文文档（eval / file-system / tool-calling / context-engineering）与 AGENTS.md、README.zh-CN.md。

## 测试计划

- [x] `gofmt -l .` — 无未格式化文件
- [x] `go vet ./...` — 无告警
- [x] `go test ./...`（24 个包）— 全部通过
- [x] `go test -race ./internal/evals/... ./internal/evals/dataset/...` — 通过（含新增 parallel_tools 回归）
