### PR TITLE
fix: 修复全仓审查发现的边角缺陷并补齐契约测试与文档

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ harness9 是一款基于 Go 语言构建的**轻量级、功能完备、生产�
 | 导出类型/函数 | PascalCase | `AgentEngine`、`NewRegistry`、`LLMProvider` |
 | 未导出类型/函数 | camelCase | `mainLoop`、`maxRetries`、`runLoop` |
 | 接口名 | 以 `-er` 后缀为惯例，或不加后缀 | `Provider`、`Registry`、`BaseTool` |
-| 常量 | PascalCase（导出）或 camelCase（未导出），**不使用全大写** | `RoleSystem`、`maxLogOutputLen` |
+| 常量 | PascalCase（导出）或 camelCase（未导出），**不使用全大写** | `RoleSystem`、`maxOutputLen` |
 | 测试文件 | `xxx_test.go`，测试函数以 `Test` 开头 | `agent_loop_test.go` |
 | 配置选项函数 | `With` 前缀 | `WithMaxTurns`、`WithToolTimeout` |
 
@@ -269,7 +269,8 @@ harness9/
 │   ├── schema/                      # 跨组件共享的核心数据类型
 │   │   ├── message.go               # Message、Role、ToolCall、ToolResult、ToolDefinition
 │   │   ├── stream.go                # StreamChunk、StreamChunkType（Provider 层流式类型）
-│   │   └── subagent.go              # SubAgentUpdate / SubAgentUpdateKind（子代理进度类型）
+│   │   ├── subagent.go              # SubAgentUpdate / SubAgentUpdateKind（子代理进度类型）
+│   │   └── message_test.go          # JSON tag 契约测试（snake_case + omitempty，锁定序列化向后兼容）
 │   ├── tools/                       # 工具注册表 + 内置工具 + 路径沙箱 + SSRF 防护
 │   │   ├── base.go                  # BaseTool 接口定义（Name / Definition / Execute）
 │   │   ├── registry.go              # 工具注册中心（Register / GetAvailableTools / Execute）
@@ -308,7 +309,7 @@ harness9/
 │   │   ├── provider.go              # TracingProvider：LLM Request Span + Token Metrics
 │   │   ├── hook.go                  # ObservabilityHook：Tool Execution Span + Tool Metrics
 │   │   ├── helpers.go               # truncateAttr / serializeMessages / serializeOutput（Span 属性净化与序列化）
-│   │   └── *_test.go                # 各组件单元测试（noop tracer）
+│   │   └── *_test.go                # 各组件单元测试（noop tracer；helpers_test.go 为同包白盒测试）
 │   ├── evals/                       # 自动化评估框架 — Test & Eval
 │   │   ├── provider.go              # ScriptedProvider：确定性 LLM mock（按脚本序列返回回复）
 │   │   ├── assertions.go            # Assertion 接口 + Case/Result 类型 + 8 种断言（Hard/Soft）
@@ -676,8 +677,9 @@ Provider 实现者需注意：`convertMessages()` 方法应负责将 `schema.Mes
 - 超时的工具会返回 `IsError: true` 的结果，LLM 可据此重试
 
 #### 工具结果的截断
-- 日志输出截断至 512 字节（`maxLogOutputLen`）
+- 日志输出截断至 512 字节（`logfmt.MaxOutputLen`，UTF-8 安全截断）
 - `read_file` 工具截断至 8192 字节
+- `bash` 工具输出截断至 16000 字节（保留首尾）
 - 截断时应在返回文本末尾添加明确的截断标记
 
 ### 6.3 引擎约束

--- a/cmd/harness9/tui_update.go
+++ b/cmd/harness9/tui_update.go
@@ -1278,15 +1278,6 @@ func summarizeTool(name string, args json.RawMessage) string {
 	}
 }
 
-// dispatch 以指定 prompt 启动一次 agent 推理流（RunStream）。
-//
-// 调用时 running 必须为 false；若已有推理在进行（running == true）则静默返回，
-// 防止多路 goroutine 并发驱动同一个 AgentEngine。
-//
-// autoExecuting 续跑时，dispatch 由 EventDone handler 在 Elm Update 循环内调用，
-// 不存在并发问题（Bubbletea 保证 Update 是单线程的）。
-// 但 running 检查保留作为额外安全网，防止其他代码路径意外调用。
-
 // harvestSubAgentResults 排空后台子代理跟踪器：将每个已完成结果即时显示到对话区（scrollback，
 // 用户立即可见），并写入 pendingSubAgentInject 以便下次 dispatch 注入 LLM 上下文。
 // 从 subAgentNotifyMsg（即时显示）与 dispatch（兜底）两处调用——DrainCompleted 幂等，已注入结果
@@ -1368,6 +1359,14 @@ func (m tuiModel) dispatchMention(raw string) (tuiModel, tea.Cmd) {
 	return m, tea.Batch(readNextSubAgentDirect(m.directCh), m.spinner.Tick)
 }
 
+// dispatch 以指定 prompt 启动一次 agent 推理流（RunStream）。
+//
+// 调用时 running 必须为 false；若已有推理在进行（running == true）则静默返回，
+// 防止多路 goroutine 并发驱动同一个 AgentEngine。
+//
+// autoExecuting 续跑时，dispatch 由 EventDone handler 在 Elm Update 循环内调用，
+// 不存在并发问题（Bubbletea 保证 Update 是单线程的）。
+// 但 running 检查保留作为额外安全网，防止其他代码路径意外调用。
 func (m tuiModel) dispatch(prompt string) (tuiModel, tea.Cmd) {
 	if m.running {
 		return m, nil

--- a/docs/core-features-en/tool-calling.md
+++ b/docs/core-features-en/tool-calling.md
@@ -243,8 +243,8 @@ The tool calling process is output through **Block-Style Structured Logs**. Desi
 ### Key Implementation Details
 
 - **JSON HTML-escape disabled**: Uses `json.NewEncoder.SetEscapeHTML(false)` to avoid `&&` being escaped into `\u0026\u0026`.
-- **Truncation threshold `maxLogOutputLen = 512`**: Any single output in the log exceeding this length is truncated, with the header carrying a `(truncated to N)` hint.
-- **Continuation line indent `logIndent = 8 spaces`**: All continuation lines use the same indentation for visual alignment.
+- **Truncation threshold `MaxOutputLen = 512`**: Any single output in the log exceeding this length is truncated (UTF-8 safe — never cuts through a multi-byte character), with the header carrying a `(truncated to N)` hint.
+- **Continuation line indent `Indent = 8 spaces`**: All continuation lines use the same indentation for visual alignment.
 - **Inline threshold `argInlineThreshold = 80`**: JSON shorter than this length after compaction is displayed inline on a single line.
 
 ### Logging Coverage Points
@@ -407,16 +407,16 @@ L4 — Line-by-Line Indent-Agnostic Matching
 | Attribute | Value |
 |------|-----|
 | Name | `bash` |
-| Parameters | `command` (string, required) — the bash command to execute |
-| Output | The combined content of `stdout` and `stderr` (`CombinedOutput`) |
-| Hard timeout | `bashHardTimeout = 30s`, takes the `min` with the parent context |
-| Truncation threshold | Truncated when exceeding `maxOutputLen = 8000` bytes |
+| Parameters | `command` (string, required) — the bash command; `timeout_secs` (int, optional) — per-call timeout in seconds |
+| Output | The combined content of `stdout` and `stderr` |
+| Default timeout | `defaultBashTimeout = 120s`; per-call relaxation via `timeout_secs` allowed (capped at `maxBashTimeout = 600s`), whichever comes first against the parent context |
+| Truncation threshold | Truncated when exceeding `maxOutputLen = 16000` bytes (head + tail preserved: ~1/3 head + ~2/3 tail, UTF-8 safe) |
 
 **Key design philosophy**:
 - **YOLO philosophy (Trust-the-LLM)**: Does not restrict the kinds of commands that can be executed, handing all judgment and decision-making entirely over to the LLM, with no whitelist/blacklist.
 - **Execution method**: Wrapped via `bash -c <command>`, supporting pipes `|`, logical and/or `&& ||`, environment variables, redirection, and other complex shell syntax.
 - **Errors relayed as-is (Self-Correction Loopback)**: When a command exits with a non-zero exit code, it **still returns `(string, nil)`**, relaying the error content (including `exit status N`) back to the LLM as readable text to trigger a self-healing retry, rather than interrupting the agent loop.
-- **Time Budgeting**: A double safeguard of the engine-layer `ToolTimeout` plus the tool-internal `bashHardTimeout`, preventing blocking commands such as `top` / `tail -f` / web servers from hanging the engine.
+- **Time Budgeting**: A double safeguard of the engine-layer `ToolTimeout` plus the tool-internal `defaultBashTimeout` (120s, relaxable to 600s via `timeout_secs`), preventing blocking commands such as `top` / `tail -f` / web servers from hanging the engine.
 - **Empty command protection**: When `command == ""`, directly returns `Error: command is an empty string` without invoking `exec`.
 
 **Why no sandboxing is applied**: The bash tool inherently provides full shell access; adding `cd /` alone would escape `workDir`, so a "semi-sandbox" would only create a false sense of security. For path-level security, use `read_file` / `write_file` instead.

--- a/docs/核心功能/tool-calling.md
+++ b/docs/核心功能/tool-calling.md
@@ -243,8 +243,8 @@ func (e *AgentEngine) executeToolsConcurrently(ctx context.Context, turn int, to
 ### 关键实现细节
 
 - **JSON HTML-Escape 关闭**：使用 `json.NewEncoder.SetEscapeHTML(false)`，避免 `&&` 被转义成 `\u0026\u0026`。
-- **截断阈值 `maxLogOutputLen = 512`**：日志中单条输出超出会被截断，header 携带 `(truncated to N)` 提示。
-- **续行缩进 `logIndent = 8 空格`**：所有续行使用同一缩进，视觉对齐。
+- **截断阈值 `MaxOutputLen = 512`**：日志中单条输出超出会被截断（UTF-8 安全，不会切断多字节字符），header 携带 `(truncated to N)` 提示。
+- **续行缩进 `Indent = 8 空格`**：所有续行使用同一缩进，视觉对齐。
 - **Inline 阈值 `argInlineThreshold = 80`**：JSON 压缩后小于此长度直接单行展示。
 
 ### 日志覆盖节点
@@ -407,16 +407,16 @@ L4 — 逐行去缩进匹配（Line-by-Line Indent-Agnostic Matching）
 | 属性 | 值 |
 |------|-----|
 | 名称 | `bash` |
-| 参数 | `command` (string, 必需) — 要执行的 bash 命令 |
-| 输出 | `stdout` 与 `stderr` 的合并内容（`CombinedOutput`） |
-| 硬性超时 | `bashHardTimeout = 30s`，与父 context 取 `min` |
-| 截断阈值 | 超过 `maxOutputLen = 8000` 字节时截断 |
+| 参数 | `command` (string, 必需) — 要执行的 bash 命令；`timeout_secs` (int, 可选) — 单次调用的超时秒数 |
+| 输出 | `stdout` 与 `stderr` 的合并内容 |
+| 默认超时 | `defaultBashTimeout = 120s`；单次可通过 `timeout_secs` 放宽（上限 `maxBashTimeout = 600s`），与父 context 取先到者 |
+| 截断阈值 | 超过 `maxOutputLen = 16000` 字节时截断（保留首尾：头部约 1/3 + 尾部约 2/3，UTF-8 安全） |
 
 **关键设计哲学**：
 - **YOLO 哲学（Trust-the-LLM）**：不限制可执行命令的种类，把所有判断与决策权完全交给大模型，不做白/黑名单。
 - **执行方式**：通过 `bash -c <command>` 包裹，支持管道 `|`、逻辑与/或 `&& ||`、环境变量、重定向等复杂 Shell 语法。
 - **错误原样回传（Self-Correction Loopback）**：命令以非零退出码结束时，**仍返回 `(string, nil)`**，把错误内容（含 `exit status N`）作为可读文本回传给 LLM，触发自愈（Self-Healing）重试，而非中断 agent loop。
-- **时间预算（Time Budgeting）**：引擎层 `ToolTimeout` + 工具内 `bashHardTimeout` 双重保险，防止 `top` / `tail -f` / Web 服务器等阻塞型命令卡死引擎。
+- **时间预算（Time Budgeting）**：引擎层 `ToolTimeout` + 工具内 `defaultBashTimeout`（120s，可经 `timeout_secs` 放宽至 600s）双重保险，防止 `top` / `tail -f` / Web 服务器等阻塞型命令卡死引擎。
 - **空命令保护**：`command == ""` 时直接返回 `Error: 命令为空字符串`，不调用 `exec`。
 
 **为什么不做沙箱**：bash 工具本质上提供完整 shell 访问，加 `cd /` 即可逃逸 `workDir`，做"半沙箱"反而给安全制造假象。如需路径安全请使用 `read_file` / `write_file`。

--- a/internal/logfmt/format.go
+++ b/internal/logfmt/format.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/harness9/internal/schema"
 )
@@ -168,7 +169,7 @@ func FormatJSON(raw json.RawMessage) string {
 func FormatOutput(s string) (body string, total int, truncated bool) {
 	total = len(s)
 	if total > MaxOutputLen {
-		s = s[:MaxOutputLen]
+		s = truncateUTF8(s, MaxOutputLen)
 		truncated = true
 	}
 	if s == "" {
@@ -189,6 +190,27 @@ func FormatOutput(s string) (body string, total int, truncated bool) {
 		b.WriteString(line)
 	}
 	return b.String(), total, truncated
+}
+
+// truncateUTF8 按字节截断 s 至 maxBytes 以内，并在截断点回退到最近的合法 UTF-8 rune 边界，
+// 避免把中文等多字节字符从中间切开、在日志中产生无效 UTF-8 乱码。
+// 与 cmd/harness9 的 truncateUTF8 采用相同的回退策略：对被截断的多字节字符回退 ≤3 字节；
+// 若输入本身含连续非法字节（二进制垃圾），会持续剥离直到遇到合法边界或清空。
+func truncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	s = s[:maxBytes]
+	// DecodeLastRuneInString 返回 (RuneError, 1) 表示末尾是不完整序列的残缺字节 → 剥离；
+	// 注意不能用 RuneStart 判断——被截断序列的首字节（如孤立的 \xe8）同样是"起始字节"。
+	for len(s) > 0 {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 // FormatMsg 渲染通用单行日志条目：[prefix] msg。

--- a/internal/logfmt/format_test.go
+++ b/internal/logfmt/format_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/harness9/internal/schema"
 )
@@ -122,6 +123,22 @@ func TestFormatOutput(t *testing.T) {
 		visible := strings.TrimPrefix(body, Indent+"│ ")
 		if len(visible) > MaxOutputLen {
 			t.Errorf("visible content should be ≤ MaxOutputLen, got %d", len(visible))
+		}
+	})
+
+	t.Run("truncation_utf8_safe", func(t *testing.T) {
+		// 中文每字符 3 字节：MaxOutputLen=512 不是 3 的倍数，
+		// 字节截断必然把某个汉字切成两半产生无效 UTF-8。
+		// 回归测试：截断结果必须仍是合法 UTF-8（修复前此用例失败）。
+		long := strings.Repeat("中文输出测试", 200)
+		body, _, truncated := FormatOutput(long)
+		if !truncated {
+			t.Fatal("oversized CJK input should set truncated=true")
+		}
+		visible := strings.TrimSuffix(strings.TrimPrefix(body, Indent+"│ "), "\n")
+		if !utf8.ValidString(visible) {
+			// 直接打印整个 visible（%q），避免 len(visible) < 8 时尾部切片导致测试自身 panic
+			t.Errorf("truncated CJK output should remain valid UTF-8, got invalid bytes: %q", visible)
 		}
 	})
 }

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -1,3 +1,7 @@
+// manager.go — Manager：多 MCP Server 连接生命周期管理。
+// 实现并发连接（30s per-server 超时）、fail-soft 状态记录、
+// ServerStatus/ToolDetails 快照（供 TUI 展示）与工具注入（InjectTools）。
+// 包级注释见 config.go，本文件为普通文件头注释，避免 godoc 拼接多份 Package 注释。
 package mcp
 
 import (

--- a/internal/mcp/transport.go
+++ b/internal/mcp/transport.go
@@ -284,6 +284,7 @@ func (t *HTTPTransport) Send(ctx context.Context, method string, params json.Raw
 
 // Notify 通过 HTTP POST 发送 JSON-RPC 通知（fire-and-forget，忽略响应体）。
 // 使用 5s 超时避免服务器不可达时无限阻塞。
+// 关闭前限量 drain 响应体，使底层 TCP 连接可被 keep-alive 复用。
 func (t *HTTPTransport) Notify(method string, params json.RawMessage) error {
 	req := rpcRequest{JSONRPC: "2.0", Method: method, Params: params}
 	body, err := json.Marshal(req)
@@ -302,6 +303,7 @@ func (t *HTTPTransport) Notify(method string, params json.RawMessage) error {
 		return err
 	}
 	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return nil
 }
 

--- a/internal/memory/anchor.go
+++ b/internal/memory/anchor.go
@@ -99,14 +99,15 @@ func ParseAnchorsAndSummary(text string) ([]Anchor, string) {
 	return result, strings.TrimSpace(summary)
 }
 
-// MergeAnchors 合并新旧锚点：new 中非 "N/A" 的值覆盖 old 的同类型值。
+// MergeAnchors 合并新旧锚点：newAnchors 中非 "N/A" 的值覆盖 oldAnchors 的同类型值。
 // 始终返回按 allAnchorTypes 顺序排列、长度为 5 的锚点切片。
-func MergeAnchors(old, new []Anchor) []Anchor {
+// 参数名避免使用 new（Go 内置函数名），防止 shadow 引发误读。
+func MergeAnchors(oldAnchors, newAnchors []Anchor) []Anchor {
 	m := make(map[AnchorType]string)
-	for _, a := range old {
+	for _, a := range oldAnchors {
 		m[a.Type] = a.Content
 	}
-	for _, a := range new {
+	for _, a := range newAnchors {
 		if a.Content != "N/A" {
 			m[a.Type] = a.Content
 		}

--- a/internal/memory/manager.go
+++ b/internal/memory/manager.go
@@ -7,9 +7,12 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/harness9/internal/logfmt"
 
 	_ "modernc.org/sqlite"
 )
@@ -158,16 +161,21 @@ func (m *Manager) ListSessions(ctx context.Context) ([]SessionInfo, error) {
 // DeleteSession 删除指定会话及其所有消息（通过 ON DELETE CASCADE）。
 // 若设置了 toolResultsDir，还会级联清理对应 session 的 offload 子目录。
 // 若设置了 compactionRecordsDir，还会级联清理对应 session 的压缩记录文件。
+// 级联文件清理为 fail-soft：失败仅记录日志，不影响会话删除结果。
 func (m *Manager) DeleteSession(ctx context.Context, id string) error {
 	_, err := m.db.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("删除会话: %w", err)
 	}
 	if m.toolResultsDir != "" {
-		_ = os.RemoveAll(filepath.Join(m.toolResultsDir, id))
+		if rmErr := os.RemoveAll(filepath.Join(m.toolResultsDir, id)); rmErr != nil {
+			log.Print(logfmt.FormatMsg("memory", fmt.Sprintf("清理会话 offload 目录失败: %v", rmErr)))
+		}
 	}
 	if m.compactionRecordsDir != "" {
-		_ = os.Remove(filepath.Join(m.compactionRecordsDir, id+".jsonl"))
+		if rmErr := os.Remove(filepath.Join(m.compactionRecordsDir, id+".jsonl")); rmErr != nil && !os.IsNotExist(rmErr) {
+			log.Print(logfmt.FormatMsg("memory", fmt.Sprintf("清理会话压缩记录失败: %v", rmErr)))
+		}
 	}
 	return nil
 }

--- a/internal/mission/store.go
+++ b/internal/mission/store.go
@@ -1,3 +1,8 @@
+// store.go — Store：Mission Control 的 SQLite 事实源。
+// 管理 missions/tasks/task_dependencies/task_attempts/artifacts/evidence/
+// workspace_leases 七张表，提供依赖就绪排队、evidence/artifact 不可变触发器与
+// workspace lease 唯一索引等持久化保证。
+// 包级注释见 types.go，本文件为普通文件头注释，避免 godoc 拼接多份 Package 注释。
 package mission
 
 import (

--- a/internal/observability/helpers_test.go
+++ b/internal/observability/helpers_test.go
@@ -1,0 +1,122 @@
+// helpers_test.go — Span 属性净化与序列化辅助函数的白盒单元测试。
+// 与其他 *_test.go（外部包 observability_test）不同，本文件使用同包（package observability）
+// 以访问未导出的 truncateAttr / serializeMessages / serializeOutput。
+package observability
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/harness9/internal/schema"
+)
+
+// TestTruncateAttr 验证 OTEL Span 属性的净化与截断约束。
+func TestTruncateAttr(t *testing.T) {
+	t.Run("short_passthrough", func(t *testing.T) {
+		got := truncateAttr("普通短文本")
+		if got != "普通短文本" {
+			t.Errorf("short input should pass through, got %q", got)
+		}
+	})
+
+	t.Run("invalid_utf8_sanitized", func(t *testing.T) {
+		// \xff 是非法 UTF-8 字节，必须被剔除以满足 OTLP protobuf 序列化要求
+		got := truncateAttr("bad\xffbyte")
+		if !utf8.ValidString(got) {
+			t.Errorf("output must be valid UTF-8, got %q", got)
+		}
+		if got != "badbyte" {
+			t.Errorf("invalid bytes should be dropped (not replaced), got %q", got)
+		}
+	})
+
+	t.Run("oversize_truncated_at_rune_boundary", func(t *testing.T) {
+		// 中文 3 字节/字：超出 maxSpanAttrLen 后必须在 rune 边界截断
+		long := strings.Repeat("汉", maxSpanAttrLen) // 3x 超限
+		got := truncateAttr(long)
+		if !utf8.ValidString(got) {
+			t.Errorf("truncated output must be valid UTF-8, got tail %q", got[len(got)-6:])
+		}
+		if !strings.HasSuffix(got, "…（已截断）") {
+			t.Errorf("truncated output should carry suffix marker, got tail %q", got[len(got)-16:])
+		}
+	})
+
+	t.Run("exact_boundary_not_truncated", func(t *testing.T) {
+		exact := strings.Repeat("a", maxSpanAttrLen)
+		got := truncateAttr(exact)
+		if got != exact {
+			t.Errorf("input exactly at limit should not be truncated, got len %d", len(got))
+		}
+	})
+}
+
+// TestSerializeMessages 验证 langfuse.input 属性的消息序列化视图。
+func TestSerializeMessages(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if got := serializeMessages(nil); got != "[]" {
+			t.Errorf("nil messages should serialize to [], got %q", got)
+		}
+	})
+
+	t.Run("fields_and_toolcalls", func(t *testing.T) {
+		msgs := []schema.Message{
+			{Role: schema.RoleSystem, Content: "sys"},
+			{Role: schema.RoleAssistant, ToolCalls: []schema.ToolCall{
+				{ID: "c1", Name: "bash", Arguments: json.RawMessage(`{"command":"ls"}`)},
+			}},
+			{Role: schema.RoleUser, Content: "obs", ToolCallID: "c1"},
+		}
+		got := serializeMessages(msgs)
+		var views []map[string]any
+		if err := json.Unmarshal([]byte(got), &views); err != nil {
+			t.Fatalf("output must be valid JSON array: %v\n%s", err, got)
+		}
+		if len(views) != 3 {
+			t.Fatalf("expected 3 views, got %d", len(views))
+		}
+		if views[0]["role"] != "system" || views[0]["content"] != "sys" {
+			t.Errorf("view[0] mismatch: %+v", views[0])
+		}
+		if views[2]["tool_call_id"] != "c1" {
+			t.Errorf("tool_call_id should be preserved: %+v", views[2])
+		}
+		calls, ok := views[1]["tool_calls"].([]any)
+		if !ok || len(calls) != 1 {
+			t.Fatalf("tool_calls view missing: %s", got)
+		}
+	})
+}
+
+// TestSerializeOutput 验证 langfuse.output 属性的响应序列化。
+func TestSerializeOutput(t *testing.T) {
+	t.Run("nil_message", func(t *testing.T) {
+		if got := serializeOutput(nil); got != "" {
+			t.Errorf("nil message should serialize to empty string, got %q", got)
+		}
+	})
+
+	t.Run("text_content", func(t *testing.T) {
+		got := serializeOutput(&schema.Message{Content: "final answer"})
+		if got != "final answer" {
+			t.Errorf("plain content mismatch: %q", got)
+		}
+	})
+
+	t.Run("tool_calls_preferred_over_text", func(t *testing.T) {
+		// 同时有文本与工具调用时，工具调用列表优先（对齐 Langfuse 的 observation 展示语义）
+		msg := &schema.Message{
+			Content:   "thinking aloud",
+			ToolCalls: []schema.ToolCall{{ID: "c9", Name: "read_file", Arguments: json.RawMessage(`{"path":"x"}`)}},
+		}
+		got := serializeOutput(msg)
+		if !strings.HasPrefix(got, "[{") {
+			t.Errorf("tool calls should serialize as JSON array, got %q", got)
+		}
+		if !strings.Contains(got, `"read_file"`) {
+			t.Errorf("tool name missing in serialized calls: %q", got)
+		}
+	})
+}

--- a/internal/observability/setup.go
+++ b/internal/observability/setup.go
@@ -1,3 +1,6 @@
+// Package observability — OTEL SDK 初始化。
+// 本文件实现 Setup/Providers：按 Config 组装 Tracer/Meter（noop/stdout/otlp 三种
+// Exporter），并提供 Shutdown 与 ForceFlush 钩子。
 package observability
 
 import (

--- a/internal/sandbox/local_environment.go
+++ b/internal/sandbox/local_environment.go
@@ -20,8 +20,10 @@ func (e *LocalEnvironment) ID() string { return "local" }
 func (e *LocalEnvironment) Close(_ context.Context) error { return nil }
 
 // RunBash 在本地以子进程方式执行 bash 命令。
-func (e *LocalEnvironment) RunBash(_ context.Context, cmd, workDir string) (string, error) {
-	c := exec.Command("bash", "-c", cmd)
+// 使用 exec.CommandContext 绑定 ctx：超时或取消时子进程被自动终止，
+// 满足 Environment 接口"ctx 控制调用生命周期"的契约（与 BashTool.runLocal 一致）。
+func (e *LocalEnvironment) RunBash(ctx context.Context, cmd, workDir string) (string, error) {
+	c := exec.CommandContext(ctx, "bash", "-c", cmd)
 	c.Dir = workDir
 	out, err := c.CombinedOutput()
 	if err != nil {

--- a/internal/sandbox/local_environment_test.go
+++ b/internal/sandbox/local_environment_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLocalEnvironment_ID(t *testing.T) {
@@ -69,5 +70,32 @@ func TestLocalEnvironment_Close(t *testing.T) {
 	env := NewLocalEnvironment()
 	if err := env.Close(context.Background()); err != nil {
 		t.Errorf("LocalEnvironment.Close() 不应返回 error: %v", err)
+	}
+}
+
+// TestLocalEnvironment_RunBash_ContextCancel 验证 Environment 接口契约：
+// ctx 取消后正在运行的命令必须被终止（exec.CommandContext 绑定），
+// RunBash 及时返回而非无限阻塞。修复前此用例失败（exec.Command 不感知 ctx）。
+func TestLocalEnvironment_RunBash_ContextCancel(t *testing.T) {
+	env := NewLocalEnvironment()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	var out string
+	go func() {
+		defer close(done)
+		out, _ = env.RunBash(ctx, "sleep 30 && echo never", t.TempDir())
+	}()
+
+	cancel() // 立即取消：sleep 应被 SIGKILL 终止
+
+	select {
+	case <-done:
+		// RunBash 已返回；失败语义通过 Self-Correction Loopback 以文本承载（err==nil）
+		if out == "" {
+			t.Error("取消后返回的输出不应为空（应包含终止错误信息）")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ctx 取消后 RunBash 应及时返回，命令未被终止（未绑定 ctx）")
 	}
 }

--- a/internal/schema/message_test.go
+++ b/internal/schema/message_test.go
@@ -1,0 +1,136 @@
+// Package schema 核心类型的序列化契约测试。
+//
+// AGENTS.md 6.5 约定：schema.Message 的 JSON tag 使用 snake_case + omitempty 组合，
+// 且该序列化格式会被 SQLiteSession 持久化（tool_calls 列）——一旦 tag 变更，
+// 历史会话中的存量数据将无法反序列化。本测试把契约固化，防止无意中破坏向后兼容。
+package schema
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMessageJSONContract 验证 Message 序列化输出的字段名与 omitempty 行为。
+func TestMessageJSONContract(t *testing.T) {
+	t.Run("full_message_field_names", func(t *testing.T) {
+		m := Message{
+			Role:       RoleAssistant,
+			Content:    "hello",
+			ToolCalls:  []ToolCall{{ID: "call_1", Name: "bash", Arguments: json.RawMessage(`{"command":"ls"}`)}},
+			ToolCallID: "call_1",
+			IsError:    true,
+		}
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		got := string(b)
+		// snake_case 契约：字段名不得出现驼峰形式
+		for _, camel := range []string{"toolCalls", "toolCallId", "toolCallID", "isError"} {
+			if strings.Contains(got, camel) {
+				t.Errorf("serialized field names must be snake_case, found %q in: %s", camel, got)
+			}
+		}
+		for _, want := range []string{`"role"`, `"content"`, `"tool_calls"`, `"tool_call_id"`, `"is_error"`} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing expected field %s in: %s", want, got)
+			}
+		}
+	})
+
+	t.Run("omitempty_drops_empty_fields", func(t *testing.T) {
+		m := Message{Role: RoleUser, Content: "hi"}
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		got := string(b)
+		for _, absent := range []string{"tool_calls", "tool_call_id", "is_error"} {
+			if strings.Contains(got, absent) {
+				t.Errorf("empty field %s should be omitted by omitempty, got: %s", absent, got)
+			}
+		}
+	})
+
+	t.Run("roundtrip_preserves_tool_calls", func(t *testing.T) {
+		// 验证 SQLiteSession 持久化路径依赖的 marshal→unmarshal 往返无损。
+		m := Message{
+			Role:      RoleAssistant,
+			ToolCalls: []ToolCall{{ID: "c1", Name: "read_file", Arguments: json.RawMessage(`{"path":"a.go"}`)}},
+		}
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var back Message
+		if err := json.Unmarshal(b, &back); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if back.Role != RoleAssistant || len(back.ToolCalls) != 1 {
+			t.Fatalf("roundtrip lost data: %+v", back)
+		}
+		if back.ToolCalls[0].ID != "c1" || back.ToolCalls[0].Name != "read_file" {
+			t.Errorf("tool call roundtrip mismatch: %+v", back.ToolCalls[0])
+		}
+		if string(back.ToolCalls[0].Arguments) != `{"path":"a.go"}` {
+			t.Errorf("arguments roundtrip mismatch: %s", back.ToolCalls[0].Arguments)
+		}
+	})
+}
+
+// TestToolCallArgumentsRaw 契约：Arguments 必须保持 json.RawMessage 延迟反序列化语义，
+// 空参数不应在序列化时被丢弃（id/name/arguments 为必填 tag，无 omitempty）。
+func TestToolCallArgumentsRaw(t *testing.T) {
+	tc := ToolCall{ID: "c2", Name: "todo_write"}
+	b, err := json.Marshal(tc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"arguments"`) {
+		t.Errorf("arguments field must always serialize (no omitempty), got: %s", got)
+	}
+
+	var back ToolCall
+	if err := json.Unmarshal([]byte(`{"id":"c3","name":"bash","arguments":{"command":"go version"}}`), &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(back.Arguments) != `{"command":"go version"}` {
+		t.Errorf("arguments must stay raw (unparsed), got: %s", back.Arguments)
+	}
+}
+
+// TestStreamChunkTypeValues 验证流式 chunk 类型枚举值与 Provider 层产出的字符串一致。
+// 这些字符串作为事件路由的 key，变更会导致引擎事件分发静默失败。
+func TestStreamChunkTypeValues(t *testing.T) {
+	cases := map[StreamChunkType]string{
+		StreamChunkTextDelta:     "text_delta",
+		StreamChunkThinkingDelta: "thinking_delta",
+		StreamChunkDone:          "done",
+		StreamChunkError:         "error",
+	}
+	for typ, want := range cases {
+		if string(typ) != want {
+			t.Errorf("StreamChunkType %q = %q, want %q", typ, typ, want)
+		}
+	}
+}
+
+// TestSubAgentUpdateKindValues 验证子代理进度更新枚举值与 TUI 侧 switch 分支一致。
+func TestSubAgentUpdateKindValues(t *testing.T) {
+	cases := map[SubAgentUpdateKind]string{
+		SubAgentStart:      "start",
+		SubAgentDelta:      "delta",
+		SubAgentThinking:   "thinking",
+		SubAgentToolStart:  "tool_start",
+		SubAgentToolResult: "tool_result",
+		SubAgentDone:       "done",
+		SubAgentError:      "error",
+	}
+	for kind, want := range cases {
+		if string(kind) != want {
+			t.Errorf("SubAgentUpdateKind %q = %q, want %q", kind, kind, want)
+		}
+	}
+}

--- a/internal/skills/use_skill_tool.go
+++ b/internal/skills/use_skill_tool.go
@@ -1,3 +1,6 @@
+// Package skills — UseSkillTool：Progressive Disclosure 的执行层工具。
+// 本文件实现 use_skill 工具，LLM 通过调用它按名称加载指定 skill 的全文内容，
+// 避免 System Prompt 在启动时整体注入所有 skill 正文。
 package skills
 
 import (


### PR DESCRIPTION
## 概述

全仓静态审查（112 个非测试源文件逐包精读）后修复的边角缺陷 + 契约测试补齐 + 文档失真修正。

## 变更内容

### Bug 修复
- **logfmt UTF-8 安全截断**：`FormatOutput` 截断点回退到合法 rune 边界（`DecodeLastRuneInString`），避免中文等多字节字符被切产生乱码；此前按字节硬截断与其他 6 处截断点的策略不一致
- **LocalEnvironment.RunBash 绑定 ctx**：`exec.Command` → `exec.CommandContext`，ctx 取消后子进程自动终止，满足 Environment 接口契约（修复前取消后命令无法终止、调用方永久阻塞）
- **HTTPTransport.Notify drain 响应体**：关闭前限量读取 4KB，恢复底层 TCP 连接 keep-alive 复用

### 规范一致性
- `DeleteSession` 级联清理失败记日志（走 logfmt）而非 `_ =` 吞错，保持 fail-soft 语义
- `MergeAnchors` 参数改名 `oldAnchors/newAnchors`，去除内置 `new` 的 shadow
- `dispatch` 孤立注释归位到函数本体；4 个文件补齐头注释（godoc 不再拼接多份 Package 注释）

### 测试补充（13 用例）
- `schema/message_test.go`：JSON tag 契约（snake_case + omitempty + RawMessage 语义 + 枚举值锁定），固化 SQLiteSession 持久化向后兼容
- `observability/helpers_test.go`：truncateAttr / serializeMessages / serializeOutput 白盒测试
- `logfmt`：中文超限截断回归测试（修复前失败）
- `sandbox`：ctx 取消终止回归测试（修复前失败）

### 文档同步
- `tool-calling.md`（中英双版）修正 3 处常量失真（`logfmt.MaxOutputLen`、`defaultBashTimeout=120s`/`maxBashTimeout=600s`/`timeout_secs`、`maxOutputLen=16000` 首尾保留）
- `AGENTS.md` 同步截断常量与 bash 截断条目

## 测试计划

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .`（输出为空）
- [x] `go test ./...`（26 包全过，含 `-race` 复跑）
- [x] `go test ./internal/evals/... ./internal/evals/dataset/... -v`（37 个测试全过，22 个黄金用例零删除）