### PR TITLE
重构: engine 主循环按阶段拆分，消除 agent_loop.go 单文件臃肿

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,13 +187,22 @@ harness9/
 │       ├── main.go                  # CLI 入口：仓库名 / 输出路径 / 颜色参数
 │       └── render.go                # SVG 渲染：时间序列曲线 + 标注 + 主题
 ├── internal/
-│   ├── engine/                      # Agent 核心引擎 — 标准 ReAct 主循环
-│   │   ├── agent_loop.go            # 共享 runLoop 主循环内核 + 阻塞式 Run
-│   │   ├── agent_loop_test.go       # 主循环单元测试
-│   │   ├── compact.go               # Compact 方法：TUI /compact 命令触发的手动强制压缩
+│   ├── engine/                      # Agent 核心引擎 — 标准 ReAct 主循环（按职责拆分为多个文件）
+│   │   ├── agent_loop.go            # 引擎结构 + NewAgentEngine + emitter 定义 + 阻塞式 Run + runLoop 阶段编排器
+│   │   ├── options.go               # With* 函数式配置选项 + 运行期 SetSession/SetPlanMode + PromptBuilder 接口
+│   │   ├── retry.go                 # LLM 生成调用双档重试（默认预算/网络传输预算）+ backoffDelay 封顶 + isTransientNetworkError
+│   │   ├── loop_phases.go           # runLoop 阶段化实现：beginInteraction/beginTurn/prepareTurnInput/generateTurn/trackStall/injectObservations/saveHistory/saveTodos
+│   │   ├── history.go               # 会话历史加载/持久化（loadHistoryWith/saveHistoryWith）+ system prompt 构建 + 压缩适配
+│   │   ├── planmode.go              # Plan Mode 只读工具白名单 + 规划前缀 + 进展工具判定 + appendUserNudge
+│   │   ├── tools_exec.go            # executeTools：同 Turn 多工具并发调度（信号量 + 每工具独立超时）
+│   │   ├── compact.go               # Compact 方法：TUI /compact 命令触发的手动强制压缩（写回失败自动回滚）
 │   │   ├── observer.go              # EngineObserver 接口 + noopObserver（可观测层无侵入接入点）
 │   │   ├── permission.go            # PermissionMode 枚举（Default/AutoApprove/ReadOnly/BypassAll）+ WithPermissionMode
 │   │   ├── stream.go                # 流式入口 RunStream + engine.Event 事件类型 + ToolResultData
+│   │   ├── agent_loop_test.go       # 主循环单元测试（重试/终止保障/Plan Mode/nudge）
+│   │   ├── loop_phases_test.go      # 阶段方法单元测试（退避计算/空响应防护/压缩视图隔离/Observation 注入）
+│   │   ├── compact_test.go          # Compact 单元测试
+│   │   ├── memory_test.go           # Session 集成测试（历史持久化/加载/压缩器）
 │   │   └── stream_test.go           # 流式接口单元测试
 │   ├── hooks/                       # 工具拦截器（Hooks）— 文件系统能力
 │   │   ├── hook.go                  # ToolHook 接口 + HookRegistry（洋葱模型）+ ApprovalFunc context 工具
@@ -440,7 +449,7 @@ harness9/
 |------|------|:----:|
 | **cmd/harness9** | 主入口：TTY 自动检测选择 TUI / CLI；`--help` / `--version` flag；`upgrade` 子命令；初始化 Memory Manager + SummarizationCompactor + Session + OffloadHook + FilePlanWriter + HookRegistry | ✅ |
 | **tui** | 全屏 TUI（Bubbletea）：WelcomeBanner + 对话页双 Phase、Spinner 动词轮换、内置命令 Tab 补全 + Skills 补全、Markdown 渲染、会话管理、状态栏 token 用量实时展示（颜色告警）+ 压缩通知 + Plan Mode 色调 + 审查对话框 + autoExecuting 续跑；ToolResultData 携带引擎侧精确耗时；Thinking 块流式渲染（EventThinkingDelta → 深灰 │ 前缀行，flushPendingThinking 在工具/正文边界自动关闭）；Shell 执行模式（`!` 前缀 → dispatchShellCommand → tea.Cmd 异步 → shellResultMsg → pendingShellOutput 注入 LLM 上下文） | ✅ |
-| **engine** | 标准 ReAct 主循环，阻塞 + 流式双模式，并发工具调度，Session/Compactor 集成，EventTokenUpdate / EventCompaction / EventToolResult（ToolResultData）/ EventThinkingDelta 事件，WithContextWindow 选项，PlanMode 工具过滤 + prompt 注入，TodoStore 跨会话持久化，WithMemoryNudge（每 N 轮向防御性副本注入长期记忆提示，不持久化），WithStallNudge（连续 N 轮无进展工具（edit_file/write_file）调用时注入一次停滞提示打断空转，防御性副本，不持久化） | ✅ |
+| **engine** | 标准 ReAct 主循环（按职责拆分：agent_loop.go 编排器 + loop_phases.go 阶段方法 + options/retry/history/planmode/tools_exec 子模块），阻塞 + 流式双模式，并发工具调度，Session/Compactor 集成，EventTokenUpdate / EventCompaction / EventToolResult（ToolResultData）/ EventThinkingDelta 事件，WithContextWindow 选项，双档 LLM 重试（默认/网络预算），PlanMode 工具过滤 + prompt 注入，TodoStore 跨会话持久化，Compact 写回失败自动回滚，WithMemoryNudge（每 N 轮向防御性副本注入长期记忆提示，不持久化），WithStallNudge（连续 N 轮无进展工具（edit_file/write_file）调用时注入一次停滞提示打断空转，防御性副本，不持久化），provider 空响应防御（转为可重试错误而非 panic） | ✅ |
 | **hooks** | 文件系统能力：ToolHook 接口 + HookRegistry（洋葱模型）；OffloadHook（超大输出 offload 到 `~/.harness9/tool_results/`，fail-open）；FilePlanWriter（todo 计划持久化为 markdown，git 项目写入 workDir/.harness9/plans/） | ✅ |
 | **planning** | PlanMode 枚举（Default/Plan/AutoEdit）、PlanWriter 接口（解耦 TodoWriteTool 与 FilePlanWriter）、TodoStore（线程安全，全量替换）、TodoItem 状态机、todo_write 工具（状态转换校验 + WithPlanWriter 注入） | ✅ |
 | **subagent** | Sub-Agent 子代理委派：SubAgentDefinition（ResolveTools 白名单∩全集-黑名单-task）、Registry（编程式 + `.harness9/agents/*.md` 文件式定义）、Runner（构建隔离子引擎 + RunStream + 桥接审批与进度）、TaskTool（task 工具，前台/后台双模式）、TaskTracker（后台任务单一事实源）；内置 general-purpose 通用子代理（继承父全部可用工具与模型）；防递归 + 权限不扩权 + 上下文隔离 | ✅ |

--- a/docs/core-features-en/agent-loop.md
+++ b/docs/core-features-en/agent-loop.md
@@ -40,9 +40,15 @@ The core of harness9 is a **standard ReAct loop** engine: each Turn executes one
 | `OpenAIProvider` | `internal/provider/openai.go` | OpenAI-compatible API adapter (OpenAI / OpenRouter / Azure) |
 | `AnthropicProvider` | `internal/provider/anthropic.go` | Anthropic-compatible API adapter (Anthropic / OpenRouter) |
 | `Registry` | `internal/tools/registry.go` | Decouples tool discovery from execution |
-| `AgentEngine.Run` | `internal/engine/agent_loop.go` | Blocking ReAct main loop |
+| `AgentEngine.Run` | `internal/engine/agent_loop.go` | Blocking ReAct main loop (orchestrator + emitter definition) |
 | `AgentEngine.RunStream` | `internal/engine/stream.go` | Streaming ReAct main loop, token-by-token output |
 | `engine.Event` | `internal/engine/stream.go` | Client-facing streaming event type from the engine |
+| `runLoop phased implementation` | `internal/engine/loop_phases.go` | Private methods for each loop phase: initialization / turn preamble / preprocessing / generation / stall detection / Observation injection / teardown |
+| `With* options` | `internal/engine/options.go` | Functional options and runtime `SetSession` / `SetPlanMode` |
+| `generateWithRetry` | `internal/engine/retry.go` | Dual-tier LLM retry (default budget / network-transport budget) + network error classification |
+| `History load & persist` | `internal/engine/history.go` | Session history load/save, system prompt building, compaction adapter |
+| `Plan Mode filtering` | `internal/engine/planmode.go` | Read-only tool whitelist, planning prefix, progress-tool & nudge detection |
+| `executeTools` | `internal/engine/tools_exec.go` | Concurrent tool scheduling within a turn (semaphore + per-tool timeout) |
 | `env` | `internal/env/env.go` | Environment variable configuration loading based on .env files |
 
 ## 2. ReAct Design Philosophy
@@ -183,6 +189,23 @@ Turn 2:
 
 ## 4. Agent Loop Cycle Flow
 
+The loop is orchestrated by the `runLoop` orchestrator (`agent_loop.go`), which dispatches to independent private methods defined in `loop_phases.go`, one per phase, all sharing a `loopContext` that aggregates the interaction state:
+
+```
+beginInteraction      Initialization: observer hookup, state snapshot, todo restore,
+                      Plan Mode prefix, history loading
+for {
+    beginTurn          Turn counter + dual termination checks (MaxTurns / ctx cancel)
+    prepareTurnInput   Tool filtering + compaction check + token estimate report + nudge injection
+    generateTurn       LLM call with retry + actual usage report
+    (termination check) Converge and exit when the model issues no tool calls
+    executeTools       Concurrent tool scheduling (tools_exec.go)
+    injectObservations Observation injection
+}
+saveHistory / saveTodos   Teardown: history persists only on the natural-termination path;
+                          todos persist on every exit path
+```
+
 ```
                      ┌─────────────────────┐
                      │   Initialize context  │
@@ -231,7 +254,7 @@ When the engine starts, it constructs the initial conversation context via `load
 // and appends the user input.
 // startLen marks the starting position of new messages (existing history + system prompt are not persisted),
 // used by saveHistoryWith to save only msgs[startLen:].
-func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session) ([]schema.Message, int) {
+func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session, logPrefix string) ([]schema.Message, int) {
     var history []schema.Message
     if sess != nil {
         msgs, err := sess.GetMessages(ctx, 0) // 0 = return all history
@@ -321,14 +344,19 @@ go func(idx int, tc schema.ToolCall) {
 
 ### 4.5 Observation Phase
 
-After tool execution completes, the results are appended to the context in their original order:
+After tool execution completes, `injectObservations` appends the results to the context in their original order. Empty outputs fall back to a placeholder message (some backends reject tool_result with empty content, returning 400, and an empty Observation carries no information for the model to reason about); `IsError` is passed through so the Provider can set `tool_result.is_error` (strengthening the self-healing signal):
 
 ```go
-for i, toolCall := range responseMsg.ToolCalls {
-    contextHistory = append(contextHistory, schema.Message{
+for i, toolCall := range toolCalls {
+    content := results[i].Output
+    if content == "" {
+        content = "[tool completed with no output]" // empty-output fallback, avoids 400s and wasted turns
+    }
+    history = append(history, schema.Message{
         Role:       schema.RoleUser,        // Observation is passed back with the user role
-        Content:    results[i].Output,
+        Content:    content,
         ToolCallID: toolCall.ID,             // Links to the original request
+        IsError:    results[i].IsError,      // Passes the error signal through for Provider is_error marking
     })
 }
 ```

--- a/docs/core-features-en/benchmark.md
+++ b/docs/core-features-en/benchmark.md
@@ -548,7 +548,7 @@ The root cause was in the runner: after clone+checkout, there was **no dependenc
 | **Wire up dependency bootstrap**: the runner now sets `BootstrapCmd` by default for every instance (ensurepip + `pip install -e .` + pytest), default image changed to `python:3.11` (full buildpack image, with pip and a compiler) | `runner.go` | R1/R4 |
 | **Verification gate**: when the Agent naturally concludes without ever having run a test, inject one continuation prompt demanding real verification (reusing the in-memory session to continue history, at most once, backstopped by timeout/turn cap) | `runner.go` | R2 |
 | **HintsText injection** + dataset parsing of evaluation fields (`FAIL_TO_PASS`/`test_patch` for analysis only, never exposed to or applied during runtime) | `prompt.go` `dataset.go` | R3/R4 |
-| **Stagnation nudge `WithStallNudge`**: injects one nudge to break the idle loop when N consecutive turns show no edit/write progress tool calls (defensive copy, not persisted) | `engine/agent_loop.go` | R6 |
+| **Stagnation nudge `WithStallNudge`**: injects one nudge to break the idle loop when N consecutive turns show no edit/write progress tool calls (defensive copy, not persisted) | `engine/options.go` + `engine/planmode.go` | R6 |
 | **Prompt rebalancing**: removed the "default fallback to static analysis" escape hatch; added minimal/error-site-local fix bias, searching tests by symbol name, DeprecationWarning convention hints | `prompt.go` | R5/R7 |
 | **edit_file banner tightened**: "no need to confirm again" → explicit "bytes written ≠ behavior correct, tests still required" | `tools/edit_file.go` | R8 |
 

--- a/docs/core-features-en/human-in-the-loop.md
+++ b/docs/core-features-en/human-in-the-loop.md
@@ -20,7 +20,8 @@ internal/permission/
 
 internal/engine/
 ├── stream.go        # EventApprovalRequired + ApprovalRequest payload
-├── agent_loop.go    # emitter.approval field + executeTools injects ApprovalFunc
+├── agent_loop.go    # emitter.approval field (emitter definition)
+├── tools_exec.go    # executeTools injects ApprovalFunc into the tool execution context
 └── permission.go    # PermissionMode enum
 
 internal/tools/

--- a/docs/core-features-en/planning.md
+++ b/docs/core-features-en/planning.md
@@ -17,8 +17,9 @@ internal/tools/
 └── todo_write.go # todo_write tool: reads/writes TodoStore + batch anti-cheat validation
 
 internal/engine/
-└── agent_loop.go # filterReadOnlyTools (tool-layer permission filtering) + Plan Mode prompt injection
-                  # TodoStore load/save within runLoop (cross-session persistence)
+├── planmode.go   # filterReadOnlyTools (tool-layer permission filtering) + Plan Mode prompt prefix
+├── loop_phases.go # beginInteraction / saveTodos: TodoStore load/save (cross-session persistence)
+└── agent_loop.go # runLoop orchestrator
 
 cmd/harness9/
 ├── tui_update.go # execPrompt / execContinuePrompt constants
@@ -257,7 +258,7 @@ A threshold of 1 retains protection against the original bug pattern (mass batch
 In Plan Mode, `write_file` and `edit_file` are **completely removed** from the tool list, rather than being restricted by declaring "don't create files" in the prompt.
 
 ```go
-// agent_loop.go
+// planmode.go
 var planModeWhitelist = map[string]bool{
     "read_file":  true,
     "bash":       true,
@@ -266,7 +267,7 @@ var planModeWhitelist = map[string]bool{
 }
 
 func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition {
-    var result []schema.ToolDefinition
+    result := make([]schema.ToolDefinition, 0, len(tools))
     for _, t := range tools {
         if planModeWhitelist[t.Name] {
             result = append(result, t)
@@ -275,8 +276,9 @@ func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition 
     return result
 }
 
-// within runLoop
-if planMode == planning.PlanModePlan {
+// loop_phases.go — inside prepareTurnInput (before each LLM call)
+availableTools := e.registry.GetAvailableTools()
+if lc.planMode == planning.PlanModePlan {
     availableTools = filterReadOnlyTools(availableTools)
 }
 ```
@@ -294,16 +296,15 @@ A prompt is a soft constraint. The LLM may forget restrictions stated in the pro
 Tool-layer filtering cannot express behavioral constraints like "bash may only be used for read-only commands", so `runLoop` prepends a prefix to the user prompt in Plan Mode:
 
 ```go
-// agent_loop.go — runLoop
-if planMode == planning.PlanModePlan {
-    userPrompt = "Analyze the following request, output a directly executable implementation plan using todo_write, " +
-        "then give a brief plain-text summary of the plan and stop.\n" +
-        "Todo item requirements: each item must correspond to a concrete implementation action (e.g.: create a certain file, implement a certain function, run a certain command), \n" +
-        "not a high-level planning description (do not write items like \"clarify requirements\" or \"design the approach\" that cannot be directly executed).\n" +
-        "You may use read_file or bash (read-only commands: ls, cat, find, grep) to understand the current codebase.\n" +
-        "Do not create files, run build/install, or make any actual modifications.\n\n" +
-        userPrompt
-}
+// planmode.go — applyPlanModePrefix (called by beginInteraction in loop_phases.go)
+const planModePromptPrefix = "Analyze the following request, output a directly executable implementation plan using todo_write, " +
+    "then give a brief plain-text summary of the plan and stop.\n" +
+    "Todo item requirements: each item must correspond to a concrete implementation action (e.g.: create a certain file, implement a certain function, run a certain command), \n" +
+    "not a high-level planning description (do not write items like \"clarify requirements\" or \"design the approach\" that cannot be directly executed).\n" +
+    "You may use read_file or bash (read-only commands: ls, cat, find, grep) to understand the current codebase.\n" +
+    "Do not create files, run build/install, or make any actual modifications.\n\n"
+
+// In Plan Mode: userPrompt = planModePromptPrefix + userPrompt
 ```
 
 Injection principle: **state behavior, not permission**. A prompt declaration like "you now have permission X" is redundant — permission is decided at the tool layer. The prompt only guides the LLM on "what to do," not "what it is able to do."
@@ -487,22 +488,25 @@ The contents of `TodoStore` are persisted to SQLite alongside the Session, so un
 `runLoop` restores it on startup and saves it at the end (`defer` guarantees it runs even in the event of a panic):
 
 ```go
-// agent_loop.go — runLoop
+// loop_phases.go — beginInteraction (startup restore) and saveTodos (deferred save)
 // Restore TodoStore from the Session at startup
-if sess != nil && todoStore != nil {
-    if todos, err := sess.GetTodos(ctx); err == nil {
-        todoStore.Write(todos)
+if lc.sess != nil && lc.todoStore != nil {
+    if todos, err := lc.sess.GetTodos(ctx); err != nil {
+        log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("failed to load todos: %v", err)))
+    } else {
+        lc.todoStore.Write(todos)
     }
 }
 
-// Save at the end (defer executes on all paths)
-defer func() {
-    if sess != nil && todoStore != nil {
-        if err := sess.SaveTodos(ctx, todoStore.Read()); err != nil {
-            log.Print(...)
-        }
+// Save at the end (runLoop defers lc.saveTodos(ctx); executes on all paths)
+func (lc *loopContext) saveTodos(ctx context.Context) {
+    if lc.sess == nil || lc.todoStore == nil {
+        return
     }
-}()
+    if err := lc.sess.SaveTodos(ctx, lc.todoStore.Read()); err != nil {
+        log.Print(logfmt.FormatMsg(lc.logPrefix, fmt.Sprintf("failed to save todos: %v", err)))
+    }
+}
 ```
 
 **State continuity across runLoop invocations**: in `autoExecuting` mode, every resumption triggers a new `runLoop`. Each `runLoop` invocation restores `TodoStore` from the DB at startup, ensuring the initial state of a resumed run matches the state at the end of the previous run — this is the prerequisite for `todo_write`'s anti-cheat validation to work correctly: `pending` tasks are saved to the DB at the end of the previous run and loaded back into memory on the next run, so the validation logic can accurately recognize a task's historical state.

--- a/docs/core-features-en/progressive-compactor.md
+++ b/docs/core-features-en/progressive-compactor.md
@@ -325,7 +325,8 @@ Each Turn: estimate tokens -> `applyCompactionWith` -> emit `EventCompaction` if
 | `internal/memory/compaction_offloader.go` | CompactionOffloader + OffloadEntry |
 | `internal/memory/record_store.go` | CompactionRecord + CompactionTier + RecordStore + FileRecordStore |
 | `internal/memory/compaction.go` | RecordedCompactor interface + repairOrphanedToolPairs |
-| `internal/engine/agent_loop.go` | applyCompactionWith type assertion + runLoop integration |
+| `internal/engine/history.go` | applyCompactionWith type assertion (compaction adapter) |
+| `internal/engine/loop_phases.go` | runLoop compaction integration inside prepareTurnInput |
 | `internal/engine/stream.go` | EventCompaction carrying CompactionRecord |
 | `internal/engine/compact.go` | Manual /compact adapts to RecordedCompactor |
 | `internal/memory/manager.go` | WithCompactionRecordsDir + cascade GC |

--- a/docs/core-features-en/tool-calling.md
+++ b/docs/core-features-en/tool-calling.md
@@ -509,6 +509,7 @@ Error information is valuable context for the LLM. When a tool execution fails, 
 | `internal/provider/anthropic.go` | Anthropic-compatible API adapter |
 | `internal/provider/tool_call_accumulator.go` | Streaming tool call argument accumulator shared by OpenAI/Anthropic |
 | `internal/provider/providertest/mock.go` | Test Mock Provider (`_test` compilation unit, does not ship in the production binary) |
-| `internal/engine/agent_loop.go` | Agent main loop, orchestrates the full Tool Calling flow + block-style log formatting |
+| `internal/engine/agent_loop.go` | Agent main loop orchestrator (Run + runLoop + emitter definition) + block-style log formatting |
+| `internal/engine/tools_exec.go` | executeTools: concurrent tool scheduling within a turn (semaphore + per-tool timeout) |
 | `internal/engine/stream.go` | Tool Calling orchestration for streaming mode |
 | `internal/engine/agent_loop_test.go` | Main loop unit tests |

--- a/docs/核心功能/agent-loop.md
+++ b/docs/核心功能/agent-loop.md
@@ -39,9 +39,15 @@ harness9 的核心是一个**标准 ReAct 循环**引擎，每个 Turn 执行一
 | `OpenAIProvider` | `internal/provider/openai.go` | OpenAI 兼容 API 适配器（OpenAI / OpenRouter / Azure） |
 | `AnthropicProvider` | `internal/provider/anthropic.go` | Anthropic 兼容 API 适配器（Anthropic / OpenRouter） |
 | `Registry` | `internal/tools/registry.go` | 解耦工具发现与执行 |
-| `AgentEngine.Run` | `internal/engine/agent_loop.go` | 阻塞式 ReAct 主循环 |
+| `AgentEngine.Run` | `internal/engine/agent_loop.go` | 阻塞式 ReAct 主循环（编排器 + emitter 定义） |
 | `AgentEngine.RunStream` | `internal/engine/stream.go` | 流式 ReAct 主循环，逐 token 输出 |
 | `engine.Event` | `internal/engine/stream.go` | 引擎面向客户端的流式事件类型 |
+| `runLoop 阶段化实现` | `internal/engine/loop_phases.go` | 主循环各阶段私有方法：初始化 / Turn 前置 / 预处理 / 生成 / 停滞检测 / Observation 注入 / 收尾 |
+| `With* 配置选项` | `internal/engine/options.go` | 函数式选项与运行期 `SetSession` / `SetPlanMode` |
+| `generateWithRetry` | `internal/engine/retry.go` | LLM 调用双档重试（默认预算 / 网络传输预算）+ 网络错误分类 |
+| `历史加载与持久化` | `internal/engine/history.go` | Session 历史加载 / 保存、system prompt 构建、压缩适配 |
+| `Plan Mode 过滤` | `internal/engine/planmode.go` | 只读工具白名单、规划前缀、进展工具与 nudge 判定 |
+| `executeTools` | `internal/engine/tools_exec.go` | 同 Turn 多工具并发调度（信号量 + 每工具独立超时） |
 | `env` | `internal/env/env.go` | 基于 .env 文件的环境变量配置加载 |
 
 ## 2. ReAct 设计理念
@@ -182,6 +188,21 @@ Turn 2:
 
 ## 4. Agent Loop 循环流程
 
+循环由 `runLoop` 编排器（`agent_loop.go`）按阶段调度，各阶段实现为 `loop_phases.go` 中的独立私有方法，共享一个聚合交互状态的 `loopContext`：
+
+```
+beginInteraction      初始化：observer 接入、状态快照、Todo 恢复、Plan 前缀、历史加载
+for {
+    beginTurn          Turn 计数 + 双重终止判定（MaxTurns / ctx 取消）
+    prepareTurnInput   工具过滤 + 压缩检查 + token 估算上报 + nudge 注入
+    generateTurn       带重试 LLM 调用 + 实际用量上报
+    （自然终止判定）     模型无工具调用则收敛退出
+    executeTools       并发工具调度（tools_exec.go）
+    injectObservations Observation 注入
+}
+saveHistory / saveTodos   收尾：历史仅自然终止路径持久化；todos 所有退出路径持久化
+```
+
 ```
                      ┌─────────────────────┐
                      │   初始化对话上下文     │
@@ -229,7 +250,7 @@ Turn 2:
 // loadHistoryWith 从 Session 恢复历史消息，注入 system prompt，追加用户输入。
 // startLen 标记新消息起始位置（已有历史 + system 不持久化），
 // 用于 saveHistoryWith 时仅保存 msgs[startLen:]。
-func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session) ([]schema.Message, int) {
+func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session, logPrefix string) ([]schema.Message, int) {
     var history []schema.Message
     if sess != nil {
         msgs, err := sess.GetMessages(ctx, 0) // 0 = 返回全部历史
@@ -318,14 +339,19 @@ go func(idx int, tc schema.ToolCall) {
 
 ### 4.5 Observation 阶段
 
-工具执行完毕后，结果按原始顺序追加到上下文：
+工具执行完毕后，`injectObservations` 将结果按原始顺序追加到上下文。空输出兜底为占位文案（部分 backend 拒绝空 content 的 tool_result，返回 400 且无信息可供模型推理），`IsError` 透传给 Provider 设置 `tool_result.is_error`（强化自愈信号）：
 
 ```go
-for i, toolCall := range responseMsg.ToolCalls {
-    contextHistory = append(contextHistory, schema.Message{
+for i, toolCall := range toolCalls {
+    content := results[i].Output
+    if content == "" {
+        content = "[工具执行完成，无输出]"   // 空输出兜底，避免 400 与无效轮次
+    }
+    history = append(history, schema.Message{
         Role:       schema.RoleUser,        // Observation 以 user 角色回传
-        Content:    results[i].Output,
+        Content:    content,
         ToolCallID: toolCall.ID,             // 关联原始请求
+        IsError:    results[i].IsError,      // 透传错误信号，供 Provider 标记 is_error
     })
 }
 ```

--- a/docs/核心功能/benchmark.md
+++ b/docs/核心功能/benchmark.md
@@ -548,7 +548,7 @@ go run ./cmd/swebench --help
 | **接通依赖自举**：runner 为每实例默认设 `BootstrapCmd`（ensurepip + `pip install -e .` + pytest），默认镜像改 `python:3.11`（buildpack 全镜像，带 pip 与编译器）| `runner.go` | R1/R4 |
 | **验证关卡**：Agent 自然结束却全程未跑过测试时，注入一次续跑提示要求真实验证（复用内存会话延续历史，至多一次，超时/turn 兜底）| `runner.go` | R2 |
 | **HintsText 注入** + dataset 解析评测字段（`FAIL_TO_PASS`/`test_patch` 仅供分析，绝不在运行时暴露/应用）| `prompt.go` `dataset.go` | R3/R4 |
-| **停滞提示 `WithStallNudge`**：连续 N 轮无 edit/write 进展工具调用时注入一次提示打断空转（防御性副本，不持久化）| `engine/agent_loop.go` | R6 |
+| **停滞提示 `WithStallNudge`**：连续 N 轮无 edit/write 进展工具调用时注入一次提示打断空转（防御性副本，不持久化）| `engine/options.go` + `engine/planmode.go` | R6 |
 | **prompt 重平衡**：删「默认退化静态分析」逃生门；加最小化/错误点局部修复偏置、按符号名查测试、DeprecationWarning 约定提示 | `prompt.go` | R5/R7 |
 | **edit_file banner 收敛**：「无需再确认」→ 明确「字节写入≠行为正确，仍需跑测试」| `tools/edit_file.go` | R8 |
 

--- a/docs/核心功能/human-in-the-loop.md
+++ b/docs/核心功能/human-in-the-loop.md
@@ -20,7 +20,8 @@ internal/permission/
 
 internal/engine/
 ├── stream.go        # EventApprovalRequired + ApprovalRequest 载荷
-├── agent_loop.go    # emitter.approval 字段 + executeTools 注入 ApprovalFunc
+├── agent_loop.go    # emitter.approval 字段（emitter 定义）
+├── tools_exec.go    # executeTools 将 ApprovalFunc 注入工具执行 context
 └── permission.go    # PermissionMode 枚举
 
 internal/tools/

--- a/docs/核心功能/planning.md
+++ b/docs/核心功能/planning.md
@@ -17,8 +17,9 @@ internal/tools/
 └── todo_write.go # todo_write 工具：读写 TodoStore + 批量防作弊校验
 
 internal/engine/
-└── agent_loop.go # filterReadOnlyTools（工具层权限过滤）+ Plan Mode prompt 注入
-                  # runLoop 中 TodoStore 的加载 / 保存（跨会话持久化）
+├── planmode.go   # filterReadOnlyTools（工具层权限过滤）+ Plan Mode prompt 前缀
+├── loop_phases.go # beginInteraction / saveTodos：TodoStore 的加载 / 保存（跨会话持久化）
+└── agent_loop.go # runLoop 编排器
 
 cmd/harness9/
 ├── tui_update.go # execPrompt / execContinuePrompt 常量
@@ -257,7 +258,7 @@ if directCompletions > 1 {
 Plan Mode 下，`write_file` 和 `edit_file` 从工具列表中**完全移除**，而不是通过 prompt 声明"不要创建文件"。
 
 ```go
-// agent_loop.go
+// planmode.go
 var planModeWhitelist = map[string]bool{
     "read_file":  true,
     "bash":       true,
@@ -266,7 +267,7 @@ var planModeWhitelist = map[string]bool{
 }
 
 func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition {
-    var result []schema.ToolDefinition
+    result := make([]schema.ToolDefinition, 0, len(tools))
     for _, t := range tools {
         if planModeWhitelist[t.Name] {
             result = append(result, t)
@@ -275,8 +276,9 @@ func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition 
     return result
 }
 
-// runLoop 中
-if planMode == planning.PlanModePlan {
+// loop_phases.go — prepareTurnInput 中（每轮 LLM 调用前）
+availableTools := e.registry.GetAvailableTools()
+if lc.planMode == planning.PlanModePlan {
     availableTools = filterReadOnlyTools(availableTools)
 }
 ```
@@ -294,15 +296,14 @@ Prompt 是软约束。LLM 会忘记 prompt 中的限制（尤其在上下文压�
 工具层的过滤无法表达"bash 只能用于只读命令"这类行为约束，因此 `runLoop` 在 Plan Mode 下对用户 prompt 追加前缀：
 
 ```go
-// agent_loop.go — runLoop
-if planMode == planning.PlanModePlan {
-    userPrompt = "分析以下请求，用 todo_write 输出一份可直接执行的实现计划，然后用纯文字简述计划后停止。\n" +
-        "todo 项要求：每条对应一个具体的实现动作（例如：创建某文件、实现某函数、运行某命令），\n" +
-        "而非高层规划描述（禁止写\"需求澄清\"、\"方案设计\"之类无法直接执行的条目）。\n" +
-        "如需了解当前代码库，可使用 read_file 或 bash（只读命令：ls、cat、find、grep）。\n" +
-        "不要创建文件、执行 build/install 或做任何实际修改。\n\n" +
-        userPrompt
-}
+// planmode.go — applyPlanModePrefix（由 loop_phases.go 的 beginInteraction 调用）
+const planModePromptPrefix = "分析以下请求，用 todo_write 输出一份可直接执行的实现计划，然后用纯文字简述计划后停止。\n" +
+    "todo 项要求：每条对应一个具体的实现动作（例如：创建某文件、实现某函数、运行某命令），\n" +
+    "而非高层规划描述（禁止写\"需求澄清\"、\"方案设计\"之类无法直接执行的条目）。\n" +
+    "如需了解当前代码库，可使用 read_file 或 bash（只读命令：ls、cat、find、grep）。\n" +
+    "不要创建文件、执行 build/install 或做任何实际修改。\n\n"
+
+// Plan Mode 下：userPrompt = planModePromptPrefix + userPrompt
 ```
 
 注入原则：**只说行为，不说权限**。"你现在有权限 X"这样的 prompt 声明是冗余的——权限由工具层决定。Prompt 只引导 LLM"该做什么"，不描述"能做什么"。
@@ -486,22 +487,25 @@ tasksPart = dimStyle.Render("  │  ") + accent.Render(fmt.Sprintf("%d/%d tasks"
 `runLoop` 在启动时恢复、在结束时保存（`defer` 保证即使 panic 也会执行）：
 
 ```go
-// agent_loop.go — runLoop
+// loop_phases.go — beginInteraction（启动恢复）与 saveTodos（defer 保存）
 // 启动时从 Session 恢复 TodoStore
-if sess != nil && todoStore != nil {
-    if todos, err := sess.GetTodos(ctx); err == nil {
-        todoStore.Write(todos)
+if lc.sess != nil && lc.todoStore != nil {
+    if todos, err := lc.sess.GetTodos(ctx); err != nil {
+        log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("加载 todos 失败: %v", err)))
+    } else {
+        lc.todoStore.Write(todos)
     }
 }
 
-// 结束时保存（defer 在所有路径上执行）
-defer func() {
-    if sess != nil && todoStore != nil {
-        if err := sess.SaveTodos(ctx, todoStore.Read()); err != nil {
-            log.Print(...)
-        }
+// 结束时保存（runLoop 中 defer lc.saveTodos(ctx)，在所有路径上执行）
+func (lc *loopContext) saveTodos(ctx context.Context) {
+    if lc.sess == nil || lc.todoStore == nil {
+        return
     }
-}()
+    if err := lc.sess.SaveTodos(ctx, lc.todoStore.Read()); err != nil {
+        log.Print(logfmt.FormatMsg(lc.logPrefix, fmt.Sprintf("保存 todos 失败: %v", err)))
+    }
+}
 ```
 
 **跨 runLoop 调用的状态连续性**：`autoExecuting` 模式下，每次续跑都会触发一次新的 `runLoop`。每次 `runLoop` 启动时都从 DB 恢复 `TodoStore`，确保续跑时的初始状态与上一次运行结束时的状态一致——这是 `todo_write` 防作弊校验能正常工作的前提：`pending` 的任务在上次运行结束后保存到 DB，下次运行加载回内存，校验逻辑可以准确识别任务的历史状态。

--- a/docs/核心功能/progressive-compactor.md
+++ b/docs/核心功能/progressive-compactor.md
@@ -605,7 +605,8 @@ func (e *AgentEngine) Compact(ctx context.Context) (memory.CompactionRecord, err
 | `internal/memory/compaction_offloader.go` | CompactionOffloader + OffloadEntry |
 | `internal/memory/record_store.go` | CompactionRecord + CompactionTier + RecordStore + FileRecordStore |
 | `internal/memory/compaction.go` | RecordedCompactor 接口 + repairOrphanedToolPairs |
-| `internal/engine/agent_loop.go` | applyCompactionWith 类型断言 + runLoop 压缩集成 |
+| `internal/engine/history.go` | applyCompactionWith 类型断言（压缩适配） |
+| `internal/engine/loop_phases.go` | prepareTurnInput 中的 runLoop 压缩集成 |
 | `internal/engine/stream.go` | EventCompaction 携带 CompactionRecord |
 | `internal/engine/compact.go` | 手动 /compact 适配 RecordedCompactor |
 | `internal/memory/manager.go` | WithCompactionRecordsDir + 级联 GC |

--- a/docs/核心功能/tool-calling.md
+++ b/docs/核心功能/tool-calling.md
@@ -509,6 +509,7 @@ LLM 的工具结果通过文本通道传递。无论工具输出是命令行输�
 | `internal/provider/anthropic.go` | Anthropic 兼容 API 适配器 |
 | `internal/provider/tool_call_accumulator.go` | OpenAI/Anthropic 共享的流式工具调用参数累积器 |
 | `internal/provider/providertest/mock.go` | 测试用 Mock Provider（`_test` 编译单元，不进入生产二进制） |
-| `internal/engine/agent_loop.go` | Agent 主循环，编排 Tool Calling 全流程 + 块状日志格式化 |
+| `internal/engine/agent_loop.go` | Agent 主循环编排器（Run + runLoop + emitter 定义）+ 块状日志格式化 |
+| `internal/engine/tools_exec.go` | executeTools：同 Turn 多工具并发调度（信号量 + 每工具独立超时） |
 | `internal/engine/stream.go` | 流式（Streaming）模式的 Tool Calling 编排 |
 | `internal/engine/agent_loop_test.go` | 主循环单元测试 |

--- a/internal/engine/agent_loop.go
+++ b/internal/engine/agent_loop.go
@@ -2,13 +2,25 @@
 //
 // 每个 Turn：LLM 调用（携带完整工具列表）→ 工具执行（如有）→ Observation 注入 → 下一 Turn。
 // 通过 emitter 抽象支持阻塞（Run）和流式（RunStream）两种输出模式，共享同一主循环内核。
+//
+// 文件布局（按职责拆分，本文件只保留引擎结构与循环编排器）：
+//
+//	options.go     — With* 配置选项与运行期 Set* 方法
+//	retry.go       — LLM 生成调用的双档重试策略（默认预算 / 网络预算）
+//	loop_phases.go — runLoop 的阶段化实现（初始化 / Turn 前置 / 预处理 / 生成 / 注入 / 收尾）
+//	history.go     — 会话历史加载、持久化与压缩适配
+//	planmode.go    — Plan Mode 工具白名单、prompt 前缀与 nudge 工具集判定
+//	tools_exec.go  — 同 Turn 多工具的并发调度
+//	stream.go      — 流式入口 RunStream 与事件类型定义
+//	compact.go     — TUI /compact 触发的手动强制压缩
+//	observer.go    — EngineObserver 可观测接入点
+//	permission.go  — PermissionMode 全局权限策略
 package engine
 
 import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,141 +32,6 @@ import (
 	"github.com/harness9/internal/schema"
 	"github.com/harness9/internal/tools"
 )
-
-// Option 是 AgentEngine 的函数选项。
-type Option func(*AgentEngine)
-
-// WithMaxTurns 设置单次 Run 允许的最大 Turn 数，0 或负数表示不限制。
-func WithMaxTurns(n int) Option {
-	return func(e *AgentEngine) { e.maxTurns = n }
-}
-
-// WithToolTimeout 设置单个工具执行的超时时间，0 表示使用 context 原始截止时间。
-func WithToolTimeout(d time.Duration) Option {
-	return func(e *AgentEngine) { e.toolTimeout = d }
-}
-
-// WithMaxConcurrentTools 设置同一 Turn 内最大并发工具数，0 或负数表示不限制。
-func WithMaxConcurrentTools(n int) Option {
-	return func(e *AgentEngine) { e.maxConcurrentTools = n }
-}
-
-// WithContextWindow 设置模型的最大 context window（tokens），用于 TUI token 使用率展示。
-// 通常通过 provider.GetModelLimits(modelName).ContextTokens 获取。
-func WithContextWindow(tokens int) Option {
-	return func(e *AgentEngine) { e.contextWindow = tokens }
-}
-
-// WithGenerateRetry 配置 LLM 生成调用的应用层重试：最多尝试 attempts 次，
-// 首次重试退避 baseDelay，其后指数增长（上限 maxGenerateRetryDelay）。
-//
-// 这是对 SDK 内置重试的补充：SDK 的重试只覆盖"首字节到达前"的连接错误，
-// 而流式响应中途断连（mid-stream EOF / 代理超时 / 5xx after headers）会以
-// StreamChunkError 形式逃逸到引擎层，旧实现直接终止整个 agent loop（丢掉整条轨迹）。
-// 此重试在保持 context 取消语义的前提下，把"一次瞬时抖动杀实例"变为可恢复事件。
-// attempts<=1 时关闭重试（仅尝试一次）。
-func WithGenerateRetry(attempts int, baseDelay time.Duration) Option {
-	return func(e *AgentEngine) {
-		e.generateRetries = attempts
-		e.generateRetryBase = baseDelay
-	}
-}
-
-// WithNetworkRetry 配置网络传输层错误（TLS/DNS/连接建立，见 isTransientNetworkError）
-// 的独立重试预算：最多尝试 attempts 次，首次重试退避 baseDelay，其后指数增长
-// （上限 maxNetworkRetryDelay）。这类错误比业务层错误（4xx/5xx）间歇性更强，
-// 默认的 WithGenerateRetry 预算（默认 3 次、总计约 3s）对它们太窄——Terminal-Bench
-// pilot 里 3 个任务在 Turn 1 就命中同一条 x509 证书错误，退避耗尽后直接放弃整个 turn
-// （见 docs/技术调研/terminal-bench-轨迹分析-v1.md §2 R2）。attempts<=1 时该扩展形同
-// 关闭——网络错误仅尝试 1 次，不再享有比默认预算更宽松的窗口（不会退化为借用
-// WithGenerateRetry 的预算，两者预算互相独立）。
-func WithNetworkRetry(attempts int, baseDelay time.Duration) Option {
-	return func(e *AgentEngine) {
-		e.networkRetries = attempts
-		e.networkRetryBase = baseDelay
-	}
-}
-
-// WithMemoryNudge 配置长期记忆 nudge：每隔 interval 个 turn 在发送给 LLM 的历史中
-// 注入一行 text 提示（仅注入到临时副本，不持久化）。interval<=0 时关闭。
-func WithMemoryNudge(interval int, text string) Option {
-	return func(e *AgentEngine) {
-		e.nudgeInterval = interval
-		e.nudgeText = text
-	}
-}
-
-// WithStallNudge 配置停滞 nudge：当连续 window 个"使用了工具但未调用任何进展工具
-// （edit_file/write_file）"的 turn 后，向发送给 LLM 的历史副本注入一次 text 提示，
-// 然后重置计数。用于打断"反复静态重读却不收敛"的空转（SWE-bench 轨迹中 xarray-3364、
-// pylint-7080 烧满 80 轮即此形态）。
-//
-// 与 WithMemoryNudge 一致：仅注入到临时副本，绝不持久化、不累积；window<=0 时关闭。
-// 进展工具集合见 progressToolNames。
-func WithStallNudge(window int, text string) Option {
-	return func(e *AgentEngine) {
-		e.stallWindow = window
-		e.stallText = text
-	}
-}
-
-// PromptBuilder 构造 Agent 的 system prompt。
-// 接口定义在 engine 包（使用者侧），由 internal/context 包实现。
-// 引擎通过此接口与 Context Engineering 模块解耦。
-type PromptBuilder interface {
-	Build() string
-}
-
-// WithEngineObserver 注册引擎生命周期观察者，供可观测层（OpenTelemetry 等）无侵入接入。
-func WithEngineObserver(o EngineObserver) Option {
-	return func(e *AgentEngine) { e.observer = o }
-}
-
-// WithPromptBuilder 设置自定义 PromptBuilder。未设置时使用内置默认文案。
-func WithPromptBuilder(pb PromptBuilder) Option {
-	return func(e *AgentEngine) { e.promptBuilder = pb }
-}
-
-// WithSession 绑定 Session，使 runLoop 在启动时加载历史、结束时保存新消息。
-func WithSession(s memory.Session) Option {
-	return func(e *AgentEngine) { e.session = s }
-}
-
-// WithCompactor 绑定上下文压缩策略，在每次 LLM 调用前裁剪历史消息。
-func WithCompactor(c memory.Compactor) Option {
-	return func(e *AgentEngine) { e.compactor = c }
-}
-
-// WithPlanMode 设置 Agent 的初始执行模式。
-// runLoop 在启动时会快照此值，循环内不会受后续 SetPlanMode 调用影响。
-func WithPlanMode(mode planning.PlanMode) Option {
-	return func(e *AgentEngine) { e.planMode = mode }
-}
-
-// WithTodoStore 绑定 TodoStore，使引擎在 runLoop 生命周期中自动执行以下操作：
-//   - 启动时：从 Session 恢复 TodoStore 状态（跨会话续接未完成任务）
-//   - 结束时：通过 defer 将 TodoStore 保存到 Session（所有路径均执行）
-func WithTodoStore(s *planning.TodoStore) Option {
-	return func(e *AgentEngine) { e.todoStore = s }
-}
-
-// SetSession 替换当前绑定的 Session，供 TUI /new、/resume 命令切换会话时调用。
-// 线程安全：可从任意 goroutine 调用（如 TUI goroutine），内部以写锁保护。
-// 注意：修改对当前正在运行的 runLoop 无影响（runLoop 在入口快照 session 值）。
-func (e *AgentEngine) SetSession(s memory.Session) {
-	e.mu.Lock()
-	e.session = s
-	e.mu.Unlock()
-}
-
-// SetPlanMode 线程安全地更新当前执行模式。TUI Shift+Tab 键调用此方法。
-// 注意：修改对当前正在运行的 runLoop 无影响（runLoop 在入口快照 planMode 值），
-// 仅在下一次 Run/RunStream 调用时生效。
-func (e *AgentEngine) SetPlanMode(mode planning.PlanMode) {
-	e.mu.Lock()
-	e.planMode = mode
-	e.mu.Unlock()
-}
 
 // AgentEngine 是 harness9 agent loop 的核心编排器，将 LLM Provider（"大脑"）
 // 与 Tool Registry（"双手"）组合在一起，执行多轮 ReAct 循环直到任务完成。
@@ -184,13 +61,6 @@ type AgentEngine struct {
 	networkRetryBase   time.Duration       // 网络传输层错误的重试退避基准（默认 5s）
 }
 
-// maxGenerateRetryDelay 是生成重试指数退避的上限，避免退避时间吞掉整体预算。
-const maxGenerateRetryDelay = 30 * time.Second
-
-// maxNetworkRetryDelay 是网络传输层错误重试指数退避的上限，比 maxGenerateRetryDelay
-// 更宽松——这类故障（TLS/DNS/连接建立）间歇性更强，值得多等一会儿而不是放弃整个 turn。
-const maxNetworkRetryDelay = 60 * time.Second
-
 // NewAgentEngine 创建新的 AgentEngine。默认值：maxTurns=500, toolTimeout=60s,
 // generateRetries=3（base 1s）—— 对瞬时 LLM/流式错误具备基础韧性。
 func NewAgentEngine(p provider.LLMProvider, r tools.Registry, workDir string, opts ...Option) *AgentEngine {
@@ -209,94 +79,6 @@ func NewAgentEngine(p provider.LLMProvider, r tools.Registry, workDir string, op
 		opt(e)
 	}
 	return e
-}
-
-// generateWithRetry 在 em.generate 之上叠加有界指数退避重试。
-//
-// 重试策略：
-//   - 成功立即返回；
-//   - context 已取消/超时（ctx.Err()!=nil）不重试，原样返回（会话级终止信号）；
-//   - 其余错误视为可能瞬时，退避后重试，直到耗尽 attempts；
-//   - 退避期间感知 ctx 取消，避免无谓等待。
-func (e *AgentEngine) generateWithRetry(ctx context.Context, em emitter, turn int, history []schema.Message, toolDefs []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
-	attempts := e.generateRetries
-	if attempts < 1 {
-		attempts = 1
-	}
-	base := e.generateRetryBase
-	if base <= 0 {
-		base = 1 * time.Second
-	}
-	networkAttempts := e.networkRetries
-	if networkAttempts < 1 {
-		networkAttempts = 1
-	}
-	networkBase := e.networkRetryBase
-	if networkBase <= 0 {
-		networkBase = 5 * time.Second
-	}
-
-	var lastErr error
-	for attempt := 1; ; attempt++ {
-		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
-		}
-		msg, usage, err := em.generate(ctx, turn, history, toolDefs)
-		if err == nil {
-			return msg, usage, nil
-		}
-		lastErr = err
-		// context 取消/超时不重试。
-		if ctx.Err() != nil {
-			return nil, nil, err
-		}
-
-		// 网络传输层错误（TLS/DNS/连接建立）间歇性更强，用独立、更宽松的预算，
-		// 不与其他错误类别共享 attempts/base——分类基于本次失败的错误本身，
-		// 不影响非网络错误仍然只用默认预算。
-		maxAttempts, delayBase, delayCap := attempts, base, maxGenerateRetryDelay
-		if isTransientNetworkError(err) {
-			maxAttempts, delayBase, delayCap = networkAttempts, networkBase, maxNetworkRetryDelay
-		}
-		if attempt >= maxAttempts {
-			break
-		}
-
-		delay := delayBase << (attempt - 1)
-		if delay > delayCap {
-			delay = delayCap
-		}
-		log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
-			"LLM 生成失败 (turn %d, 尝试 %d/%d)，%s 后重试: %v", turn, attempt, maxAttempts, delay, err)))
-		select {
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		case <-time.After(delay):
-		}
-	}
-	return nil, nil, lastErr
-}
-
-// isTransientNetworkError 判断 LLM 生成失败的根因是否为建立到 API 端点连接阶段的
-// 瞬时网络故障（TLS/证书校验、DNS 解析、连接建立），而非业务层错误（如 4xx/5xx）。
-// 这类故障间歇性更强，容错窗口需要比默认重试策略更宽——Terminal-Bench pilot 里
-// 3 个任务在同一条 x509 证书错误上耗尽默认预算后直接放弃整个 turn，详见
-// docs/技术调研/terminal-bench-轨迹分析-v1.md §2 R2。
-//
-// 采用字符串匹配而非 errors.As 类型断言：openai-go/anthropic-sdk-go 对底层
-// net/http 错误的包装不保证保留可断言的具体类型，但错误消息里的关键字符串
-// （x509:/tls:/no such host 等）是稳定、可观测的。
-func isTransientNetworkError(err error) bool {
-	msg := err.Error()
-	for _, marker := range []string{
-		"x509:", "tls:", "no such host", "connection refused",
-		"connection reset", "i/o timeout", "dial tcp",
-	} {
-		if strings.Contains(msg, marker) {
-			return true
-		}
-	}
-	return false
 }
 
 // emitter 封装 Run 与 RunStream 在"输出侧"的差异：
@@ -332,7 +114,9 @@ func (e *AgentEngine) Run(ctx context.Context, userPrompt string) error {
 			if err != nil {
 				return nil, nil, err
 			}
-			if msg.Content != "" {
+			// 防御：契约违规的空响应（msg 为 nil）不在此处解引用——
+			// 原样上抛给 generateWithRetry 统一处理（转为可重试错误）。
+			if msg != nil && msg.Content != "" {
 				fmt.Printf("[assistant] %s\n", msg.Content)
 			}
 			return msg, usage, nil
@@ -359,349 +143,67 @@ func (e *AgentEngine) Run(ctx context.Context, userPrompt string) error {
 	return e.runLoop(ctx, userPrompt, "engine", em)
 }
 
-// runLoop 是 Run 与 RunStream 共享的主循环内核。
+// runLoop 是 Run 与 RunStream 共享的主循环内核，按阶段编排一次完整交互：
+//
+//	beginInteraction → 初始化（observer / 快照 / Todo 恢复 / Plan 前缀 / 历史加载）
+//	for {
+//	    beginTurn         → Turn 计数 + 双重终止判定（MaxTurns / ctx 取消）
+//	    prepareTurnInput  → 工具过滤 + 压缩检查 + token 估算 + nudge 注入
+//	    generateTurn      → 带重试 LLM 调用 + 实际用量上报
+//	    （自然终止判定）    → 模型无工具调用则收敛退出
+//	    executeTools      → 并发工具调度（tools_exec.go）
+//	    injectObservations → Observation 注入
+//	}
+//	saveHistory      → 仅自然终止路径持久化新增消息
+//
+// 错误语义：非自然终止（MaxTurns / ctx 取消 / 生成失败）时返回错误且不持久化
+// 本轮新增历史（丢弃整条轨迹，与既有行为一致）；TodoStore 无论何种退出路径均持久化。
 func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix string, em emitter) error {
 	log.Print(logfmt.FormatLoopStart(logPrefix, e.workDir, e.maxTurns, e.toolTimeout, e.maxConcurrentTools))
 
-	// 可观测层接入：若未注入 observer 则退化为 noop。
-	obs := e.observer
-	if obs == nil {
-		obs = noopObserver{}
-	}
-	// 单独加读锁读取 sessionID 用于 span 属性（与下方 sess/comp 快照锁分离，避免持锁时间过长）。
-	e.mu.RLock()
-	var sessIDForObs string
-	if e.session != nil {
-		sessIDForObs = e.session.SessionID()
-	}
-	e.mu.RUnlock()
-	var interactionErr error
-	turnCount := 0
-	ctx = obs.OnInteractionStart(ctx, sessIDForObs, userPrompt)
-	defer func() { obs.OnInteractionEnd(ctx, turnCount, interactionErr) }()
+	lc := e.beginInteraction(ctx, userPrompt, logPrefix, em)
 
-	// 在循环开始时快照 session 和 compactor，避免与 TUI goroutine 的 SetSession 产生数据竞争。
-	e.mu.RLock()
-	sess := e.session
-	comp := e.compactor
-	planMode := e.planMode
-	todoStore := e.todoStore
-	e.mu.RUnlock()
-
-	// 启动时从 Session 恢复 TodoStore 状态（跨会话续接未完成任务）。
-	if sess != nil && todoStore != nil {
-		if todos, err := sess.GetTodos(ctx); err != nil {
-			log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("加载 todos 失败: %v", err)))
-		} else {
-			todoStore.Write(todos)
-		}
-	}
-
-	// Plan Mode：注入规划行为约束（write_file/edit_file 已由 filterReadOnlyTools 在工具层硬性过滤，
-	// 此处只补充 bash 只读限制和 todo_write 输出要求等无法在工具层表达的行为规则）。
-	if planMode == planning.PlanModePlan {
-		userPrompt = "分析以下请求，用 todo_write 输出一份可直接执行的实现计划，然后用纯文字简述计划后停止。\n" +
-			"todo 项要求：每条对应一个具体的实现动作（例如：创建某文件、实现某函数、运行某命令），\n" +
-			"而非高层规划描述（禁止写\"需求澄清\"、\"方案设计\"之类无法直接执行的条目）。\n" +
-			"如需了解当前代码库，可使用 read_file 或 bash（只读命令：ls、cat、find、grep）。\n" +
-			"不要创建文件、执行 build/install 或做任何实际修改。\n\n" +
-			userPrompt
-	}
-
-	contextHistory, startLen := e.loadHistoryWith(ctx, userPrompt, sess)
-
-	// 结束时将 TodoStore 持久化到 Session（write-replace）。
-	defer func() {
-		if sess != nil && todoStore != nil {
-			if err := sess.SaveTodos(ctx, todoStore.Read()); err != nil {
-				log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("保存 todos 失败: %v", err)))
-			}
-		}
-	}()
-
-	overallStart := time.Now()
-
-	// turnsSinceProgress 记录自上次"进展工具"调用以来的轮数，驱动 WithStallNudge 停滞检测。
-	turnsSinceProgress := 0
+	// defer 注册顺序（LIFO 决定执行顺序）：
+	//   OnInteractionEnd 先注册 → 交互结束时最后执行，确保 span 覆盖 todos 持久化；
+	//   saveTodos 后注册 → 所有退出路径最先执行，保证规划进度不因异常退出丢失。
+	defer func() { lc.obs.OnInteractionEnd(lc.obsCtx, lc.turns, lc.interactionErr) }()
+	defer lc.saveTodos(ctx)
 
 	for {
-		turnCount++
-		turnCtx := obs.OnTurnStart(ctx, turnCount)
-
-		if e.maxTurns > 0 && turnCount > e.maxTurns {
-			interactionErr = fmt.Errorf("已达最大 Turn 数 (%d)，循环终止", e.maxTurns)
-			return interactionErr
-		}
-		select {
-		case <-ctx.Done():
-			interactionErr = fmt.Errorf("context 已取消：%w", ctx.Err())
-			return interactionErr
-		default:
-		}
-
-		availableTools := e.registry.GetAvailableTools()
-		if planMode == planning.PlanModePlan {
-			availableTools = filterReadOnlyTools(availableTools)
-		}
-		toolTokens := memory.EstimateToolTokens(availableTools)
-
-		// Preflight token check: estimate tokens before and after compaction.
-		compactedHistory, compactionRecord := e.applyCompactionWith(comp, contextHistory)
-		msgTokensAfter := memory.EstimateTokens(compactedHistory)
-		totalTokens := msgTokensAfter + toolTokens
-
-		if compactionRecord != nil && compactionRecord.Tier != memory.TierNone {
-			em.compaction(*compactionRecord)
-		}
-
-		// Report current context token usage to TUI / CLI.
-		em.tokenUpdate(totalTokens, e.contextWindow)
-
-		// 记忆 nudge：每隔 nudgeInterval 轮，向发送给 LLM 的历史副本追加一行提示。
-		// 注入到防御性副本，绝不写入 contextHistory（因此不会被持久化、不会累积）。
-		if e.nudgeInterval > 0 && e.nudgeText != "" && turnCount%e.nudgeInterval == 0 {
-			compactedHistory = appendUserNudge(compactedHistory, e.nudgeText)
-		}
-
-		// 停滞 nudge：连续 stallWindow 轮未调用进展工具（只在静态重读/grep 空转）时，
-		// 注入一次提示打断空转，并重置计数，避免每轮重复刷屏。同样仅作用于临时副本。
-		if e.stallWindow > 0 && e.stallText != "" && turnsSinceProgress >= e.stallWindow {
-			compactedHistory = appendUserNudge(compactedHistory, e.stallText)
-			turnsSinceProgress = 0
+		turnCtx, err := lc.beginTurn(ctx)
+		if err != nil {
+			return err
 		}
 
 		turnStart := time.Now()
-		log.Print(logfmt.FormatTurnStart(logPrefix, turnCount, len(compactedHistory), len(availableTools)))
+		input, _ := lc.prepareTurnInput()
+		log.Print(logfmt.FormatTurnStart(logPrefix, lc.turns, len(input.history), len(input.toolDefs)))
 
-		llmStart := time.Now()
-		responseMsg, usage, err := e.generateWithRetry(turnCtx, em, turnCount, compactedHistory, availableTools)
+		responseMsg, llmDuration, err := lc.generateTurn(turnCtx, input)
 		if err != nil {
-			interactionErr = err
-			return fmt.Errorf("模型生成失败 (turn %d): %w", turnCount, err)
-		}
-		llmDuration := time.Since(llmStart)
-
-		// 用实际 API 返回的 token 用量更新显示，替代之前的估算值。
-		if usage != nil && usage.InputTokens > 0 {
-			em.tokenUpdate(usage.InputTokens, e.contextWindow)
+			return err
 		}
 
-		contextHistory = append(contextHistory, *responseMsg)
-
+		// 自然终止判定：模型不再发起工具调用，ReAct 循环收敛。
 		if len(responseMsg.ToolCalls) == 0 {
-			log.Print(logfmt.FormatTurnDone(logPrefix, turnCount, llmDuration, time.Since(overallStart)))
-			obs.OnTurnEnd(turnCtx, turnCount, false)
+			log.Print(logfmt.FormatTurnDone(logPrefix, lc.turns, llmDuration, time.Since(lc.overallStart)))
+			lc.obs.OnTurnEnd(turnCtx, lc.turns, false)
 			break
 		}
 
-		// 停滞计数：本轮调用了进展工具则归零，否则累加（驱动 WithStallNudge）。
-		if hasProgressTool(responseMsg.ToolCalls) {
-			turnsSinceProgress = 0
-		} else {
-			turnsSinceProgress++
-		}
+		lc.trackStall(responseMsg.ToolCalls)
 
 		toolStart := time.Now()
-		results := e.executeTools(turnCtx, turnCount, responseMsg.ToolCalls, logPrefix, em)
+		results := e.executeTools(turnCtx, lc.turns, responseMsg.ToolCalls, logPrefix, em)
 		toolDuration := time.Since(toolStart)
 
-		for i, toolCall := range responseMsg.ToolCalls {
-			// 空输出兜底：部分 backend 拒绝空 content 的 tool_result（返回 400，
-			// 在无重试时直接杀实例），且空 Observation 无信息可供模型推理、浪费一轮。
-			content := results[i].Output
-			if content == "" {
-				content = "[工具执行完成，无输出]"
-			}
-			contextHistory = append(contextHistory, schema.Message{
-				Role:       schema.RoleUser,
-				Content:    content,
-				ToolCallID: toolCall.ID,
-				// 透传结构化错误信号，供 Provider 设置 tool_result.is_error，强化自愈。
-				IsError: results[i].IsError,
-			})
-		}
+		lc.history = injectObservations(lc.history, responseMsg.ToolCalls, results)
 
-		log.Print(logfmt.FormatObservation(logPrefix, turnCount, len(contextHistory), llmDuration, toolDuration, time.Since(turnStart)))
-		obs.OnTurnEnd(turnCtx, turnCount, true)
+		log.Print(logfmt.FormatObservation(logPrefix, lc.turns, len(lc.history), llmDuration, toolDuration, time.Since(turnStart)))
+		lc.obs.OnTurnEnd(turnCtx, lc.turns, true)
 	}
 
-	e.saveHistoryWith(ctx, sess, contextHistory, startLen)
-	log.Print(logfmt.FormatLoopEnd(logPrefix, turnCount, time.Since(overallStart)))
+	lc.saveHistory(ctx)
+	log.Print(logfmt.FormatLoopEnd(logPrefix, lc.turns, time.Since(lc.overallStart)))
 	return nil
-}
-
-// buildSystemPrompt 返回 system prompt 字符串。
-// 若设置了 PromptBuilder 则委托给它，否则回退到内置默认文案。
-func (e *AgentEngine) buildSystemPrompt() string {
-	if e.promptBuilder != nil {
-		return e.promptBuilder.Build()
-	}
-	return fmt.Sprintf(`你的名字是 harness9。请始终以 "harness9" 自称 — 不要使用 "AI 助手"、"语言模型" 或任何其他通称。
-
-harness9 是一个通用 AI Agent，可完全访问用户的计算机。
-
-能力：
-- 执行 Shell 命令：运行程序、管理进程、安装软件包、与操作系统交互
-- 读取、写入和编辑文件系统中的文件
-- 将多个工具串联使用，自主完成复杂的多步骤任务
-
-工作目录：%s
-
-工作准则：
-- 先调查后行动：优先读取文件并运行诊断命令
-- 小步可验证地推进：每次重要操作后检查结果
-- 命令失败时，诊断根本原因而非猜测
-- 优先局部修改而非整体重写；保持现有风格和约定
-- 任务描述模糊时，选择最合理的解释后直接推进`, e.workDir)
-}
-
-// loadHistoryWith 从 sess 加载历史消息，注入 system prompt 和当前用户输入。
-// sess 为 nil 时退化为原有行为（全新 contextHistory）。
-// 返回完整历史切片和新消息的起始索引（用于 saveHistoryWith）。
-func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session) ([]schema.Message, int) {
-	var history []schema.Message
-	if sess != nil {
-		msgs, err := sess.GetMessages(ctx, 0)
-		if err != nil {
-			log.Print(logfmt.FormatMsg("engine", fmt.Sprintf("加载会话历史失败: %v", err)))
-		} else {
-			history = msgs
-		}
-	}
-	// system prompt 不持久化到 DB，每次调用时重新注入
-	if len(history) == 0 || history[0].Role != schema.RoleSystem {
-		history = append([]schema.Message{{Role: schema.RoleSystem, Content: e.buildSystemPrompt()}}, history...)
-	}
-	startLen := len(history) // 新消息从此处开始；system prompt 不计入持久化范围
-	history = append(history, schema.Message{Role: schema.RoleUser, Content: userPrompt})
-	return history, startLen
-}
-
-// applyCompactionWith 对消息列表应用压缩策略。comp 为 nil 时原样返回。
-// 若 compactor 实现 RecordedCompactor 接口，同时返回压缩审计记录（含 tier、锚点、外存条目等）。
-func (e *AgentEngine) applyCompactionWith(comp memory.Compactor, msgs []schema.Message) ([]schema.Message, *memory.CompactionRecord) {
-	if comp == nil {
-		return msgs, nil
-	}
-	if rc, ok := comp.(memory.RecordedCompactor); ok {
-		result, record := rc.CompactWithRecord(msgs)
-		return result, &record
-	}
-	return comp.Compact(msgs), nil
-}
-
-// saveHistoryWith 将本次 Run 新增的消息（msgs[startLen:]）写回 sess。
-// sess 为 nil 时为 no-op；失败仅打 warning 日志，不中断主流程。
-func (e *AgentEngine) saveHistoryWith(ctx context.Context, sess memory.Session, msgs []schema.Message, startLen int) {
-	if sess == nil || startLen >= len(msgs) {
-		return
-	}
-	newMsgs := msgs[startLen:]
-	if err := sess.AddMessages(ctx, newMsgs); err != nil {
-		log.Print(logfmt.FormatMsg("engine", fmt.Sprintf("保存会话历史失败: %v", err)))
-	}
-}
-
-// planModeWhitelist 是 Plan Mode 下允许 LLM 调用的工具名称白名单（read-only map，安全并发读）。
-//
-// 白名单的设计意图：
-//   - read_file / bash：允许探索代码库，但 prompt 层约束 bash 只使用只读命令（ls/cat/find/grep）
-//   - todo_write：Plan Mode 的核心产出——LLM 通过此工具输出结构化实现计划
-//   - use_skill：允许加载 Skills 获取项目规范文档
-//   - write_file / edit_file：不在白名单，从工具列表中硬性移除（工具层硬约束，优于 prompt 层软约束）
-//   - web_search / web_fetch：不在白名单；Plan Mode 专注于本地代码库探索，
-//     网络访问不属于规划阶段所需能力，如需联网研究请使用 Default/AutoEdit 模式
-//   - memory_search / memory_write：不在白名单；Plan Mode 是轻量规划阶段，不触发记忆读写，
-//     避免规划过程产生副作用（如写入错误的记忆条目）；记忆操作在 Default/AutoEdit 模式下可用
-//   - task：不在白名单；Plan Mode 仅生成计划，不触发子代理委派（委派是执行阶段的动作）
-var planModeWhitelist = map[string]bool{
-	"read_file":  true,
-	"bash":       true,
-	"use_skill":  true,
-	"todo_write": true,
-}
-
-// progressToolNames 是被视为"取得实质进展"的工具集合（用于 WithStallNudge 停滞检测）。
-// 调用其一即重置停滞计数：它们改变工作区状态（写入/编辑文件），是 Agent 真正推进任务的信号。
-// 只读探索（read_file/bash grep 等）不计入进展，连续多轮只读即被判定为停滞。
-var progressToolNames = map[string]bool{
-	"write_file": true,
-	"edit_file":  true,
-}
-
-// hasProgressTool 判断本轮工具调用中是否包含进展工具。
-func hasProgressTool(calls []schema.ToolCall) bool {
-	for _, tc := range calls {
-		if progressToolNames[tc.Name] {
-			return true
-		}
-	}
-	return false
-}
-
-// appendUserNudge 返回在历史副本末尾追加一条 user nudge 消息的新切片。
-// 不修改入参、不持久化——nudge 仅对当轮发送给 LLM 的临时副本可见。
-func appendUserNudge(history []schema.Message, text string) []schema.Message {
-	withNudge := make([]schema.Message, len(history), len(history)+1)
-	copy(withNudge, history)
-	return append(withNudge, schema.Message{Role: schema.RoleUser, Content: text})
-}
-
-// filterReadOnlyTools 从工具定义列表中过滤出 planModeWhitelist 中的子集，
-// 在 Plan Mode 下替代完整工具列表传递给 LLM。
-// 使用工具层硬约束而非 prompt 层软约束，确保 LLM 无论在何种上下文状态下都无法访问被过滤的工具。
-func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition {
-	var result []schema.ToolDefinition
-	for _, t := range tools {
-		if planModeWhitelist[t.Name] {
-			result = append(result, t)
-		}
-	}
-	return result
-}
-
-// executeTools 并发执行所有工具调用，每个工具带有独立的超时控制。
-// 通过预分配切片 + 索引写入保证结果顺序与 ToolCalls 一致。
-func (e *AgentEngine) executeTools(ctx context.Context, turn int, toolCalls []schema.ToolCall, logPrefix string, em emitter) []schema.ToolResult {
-	log.Print(logfmt.FormatParallelTools(logPrefix, turn, len(toolCalls), e.maxConcurrentTools))
-
-	results := make([]schema.ToolResult, len(toolCalls))
-	var wg sync.WaitGroup
-
-	var sem chan struct{}
-	if e.maxConcurrentTools > 0 {
-		sem = make(chan struct{}, e.maxConcurrentTools)
-	}
-
-	for i, toolCall := range toolCalls {
-		wg.Add(1)
-		go func(idx int, tc schema.ToolCall) {
-			defer wg.Done()
-
-			if sem != nil {
-				sem <- struct{}{}
-				defer func() { <-sem }()
-			}
-
-			toolCtx := ctx
-			var cancel context.CancelFunc
-			if e.toolTimeout > 0 {
-				toolCtx, cancel = context.WithTimeout(ctx, e.toolTimeout)
-				defer cancel()
-			}
-
-			if em.approval != nil {
-				toolCtx = hooks.WithApprovalFn(toolCtx, em.approval)
-			}
-
-			em.toolStart(turn, tc)
-
-			start := time.Now()
-			results[idx] = e.registry.Execute(toolCtx, tc)
-			em.toolDone(turn, tc, results[idx], time.Since(start))
-		}(i, toolCall)
-	}
-
-	wg.Wait()
-	return results
 }

--- a/internal/engine/agent_loop.go
+++ b/internal/engine/agent_loop.go
@@ -167,16 +167,20 @@ func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix 
 	//   OnInteractionEnd 先注册 → 交互结束时最后执行，确保 span 覆盖 todos 持久化；
 	//   saveTodos 后注册 → 所有退出路径最先执行，保证规划进度不因异常退出丢失。
 	defer func() { lc.obs.OnInteractionEnd(lc.obsCtx, lc.turns, lc.interactionErr) }()
-	defer lc.saveTodos(ctx)
+	// 所有阶段与收尾均传递 obsCtx（observer 增强后的 ctx），确保 Span/值注入
+	// 在整个交互生命周期内持续传播（与重构前 ctx 重新赋值的语义一致）。
+	defer lc.saveTodos(lc.obsCtx)
 
 	for {
-		turnCtx, err := lc.beginTurn(ctx)
+		turnCtx, err := lc.beginTurn(lc.obsCtx)
 		if err != nil {
 			return err
 		}
 
+		input := lc.prepareTurnInput()
+		// turnStart 在预处理（含压缩）之后计时：FormatObservation 记录的耗时口径
+		// 保持为"本 Turn 的 LLM + 工具执行"，不含压缩预处理（与重构前一致）。
 		turnStart := time.Now()
-		input, _ := lc.prepareTurnInput()
 		log.Print(logfmt.FormatTurnStart(logPrefix, lc.turns, len(input.history), len(input.toolDefs)))
 
 		responseMsg, llmDuration, err := lc.generateTurn(turnCtx, input)
@@ -203,7 +207,7 @@ func (e *AgentEngine) runLoop(ctx context.Context, userPrompt string, logPrefix 
 		lc.obs.OnTurnEnd(turnCtx, lc.turns, true)
 	}
 
-	lc.saveHistory(ctx)
+	lc.saveHistory(lc.obsCtx)
 	log.Print(logfmt.FormatLoopEnd(logPrefix, lc.turns, time.Since(lc.overallStart)))
 	return nil
 }

--- a/internal/engine/compact.go
+++ b/internal/engine/compact.go
@@ -7,7 +7,9 @@ package engine
 import (
 	"context"
 	"fmt"
+	"log"
 
+	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/memory"
 	"github.com/harness9/internal/schema"
 )
@@ -74,6 +76,13 @@ func (e *AgentEngine) Compact(ctx context.Context) (memory.CompactionRecord, err
 		return record, fmt.Errorf("compact: clear session: %w", err)
 	}
 	if err := sess.AddMessages(ctx, compacted); err != nil {
+		// 写回失败时尽力回滚原始历史：Clear 已执行、compacted 未落盘，
+		// 若不恢复原始消息，一次瞬时 DB 错误就会导致整条会话历史永久丢失。
+		// 回滚本身也可能失败（如 DB 持续不可用），此时只能记录告警，无法挽留数据。
+		if restoreErr := sess.AddMessages(ctx, msgs); restoreErr != nil {
+			log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
+				"compact: 写回压缩历史失败且回滚也失败（会话数据可能丢失）: 写回=%v 回滚=%v", err, restoreErr)))
+		}
 		return record, fmt.Errorf("compact: write compacted messages: %w", err)
 	}
 

--- a/internal/engine/compact.go
+++ b/internal/engine/compact.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/harness9/internal/logfmt"
 	"github.com/harness9/internal/memory"
@@ -78,11 +79,15 @@ func (e *AgentEngine) Compact(ctx context.Context) (memory.CompactionRecord, err
 	if err := sess.AddMessages(ctx, compacted); err != nil {
 		// 写回失败时尽力回滚原始历史：Clear 已执行、compacted 未落盘，
 		// 若不恢复原始消息，一次瞬时 DB 错误就会导致整条会话历史永久丢失。
+		// 回滚使用独立 ctx：写回失败若恰恰源于当前 ctx 取消/超时，复用原 ctx
+		// 的回滚必然同样失败；给 5s 独立窗口，让瞬时 DB 故障下的恢复成为可能。
 		// 回滚本身也可能失败（如 DB 持续不可用），此时只能记录告警，无法挽留数据。
-		if restoreErr := sess.AddMessages(ctx, msgs); restoreErr != nil {
+		restoreCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if restoreErr := sess.AddMessages(restoreCtx, msgs); restoreErr != nil {
 			log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
 				"compact: 写回压缩历史失败且回滚也失败（会话数据可能丢失）: 写回=%v 回滚=%v", err, restoreErr)))
 		}
+		cancel()
 		return record, fmt.Errorf("compact: write compacted messages: %w", err)
 	}
 

--- a/internal/engine/history.go
+++ b/internal/engine/history.go
@@ -1,0 +1,91 @@
+// Package engine — 会话历史的加载、持久化与压缩适配。
+//
+// 该文件集中了 runLoop 与 Session（持久化层）、Compactor（压缩层）之间的全部交互，
+// 使主循环本身不感知存储细节。核心约定：
+//   - system prompt 不持久化到 DB，每次 Run 时重新注入；
+//   - 压缩是"逐轮视图"而非"就地修改"——压缩结果仅作用于当次 LLM 调用的输入，
+//     引擎本地的完整历史不受影响（详见 loop_phases.go 的 prepareTurnInput）。
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/harness9/internal/logfmt"
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/schema"
+)
+
+// buildSystemPrompt 返回 system prompt 字符串。
+// 若设置了 PromptBuilder 则委托给它，否则回退到内置默认文案。
+func (e *AgentEngine) buildSystemPrompt() string {
+	if e.promptBuilder != nil {
+		return e.promptBuilder.Build()
+	}
+	return fmt.Sprintf(`你的名字是 harness9。请始终以 "harness9" 自称 — 不要使用 "AI 助手"、"语言模型" 或任何其他通称。
+
+harness9 是一个通用 AI Agent，可完全访问用户的计算机。
+
+能力：
+- 执行 Shell 命令：运行程序、管理进程、安装软件包、与操作系统交互
+- 读取、写入和编辑文件系统中的文件
+- 将多个工具串联使用，自主完成复杂的多步骤任务
+
+工作目录：%s
+
+工作准则：
+- 先调查后行动：优先读取文件并运行诊断命令
+- 小步可验证地推进：每次重要操作后检查结果
+- 命令失败时，诊断根本原因而非猜测
+- 优先局部修改而非整体重写；保持现有风格和约定
+- 任务描述模糊时，选择最合理的解释后直接推进`, e.workDir)
+}
+
+// loadHistoryWith 从 sess 加载历史消息，注入 system prompt 和当前用户输入。
+// sess 为 nil 时退化为原有行为（全新 contextHistory）。
+// 返回完整历史切片和新消息的起始索引（用于 saveHistoryWith）。
+func (e *AgentEngine) loadHistoryWith(ctx context.Context, userPrompt string, sess memory.Session, logPrefix string) ([]schema.Message, int) {
+	var history []schema.Message
+	if sess != nil {
+		msgs, err := sess.GetMessages(ctx, 0)
+		if err != nil {
+			// 历史加载失败不终止 Run：降级为全新会话（自愈），仅记录告警。
+			log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("加载会话历史失败: %v", err)))
+		} else {
+			history = msgs
+		}
+	}
+	// system prompt 不持久化到 DB，每次调用时重新注入
+	if len(history) == 0 || history[0].Role != schema.RoleSystem {
+		history = append([]schema.Message{{Role: schema.RoleSystem, Content: e.buildSystemPrompt()}}, history...)
+	}
+	startLen := len(history) // 新消息从此处开始；system prompt 不计入持久化范围
+	history = append(history, schema.Message{Role: schema.RoleUser, Content: userPrompt})
+	return history, startLen
+}
+
+// saveHistoryWith 将本次 Run 新增的消息（msgs[startLen:]）写回 sess。
+// sess 为 nil 时为 no-op；失败仅打 warning 日志，不中断主流程。
+func (e *AgentEngine) saveHistoryWith(ctx context.Context, sess memory.Session, msgs []schema.Message, startLen int, logPrefix string) {
+	if sess == nil || startLen >= len(msgs) {
+		return
+	}
+	newMsgs := msgs[startLen:]
+	if err := sess.AddMessages(ctx, newMsgs); err != nil {
+		log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("保存会话历史失败: %v", err)))
+	}
+}
+
+// applyCompactionWith 对消息列表应用压缩策略。comp 为 nil 时原样返回。
+// 若 compactor 实现 RecordedCompactor 接口，同时返回压缩审计记录（含 tier、锚点、外存条目等）。
+func (e *AgentEngine) applyCompactionWith(comp memory.Compactor, msgs []schema.Message) ([]schema.Message, *memory.CompactionRecord) {
+	if comp == nil {
+		return msgs, nil
+	}
+	if rc, ok := comp.(memory.RecordedCompactor); ok {
+		result, record := rc.CompactWithRecord(msgs)
+		return result, &record
+	}
+	return comp.Compact(msgs), nil
+}

--- a/internal/engine/loop_phases.go
+++ b/internal/engine/loop_phases.go
@@ -88,6 +88,10 @@ func (e *AgentEngine) beginInteraction(ctx context.Context, userPrompt, logPrefi
 	}
 	e.mu.RUnlock()
 	lc.obsCtx = lc.obs.OnInteractionStart(ctx, sessIDForObs, userPrompt)
+	// 后续所有阶段（Todo 恢复 / 历史加载 / Turn / 收尾）统一使用 obsCtx：
+	// observer 可能在 OnInteractionStart 中注入 Span 或其他值，若继续使用原始 ctx，
+	// 这些注入会丢失（OTELEngineObserver 的 interaction→turn Span 父子关系即依赖此传播）。
+	ctx = lc.obsCtx
 
 	// 在循环开始时快照 session/compactor/planMode/todoStore，避免与 TUI goroutine 的
 	// SetSession/SetPlanMode 产生数据竞争。
@@ -146,7 +150,9 @@ func (lc *loopContext) beginTurn(ctx context.Context) (context.Context, error) {
 //  3. token 估算上报：压缩后消息 + 工具定义的估算值（LLM 调用后由实际用量覆盖）
 //  4. nudge 注入：记忆 nudge（周期性）与停滞 nudge（无进展检测），
 //     均只注入发送副本，绝不写入 lc.history（因此不会被持久化、不会累积）
-func (lc *loopContext) prepareTurnInput() (turnInput, *memory.CompactionRecord) {
+//
+// 压缩审计记录在方法内部经 em.compaction 上报后即完成使命，不再外泄给调用方。
+func (lc *loopContext) prepareTurnInput() turnInput {
 	e := lc.engine
 
 	// 1. 工具列表每轮重新读取：注册表内容可能在运行期变化（如 MCP 异步注入）。
@@ -178,7 +184,7 @@ func (lc *loopContext) prepareTurnInput() (turnInput, *memory.CompactionRecord) 
 		lc.turnsSinceProgress = 0
 	}
 
-	return turnInput{history: compactedHistory, toolDefs: availableTools}, record
+	return turnInput{history: compactedHistory, toolDefs: availableTools}
 }
 
 // generateTurn 执行一次带重试的 LLM 调用（计时仅覆盖生成本身）。
@@ -186,7 +192,7 @@ func (lc *loopContext) prepareTurnInput() (turnInput, *memory.CompactionRecord) 
 // （完整历史，而非压缩/nudge 副本）。失败时记录 interactionErr 并返回包装后的错误。
 func (lc *loopContext) generateTurn(turnCtx context.Context, in turnInput) (*schema.Message, time.Duration, error) {
 	llmStart := time.Now()
-	responseMsg, usage, err := lc.engine.generateWithRetry(turnCtx, lc.em, lc.turns, in.history, in.toolDefs)
+	responseMsg, usage, err := lc.engine.generateWithRetry(turnCtx, lc.em, lc.turns, lc.logPrefix, in.history, in.toolDefs)
 	if err != nil {
 		lc.interactionErr = err
 		return nil, 0, fmt.Errorf("模型生成失败 (turn %d): %w", lc.turns, err)

--- a/internal/engine/loop_phases.go
+++ b/internal/engine/loop_phases.go
@@ -1,0 +1,253 @@
+// Package engine — runLoop 的阶段化实现。
+//
+// runLoop 编排器（agent_loop.go）按阶段调用本文件定义的私有方法，每个方法
+// 对应 ReAct 循环中的一个清晰阶段：
+//
+//	beginInteraction   → 初始化：observer 接入、状态快照、Todo 恢复、Plan 前缀、历史加载
+//	beginTurn          → Turn 前置：计数、observer 回调、双重终止判定（MaxTurns / ctx 取消）
+//	prepareTurnInput   → 上下文预处理：工具过滤、压缩检查、token 估算上报、nudge 注入
+//	generateTurn       → LLM 调用：带重试生成、实际用量上报、响应追加到完整历史
+//	trackStall         → 停滞检测：进展工具计数维护
+//	injectObservations → 结果注入：工具执行结果作为 Observation（user 角色）追加
+//	saveHistory        → 收尾：本次 Run 新增消息持久化（仅自然终止路径）
+//	saveTodos          → 收尾：TodoStore 持久化（所有退出路径，defer 保证）
+//
+// 并发模型：loopContext 的字段仅在 runLoop 所在 goroutine 中读写（emitter 内部
+// 回调除外，其自身保证并发安全），因此无需加锁；与 TUI goroutine 的隔离通过
+// 入口处对 AgentEngine 字段的一次性快照实现。
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/harness9/internal/logfmt"
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/planning"
+	"github.com/harness9/internal/schema"
+)
+
+// loopContext 聚合单次交互（一次 Run / RunStream 调用）的全部可变状态。
+// 引入它是为了消除阶段方法之间 6+ 参数的层层透传；engine 反向持有使阶段方法
+// 可以同时访问引擎配置（如 contextWindow）与交互状态（如 turns）。
+type loopContext struct {
+	engine    *AgentEngine
+	logPrefix string
+	em        emitter
+
+	// 以下字段在入口一次性快照自 AgentEngine，运行期不受 SetSession/SetPlanMode
+	// 等跨 goroutine 修改的影响（修改仅对下一次交互生效）。
+	sess      memory.Session
+	comp      memory.Compactor
+	todoStore *planning.TodoStore
+	planMode  planning.PlanMode
+
+	obs                EngineObserver   // 非 nil：入口已兜底为 noopObserver
+	obsCtx             context.Context  // interaction span 注入后的 ctx，所有 Turn ctx 的祖先
+	history            []schema.Message // 引擎本地的完整历史（含 system prompt 与本次全部新增消息）
+	startLen           int              // 本次 Run 新增消息在 history 中的起始下标（持久化边界）
+	turns              int              // 已进入的 Turn 计数（含被 MaxTurns 拒绝的那一轮）
+	turnsSinceProgress int              // 自上次进展工具调用以来的轮数（驱动停滞 nudge）
+	interactionErr     error            // 记录导致交互非正常结束的错误，供 OnInteractionEnd 上报
+	overallStart       time.Time
+}
+
+// turnInput 是单次 LLM 调用的完整输入。
+type turnInput struct {
+	// history 是发送给 LLM 的历史视图：在完整历史之上应用压缩与 nudge 注入后的副本，
+	// 仅作用于当次调用——lc.history 保持完整增长，不因压缩或 nudge 而改变。
+	history []schema.Message
+	// toolDefs 是本 Turn 对 LLM 可见的工具定义（Plan Mode 下已过滤为只读白名单）。
+	toolDefs []schema.ToolDefinition
+}
+
+// beginInteraction 完成 runLoop 入口的全部一次性准备，返回携带快照状态的 loopContext。
+// 此方法不返回错误：所有可失败步骤（Todo 恢复、历史加载）均降级处理并记录告警，
+// 保证 Run/RunStream 的失败语义完全由循环阶段决定（与重构前行为一致）。
+func (e *AgentEngine) beginInteraction(ctx context.Context, userPrompt, logPrefix string, em emitter) *loopContext {
+	lc := &loopContext{
+		engine:       e,
+		logPrefix:    logPrefix,
+		em:           em,
+		overallStart: time.Now(),
+	}
+
+	// 可观测层接入：若未注入 observer 则退化为 noop。
+	lc.obs = e.observer
+	if lc.obs == nil {
+		lc.obs = noopObserver{}
+	}
+
+	// 单独加读锁读取 sessionID 用于 span 属性（与下方状态快照的锁分离，避免持锁时间过长）。
+	e.mu.RLock()
+	var sessIDForObs string
+	if e.session != nil {
+		sessIDForObs = e.session.SessionID()
+	}
+	e.mu.RUnlock()
+	lc.obsCtx = lc.obs.OnInteractionStart(ctx, sessIDForObs, userPrompt)
+
+	// 在循环开始时快照 session/compactor/planMode/todoStore，避免与 TUI goroutine 的
+	// SetSession/SetPlanMode 产生数据竞争。
+	e.mu.RLock()
+	lc.sess = e.session
+	lc.comp = e.compactor
+	lc.planMode = e.planMode
+	lc.todoStore = e.todoStore
+	e.mu.RUnlock()
+
+	// 启动时从 Session 恢复 TodoStore 状态（跨会话续接未完成任务）。
+	// 失败不终止 Run：todo 是辅助状态，丢失可接受，仅记录告警。
+	if lc.sess != nil && lc.todoStore != nil {
+		if todos, err := lc.sess.GetTodos(ctx); err != nil {
+			log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf("加载 todos 失败: %v", err)))
+		} else {
+			lc.todoStore.Write(todos)
+		}
+	}
+
+	// Plan Mode：注入规划行为约束（write_file/edit_file 已由 filterReadOnlyTools 在工具层
+	// 硬性过滤，此处只补充 bash 只读限制和 todo_write 输出要求等无法在工具层表达的行为规则）。
+	userPrompt = applyPlanModePrefix(lc.planMode, userPrompt)
+
+	lc.history, lc.startLen = e.loadHistoryWith(ctx, userPrompt, lc.sess, logPrefix)
+	return lc
+}
+
+// beginTurn 执行每个 Turn 的前置动作：计数递增、observer 回调、双重终止判定。
+// 返回本 Turn 的增强 ctx（LLM 调用与工具执行均继承此 ctx）。
+// 命中 MaxTurns 或 ctx 取消时返回错误——这是三重终止保障中的两重
+// （第三重"自然终止"在 generateTurn 之后的调用方处判定）。
+func (lc *loopContext) beginTurn(ctx context.Context) (context.Context, error) {
+	lc.turns++
+	// OnTurnStart 先于终止判定调用：即使本轮被拒绝，观察者的 Span 计数仍保持配平。
+	turnCtx := lc.obs.OnTurnStart(ctx, lc.turns)
+
+	if lc.engine.maxTurns > 0 && lc.turns > lc.engine.maxTurns {
+		lc.interactionErr = fmt.Errorf("已达最大 Turn 数 (%d)，循环终止", lc.engine.maxTurns)
+		return nil, lc.interactionErr
+	}
+	select {
+	case <-ctx.Done():
+		lc.interactionErr = fmt.Errorf("context 已取消：%w", ctx.Err())
+		return nil, lc.interactionErr
+	default:
+	}
+	return turnCtx, nil
+}
+
+// prepareTurnInput 完成每轮 LLM 调用前的上下文预处理（保持以下执行顺序，
+// 与压缩通知 → token 上报 → nudge 注入的对外事件顺序一致）：
+//
+//  1. 工具过滤：读取本 Turn 可用工具列表，Plan Mode 下过滤为只读白名单
+//  2. 压缩检查：超过阈值时生成本轮的压缩视图，并上报压缩详情
+//  3. token 估算上报：压缩后消息 + 工具定义的估算值（LLM 调用后由实际用量覆盖）
+//  4. nudge 注入：记忆 nudge（周期性）与停滞 nudge（无进展检测），
+//     均只注入发送副本，绝不写入 lc.history（因此不会被持久化、不会累积）
+func (lc *loopContext) prepareTurnInput() (turnInput, *memory.CompactionRecord) {
+	e := lc.engine
+
+	// 1. 工具列表每轮重新读取：注册表内容可能在运行期变化（如 MCP 异步注入）。
+	availableTools := e.registry.GetAvailableTools()
+	if lc.planMode == planning.PlanModePlan {
+		availableTools = filterReadOnlyTools(availableTools)
+	}
+
+	// 2. 压缩检查：comp 为 nil 时原样返回。压缩是逐轮视图——结果仅用于本次调用，
+	//    lc.history 保留完整历史，保证下一轮压缩仍能看到全部上下文重新计算。
+	compactedHistory, record := e.applyCompactionWith(lc.comp, lc.history)
+	if record != nil && record.Tier != memory.TierNone {
+		lc.em.compaction(*record)
+	}
+
+	// 3. token 用量上报（估算值）：字符数÷4 估算，供 TUI 在 LLM 响应前先行展示。
+	totalTokens := memory.EstimateTokens(compactedHistory) + memory.EstimateToolTokens(availableTools)
+	lc.em.tokenUpdate(totalTokens, e.contextWindow)
+
+	// 4a. 记忆 nudge：每隔 nudgeInterval 轮注入一次长期记忆提示。
+	if e.nudgeInterval > 0 && e.nudgeText != "" && lc.turns%e.nudgeInterval == 0 {
+		compactedHistory = appendUserNudge(compactedHistory, e.nudgeText)
+	}
+
+	// 4b. 停滞 nudge：连续 stallWindow 轮未调用进展工具（只在静态重读/grep 空转）时，
+	// 注入一次提示打断空转，并重置计数，避免每轮重复刷屏。
+	if e.stallWindow > 0 && e.stallText != "" && lc.turnsSinceProgress >= e.stallWindow {
+		compactedHistory = appendUserNudge(compactedHistory, e.stallText)
+		lc.turnsSinceProgress = 0
+	}
+
+	return turnInput{history: compactedHistory, toolDefs: availableTools}, record
+}
+
+// generateTurn 执行一次带重试的 LLM 调用（计时仅覆盖生成本身）。
+// 成功后依次：以上报实际 token 用量（覆盖估算值）、把响应追加到 lc.history
+// （完整历史，而非压缩/nudge 副本）。失败时记录 interactionErr 并返回包装后的错误。
+func (lc *loopContext) generateTurn(turnCtx context.Context, in turnInput) (*schema.Message, time.Duration, error) {
+	llmStart := time.Now()
+	responseMsg, usage, err := lc.engine.generateWithRetry(turnCtx, lc.em, lc.turns, in.history, in.toolDefs)
+	if err != nil {
+		lc.interactionErr = err
+		return nil, 0, fmt.Errorf("模型生成失败 (turn %d): %w", lc.turns, err)
+	}
+	llmDuration := time.Since(llmStart)
+
+	// 用实际 API 返回的 token 用量更新显示，替代 prepareTurnInput 阶段的估算值。
+	if usage != nil && usage.InputTokens > 0 {
+		lc.em.tokenUpdate(usage.InputTokens, lc.engine.contextWindow)
+	}
+
+	// 响应追加到完整历史：压缩副本只影响当次 LLM 输入，本地历史必须完整增长，
+	// 否则后续轮次将丢失本条 assistant 消息（Anthropic 交替约束也会被破坏）。
+	lc.history = append(lc.history, *responseMsg)
+	return responseMsg, llmDuration, nil
+}
+
+// trackStall 更新停滞计数：本轮调用了进展工具（write_file/edit_file）则归零，否则累加。
+// 计数驱动 prepareTurnInput 中的停滞 nudge 注入。
+func (lc *loopContext) trackStall(calls []schema.ToolCall) {
+	if hasProgressTool(calls) {
+		lc.turnsSinceProgress = 0
+	} else {
+		lc.turnsSinceProgress++
+	}
+}
+
+// injectObservations 将工具执行结果作为 Observation（user 角色）逐条注入历史并返回新历史。
+// 顺序与 toolCalls 一致（executeTools 已按索引写入保证）。
+// 空输出兜底为占位文案：部分 backend 拒绝空 content 的 tool_result（返回 400，
+// 在无重试时直接杀实例），且空 Observation 无信息可供模型推理、浪费一轮。
+func injectObservations(history []schema.Message, toolCalls []schema.ToolCall, results []schema.ToolResult) []schema.Message {
+	for i, toolCall := range toolCalls {
+		content := results[i].Output
+		if content == "" {
+			content = "[工具执行完成，无输出]"
+		}
+		history = append(history, schema.Message{
+			Role:       schema.RoleUser,
+			Content:    content,
+			ToolCallID: toolCall.ID,
+			// 透传结构化错误信号，供 Provider 设置 tool_result.is_error，强化自愈。
+			IsError: results[i].IsError,
+		})
+	}
+	return history
+}
+
+// saveHistory 将本次 Run 新增的消息（history[startLen:]）写回 Session。
+// 仅在自然终止路径调用（MaxTurns / ctx 取消 / LLM 失败时丢弃整条轨迹，与既有语义一致）。
+func (lc *loopContext) saveHistory(ctx context.Context) {
+	lc.engine.saveHistoryWith(ctx, lc.sess, lc.history, lc.startLen, lc.logPrefix)
+}
+
+// saveTodos 将 TodoStore 持久化到 Session（write-replace）。
+// 以 defer 注册、在所有退出路径执行；失败仅记录告警，不影响 Run 结果。
+func (lc *loopContext) saveTodos(ctx context.Context) {
+	if lc.sess == nil || lc.todoStore == nil {
+		return
+	}
+	if err := lc.sess.SaveTodos(ctx, lc.todoStore.Read()); err != nil {
+		log.Print(logfmt.FormatMsg(lc.logPrefix, fmt.Sprintf("保存 todos 失败: %v", err)))
+	}
+}

--- a/internal/engine/loop_phases_test.go
+++ b/internal/engine/loop_phases_test.go
@@ -47,7 +47,7 @@ func TestBackoffDelay(t *testing.T) {
 		{"第 4 次失败 8 倍", 1 * time.Second, 4, 30 * time.Second, 8 * time.Second},
 		{"超过上限按上限封顶", 1 * time.Second, 10, 30 * time.Second, 30 * time.Second},
 		{"移位溢出防护：超大 attempt 取上限而非 0", 1 * time.Second, 100, 30 * time.Second, 30 * time.Second},
-		{"移位溢出防护： attempt 恰在位宽边界", 1 * time.Second, 64, 60 * time.Second, 60 * time.Second},
+		{"移位溢出防护：attempt 恰在位宽边界", 1 * time.Second, 64, 60 * time.Second, 60 * time.Second},
 		{"负数 attempt 按第 1 次处理", 500 * time.Millisecond, -3, 30 * time.Second, 500 * time.Millisecond},
 	}
 	for _, tt := range tests {

--- a/internal/engine/loop_phases_test.go
+++ b/internal/engine/loop_phases_test.go
@@ -1,0 +1,219 @@
+// loop_phases_test.go 覆盖 runLoop 阶段化拆分后暴露出的可独立测试路径：
+// 指数退避计算、provider 空响应防护、压缩视图与完整历史的隔离、Observation 注入。
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/planning"
+	"github.com/harness9/internal/schema"
+)
+
+// noopEmitter 返回全回调为空实现的 emitter，供直接调用阶段方法的测试使用
+// （runLoop 真实路径中 emitter 各回调恒非 nil，此处仅为满足调用前提）。
+func noopEmitter() emitter {
+	return emitter{
+		generate: func(context.Context, int, []schema.Message, []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+			return nil, nil, nil
+		},
+		toolStart:   func(int, schema.ToolCall) {},
+		toolDone:    func(int, schema.ToolCall, schema.ToolResult, time.Duration) {},
+		tokenUpdate: func(int, int) {},
+		compaction:  func(memory.CompactionRecord) {},
+	}
+}
+
+// TestBackoffDelay 验证指数退避计算的封顶与移位溢出防护。
+// 回归背景：旧实现 `base << (attempt-1)` 未封顶移位数，attempt ≥ 65 时
+// Go 移位结果为 0，退避塌缩为 0、退化为无间隔高频重试。
+func TestBackoffDelay(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     time.Duration
+		attempt  int
+		maxDelay time.Duration
+		want     time.Duration
+	}{
+		{"第 1 次失败按基准退避", 1 * time.Second, 1, 30 * time.Second, 1 * time.Second},
+		{"第 2 次失败翻倍", 1 * time.Second, 2, 30 * time.Second, 2 * time.Second},
+		{"第 4 次失败 8 倍", 1 * time.Second, 4, 30 * time.Second, 8 * time.Second},
+		{"超过上限按上限封顶", 1 * time.Second, 10, 30 * time.Second, 30 * time.Second},
+		{"移位溢出防护：超大 attempt 取上限而非 0", 1 * time.Second, 100, 30 * time.Second, 30 * time.Second},
+		{"移位溢出防护： attempt 恰在位宽边界", 1 * time.Second, 64, 60 * time.Second, 60 * time.Second},
+		{"负数 attempt 按第 1 次处理", 500 * time.Millisecond, -3, 30 * time.Second, 500 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backoffDelay(tt.base, tt.attempt, tt.maxDelay); got != tt.want {
+				t.Errorf("backoffDelay(%v, %d, %v) = %v, want %v", tt.base, tt.attempt, tt.maxDelay, got, tt.want)
+			}
+		})
+	}
+}
+
+// nilOnceProvider 首次调用返回 (nil, nil, nil)——违反 Provider 契约的空响应，
+// 其后正常返回，用于验证 generateWithRetry 的空响应防护（应视为可重试错误）。
+type nilOnceProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *nilOnceProvider) Generate(_ context.Context, _ []schema.Message, _ []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls++
+	if p.calls == 1 {
+		return nil, nil, nil
+	}
+	return &schema.Message{Role: schema.RoleAssistant, Content: "ok"}, nil, nil
+}
+
+func (p *nilOnceProvider) GenerateStream(ctx context.Context, msgs []schema.Message, td []schema.ToolDefinition) (<-chan schema.StreamChunk, error) {
+	msg, _, err := p.Generate(ctx, msgs, td)
+	if err != nil {
+		return nil, err
+	}
+	ch := make(chan schema.StreamChunk, 1)
+	go func() {
+		defer close(ch)
+		ch <- schema.StreamChunk{Type: schema.StreamChunkDone, Message: msg}
+	}()
+	return ch, nil
+}
+
+// TestGenerateRetry_NilMessageTreatedAsRetryable 验证：Provider 返回空响应（nil message
+// 且 nil error）不会 panic，而是作为可重试错误处理；重试成功后 Run 正常收敛。
+// 防护缺失时 runLoop 对 nil 解引用会直接崩溃整个实例。
+func TestGenerateRetry_NilMessageTreatedAsRetryable(t *testing.T) {
+	p := &nilOnceProvider{}
+	r := &staticRegistry{output: "ok"}
+	eng := NewAgentEngine(p, r, "/test", WithGenerateRetry(3, time.Millisecond))
+
+	if err := eng.Run(context.Background(), "task"); err != nil {
+		t.Fatalf("空响应应触发重试并恢复，got: %v", err)
+	}
+	if p.calls != 2 {
+		t.Errorf("应尝试 2 次（空响应 + 正常响应），实际 %d", p.calls)
+	}
+}
+
+// TestPrepareTurnInput_CompactionDoesNotMutateHistory 验证压缩视图隔离不变量：
+// prepareTurnInput 返回的 input.history 是压缩后的临时视图，引擎本地的
+// lc.history 必须保持完整——这是后续轮次能看到全部上下文的前提。
+func TestPrepareTurnInput_CompactionDoesNotMutateHistory(t *testing.T) {
+	p := &countingProvider{
+		responses: []func([]schema.ToolDefinition) *schema.Message{
+			func(_ []schema.ToolDefinition) *schema.Message {
+				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
+			},
+		},
+	}
+	reg := &staticRegistry{tools: []schema.ToolDefinition{{Name: "bash"}}, output: "ok"}
+	eng := NewAgentEngine(p, reg, "/test",
+		WithCompactor(&memory.SlidingWindowCompactor{MaxMessages: 3}),
+	)
+
+	// prepareTurnInput 会调用 emitter 回调（压缩通知 / token 上报），
+	// 测试场景使用 no-op 实现。
+	lc := eng.beginInteraction(context.Background(), "hello", "engine", noopEmitter())
+	// 构造超过压缩阈值的历史（system + 5 条 + user = 7 条）。
+	for i := 0; i < 5; i++ {
+		lc.history = append(lc.history,
+			schema.Message{Role: schema.RoleUser, Content: fmt.Sprintf("q%d", i)},
+			schema.Message{Role: schema.RoleAssistant, Content: fmt.Sprintf("a%d", i)},
+		)
+	}
+	before := append([]schema.Message(nil), lc.history...)
+
+	input, _ := lc.prepareTurnInput()
+
+	if len(input.history) > 3 {
+		t.Errorf("发送视图应被压缩到 ≤3 条，实际 %d", len(input.history))
+	}
+	if len(lc.history) != len(before) {
+		t.Errorf("完整历史不应被压缩修改：before=%d after=%d", len(before), len(lc.history))
+	}
+	for i := range before {
+		if before[i].Content != lc.history[i].Content {
+			t.Errorf("完整历史第 %d 条被修改: %q → %q", i, before[i].Content, lc.history[i].Content)
+		}
+	}
+}
+
+// TestInjectObservations 验证 Observation 注入的三条不变量：
+// user 角色 + ToolCallID 关联、空输出兜底为占位文案、IsError 透传（驱动 Provider
+// 设置 tool_result.is_error，强化自愈信号）。
+func TestInjectObservations(t *testing.T) {
+	calls := []schema.ToolCall{
+		{ID: "c1", Name: "bash", Arguments: []byte(`{}`)},
+		{ID: "c2", Name: "read_file", Arguments: []byte(`{}`)},
+	}
+	results := []schema.ToolResult{
+		{ToolCallID: "c1", Output: "file list"},       // 正常输出
+		{ToolCallID: "c2", Output: "", IsError: true}, // 空输出 + 错误标记
+	}
+
+	history := injectObservations([]schema.Message{{Role: schema.RoleSystem, Content: "sys"}}, calls, results)
+
+	if len(history) != 3 {
+		t.Fatalf("应注入 2 条 Observation，实际 %d 条", len(history)-1)
+	}
+	obs1 := history[1]
+	if obs1.Role != schema.RoleUser || obs1.ToolCallID != "c1" {
+		t.Errorf("Observation 应为 user 角色且携带 ToolCallID，got %+v", obs1)
+	}
+	if obs1.Content != "file list" {
+		t.Errorf("正常输出应原样注入，got %q", obs1.Content)
+	}
+	obs2 := history[2]
+	if obs2.Content != "[工具执行完成，无输出]" {
+		t.Errorf("空输出应兜底为占位文案，got %q", obs2.Content)
+	}
+	if !obs2.IsError {
+		t.Error("IsError 应透传到 Observation 消息")
+	}
+}
+
+// TestBeginTurn_RejectsOverMaxTurns 验证 beginTurn 阶段的 MaxTurns 判定与
+// interactionErr 记录（OnInteractionEnd 依赖该字段上报错误）。
+func TestBeginTurn_RejectsOverMaxTurns(t *testing.T) {
+	p := &countingProvider{}
+	reg := &staticRegistry{output: "ok"}
+	eng := NewAgentEngine(p, reg, "/test", WithMaxTurns(2))
+
+	lc := eng.beginInteraction(context.Background(), "hello", "engine", emitter{})
+	lc.turns = 2 // 模拟已完成 2 轮
+
+	_, err := lc.beginTurn(context.Background())
+	if err == nil {
+		t.Fatal("超过 MaxTurns 应返回错误")
+	}
+	if lc.interactionErr == nil {
+		t.Error("interactionErr 应被记录，供 OnInteractionEnd 上报")
+	}
+}
+
+// TestApplyPlanModePrefix 验证 Plan Mode 前缀注入的开关行为：
+// Plan 模式加前缀且保留原始 prompt，其余模式原样返回。
+func TestApplyPlanModePrefix(t *testing.T) {
+	const prompt = "implement feature X"
+
+	if got := applyPlanModePrefix(planning.PlanModeDefault, prompt); got != prompt {
+		t.Errorf("Default 模式不应注入前缀，got %q", got)
+	}
+	if got := applyPlanModePrefix(planning.PlanModeAutoEdit, prompt); got != prompt {
+		t.Errorf("AutoEdit 模式不应注入前缀，got %q", got)
+	}
+	plan := applyPlanModePrefix(planning.PlanModePlan, prompt)
+	if plan == prompt {
+		t.Error("Plan 模式应注入规划前缀")
+	}
+	if len(plan) <= len(prompt) || plan[len(plan)-len(prompt):] != prompt {
+		t.Error("原始 prompt 应保留在前缀之后")
+	}
+}

--- a/internal/engine/loop_phases_test.go
+++ b/internal/engine/loop_phases_test.go
@@ -3,8 +3,11 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -130,7 +133,7 @@ func TestPrepareTurnInput_CompactionDoesNotMutateHistory(t *testing.T) {
 	}
 	before := append([]schema.Message(nil), lc.history...)
 
-	input, _ := lc.prepareTurnInput()
+	input := lc.prepareTurnInput()
 
 	if len(input.history) > 3 {
 		t.Errorf("发送视图应被压缩到 ≤3 条，实际 %d", len(input.history))
@@ -215,5 +218,84 @@ func TestApplyPlanModePrefix(t *testing.T) {
 	}
 	if len(plan) <= len(prompt) || plan[len(plan)-len(prompt):] != prompt {
 		t.Error("原始 prompt 应保留在前缀之后")
+	}
+}
+
+// ctxMarkKey 是 ctx 传播回归测试的自定义 key（模拟 observer 注入的 Span 等值）。
+type ctxMarkKey struct{}
+
+// markingObserver 在 OnInteractionStart 向 ctx 注入标记，并检测 OnTurnStart
+// 是否仍能读到。回归背景：runLoop 阶段化拆分时曾把原始 ctx 而非 obsCtx 传给
+// beginTurn/saveTodos/saveHistory——OTELEngineObserver 的 interaction→turn
+// Span 父子关系依赖 OnInteractionStart 注入 ctx 值，断链后所有 Span 退化为
+// 根 Span，Langfuse trace 分组静默失效。
+type markingObserver struct {
+	noopObserver
+	turnStartSawMark bool
+}
+
+func (m *markingObserver) OnInteractionStart(ctx context.Context, _, _ string) context.Context {
+	return context.WithValue(ctx, ctxMarkKey{}, "marked")
+}
+
+func (m *markingObserver) OnTurnStart(ctx context.Context, _ int) context.Context {
+	if _, ok := ctx.Value(ctxMarkKey{}).(string); ok {
+		m.turnStartSawMark = true
+	}
+	return ctx
+}
+
+// TestRunLoop_ObserverCtxPropagation 验证 observer 不变量：OnInteractionStart
+// 注入的 ctx 值必须在 OnTurnStart 阶段仍可读——runLoop 必须向所有阶段传递
+// obsCtx 而非原始 ctx。
+func TestRunLoop_ObserverCtxPropagation(t *testing.T) {
+	p := &countingProvider{
+		responses: []func([]schema.ToolDefinition) *schema.Message{
+			func(_ []schema.ToolDefinition) *schema.Message {
+				return &schema.Message{Role: schema.RoleAssistant, Content: "done"}
+			},
+		},
+	}
+	reg := &staticRegistry{output: "ok"}
+	obs := &markingObserver{}
+	eng := NewAgentEngine(p, reg, "/test", WithEngineObserver(obs))
+
+	if err := eng.Run(context.Background(), "hello"); err != nil {
+		t.Fatalf("Run 失败: %v", err)
+	}
+	if !obs.turnStartSawMark {
+		t.Error("OnTurnStart 应能读到 OnInteractionStart 注入的 ctx 值（obsCtx 必须贯穿所有阶段）")
+	}
+}
+
+// TestGenerateRetry_UsesLogPrefix 验证重试日志使用调用方传入的 logPrefix
+// （流式模式为 "engine-stream"），而非硬编码 "engine"。
+func TestGenerateRetry_UsesLogPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() { log.SetOutput(prevOut); log.SetFlags(prevFlags) }()
+
+	eng := NewAgentEngine(&countingProvider{}, &staticRegistry{output: "ok"}, "/test",
+		WithGenerateRetry(2, time.Millisecond))
+	calls := 0
+	em := emitter{generate: func(context.Context, int, []schema.Message, []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+		calls++
+		if calls == 1 {
+			return nil, nil, fmt.Errorf("transient failure")
+		}
+		return &schema.Message{Role: schema.RoleAssistant, Content: "ok"}, nil, nil
+	}}
+
+	msg, _, err := eng.generateWithRetry(context.Background(), em, 1, "engine-stream", nil, nil)
+	if err != nil {
+		t.Fatalf("generateWithRetry 应在重试后恢复: %v", err)
+	}
+	if msg == nil || msg.Content != "ok" {
+		t.Errorf("应返回重试成功的响应，got %+v", msg)
+	}
+	if !strings.Contains(buf.String(), "engine-stream") {
+		t.Errorf("重试日志应使用传入的 logPrefix %q，实际输出: %q", "engine-stream", buf.String())
 	}
 }

--- a/internal/engine/options.go
+++ b/internal/engine/options.go
@@ -1,0 +1,148 @@
+// Package engine — AgentEngine 的函数式配置选项。
+//
+// 所有选项统一采用 `With` 前缀（见 AGENTS.md §3.2 命名规范），在 NewAgentEngine
+// 构造时一次性注入。运行期可变的个别状态（session / planMode）另提供线程安全的
+// Set* 方法，供 TUI goroutine 跨 goroutine 调用；修改仅对下一次 Run/RunStream 生效。
+package engine
+
+import (
+	"time"
+
+	"github.com/harness9/internal/memory"
+	"github.com/harness9/internal/planning"
+)
+
+// Option 是 AgentEngine 的函数选项。
+type Option func(*AgentEngine)
+
+// WithMaxTurns 设置单次 Run 允许的最大 Turn 数，0 或负数表示不限制。
+func WithMaxTurns(n int) Option {
+	return func(e *AgentEngine) { e.maxTurns = n }
+}
+
+// WithToolTimeout 设置单个工具执行的超时时间，0 表示使用 context 原始截止时间。
+func WithToolTimeout(d time.Duration) Option {
+	return func(e *AgentEngine) { e.toolTimeout = d }
+}
+
+// WithMaxConcurrentTools 设置同一 Turn 内最大并发工具数，0 或负数表示不限制。
+func WithMaxConcurrentTools(n int) Option {
+	return func(e *AgentEngine) { e.maxConcurrentTools = n }
+}
+
+// WithContextWindow 设置模型的最大 context window（tokens），用于 TUI token 使用率展示。
+// 通常通过 provider.GetModelLimits(modelName).ContextTokens 获取。
+func WithContextWindow(tokens int) Option {
+	return func(e *AgentEngine) { e.contextWindow = tokens }
+}
+
+// WithGenerateRetry 配置 LLM 生成调用的应用层重试：最多尝试 attempts 次，
+// 首次重试退避 baseDelay，其后指数增长（上限 maxGenerateRetryDelay）。
+//
+// 这是对 SDK 内置重试的补充：SDK 的重试只覆盖"首字节到达前"的连接错误，
+// 而流式响应中途断连（mid-stream EOF / 代理超时 / 5xx after headers）会以
+// StreamChunkError 形式逃逸到引擎层，旧实现直接终止整个 agent loop（丢掉整条轨迹）。
+// 此重试在保持 context 取消语义的前提下，把"一次瞬时抖动杀实例"变为可恢复事件。
+// attempts<=1 时关闭重试（仅尝试一次）。
+func WithGenerateRetry(attempts int, baseDelay time.Duration) Option {
+	return func(e *AgentEngine) {
+		e.generateRetries = attempts
+		e.generateRetryBase = baseDelay
+	}
+}
+
+// WithNetworkRetry 配置网络传输层错误（TLS/DNS/连接建立，见 isTransientNetworkError）
+// 的独立重试预算：最多尝试 attempts 次，首次重试退避 baseDelay，其后指数增长
+// （上限 maxNetworkRetryDelay）。这类错误比业务层错误（4xx/5xx）间歇性更强，
+// 默认的 WithGenerateRetry 预算（默认 3 次、总计约 3s）对它们太窄——Terminal-Bench
+// pilot 里 3 个任务在 Turn 1 就命中同一条 x509 证书错误，退避耗尽后直接放弃整个 turn
+// （见 docs/技术调研/terminal-bench-轨迹分析-v1.md §2 R2）。attempts<=1 时该扩展形同
+// 关闭——网络错误仅尝试 1 次，不再享有比默认预算更宽松的窗口（不会退化为借用
+// WithGenerateRetry 的预算，两者预算互相独立）。
+func WithNetworkRetry(attempts int, baseDelay time.Duration) Option {
+	return func(e *AgentEngine) {
+		e.networkRetries = attempts
+		e.networkRetryBase = baseDelay
+	}
+}
+
+// WithMemoryNudge 配置长期记忆 nudge：每隔 interval 个 turn 在发送给 LLM 的历史中
+// 注入一行 text 提示（仅注入到临时副本，不持久化）。interval<=0 时关闭。
+func WithMemoryNudge(interval int, text string) Option {
+	return func(e *AgentEngine) {
+		e.nudgeInterval = interval
+		e.nudgeText = text
+	}
+}
+
+// WithStallNudge 配置停滞 nudge：当连续 window 个"使用了工具但未调用任何进展工具
+// （edit_file/write_file）"的 turn 后，向发送给 LLM 的历史副本注入一次 text 提示，
+// 然后重置计数。用于打断"反复静态重读却不收敛"的空转（SWE-bench 轨迹中 xarray-3364、
+// pylint-7080 烧满 80 轮即此形态）。
+//
+// 与 WithMemoryNudge 一致：仅注入到临时副本，绝不持久化、不累积；window<=0 时关闭。
+// 进展工具集合见 progressToolNames。
+func WithStallNudge(window int, text string) Option {
+	return func(e *AgentEngine) {
+		e.stallWindow = window
+		e.stallText = text
+	}
+}
+
+// WithEngineObserver 注册引擎生命周期观察者，供可观测层（OpenTelemetry 等）无侵入接入。
+func WithEngineObserver(o EngineObserver) Option {
+	return func(e *AgentEngine) { e.observer = o }
+}
+
+// WithPromptBuilder 设置自定义 PromptBuilder。未设置时使用内置默认文案。
+func WithPromptBuilder(pb PromptBuilder) Option {
+	return func(e *AgentEngine) { e.promptBuilder = pb }
+}
+
+// WithSession 绑定 Session，使 runLoop 在启动时加载历史、结束时保存新消息。
+func WithSession(s memory.Session) Option {
+	return func(e *AgentEngine) { e.session = s }
+}
+
+// WithCompactor 绑定上下文压缩策略，在每次 LLM 调用前裁剪历史消息。
+func WithCompactor(c memory.Compactor) Option {
+	return func(e *AgentEngine) { e.compactor = c }
+}
+
+// WithPlanMode 设置 Agent 的初始执行模式。
+// runLoop 在启动时会快照此值，循环内不会受后续 SetPlanMode 调用影响。
+func WithPlanMode(mode planning.PlanMode) Option {
+	return func(e *AgentEngine) { e.planMode = mode }
+}
+
+// WithTodoStore 绑定 TodoStore，使引擎在 runLoop 生命周期中自动执行以下操作：
+//   - 启动时：从 Session 恢复 TodoStore 状态（跨会话续接未完成任务）
+//   - 结束时：通过 defer 将 TodoStore 保存到 Session（所有路径均执行）
+func WithTodoStore(s *planning.TodoStore) Option {
+	return func(e *AgentEngine) { e.todoStore = s }
+}
+
+// SetSession 替换当前绑定的 Session，供 TUI /new、/resume 命令切换会话时调用。
+// 线程安全：可从任意 goroutine 调用（如 TUI goroutine），内部以写锁保护。
+// 注意：修改对当前正在运行的 runLoop 无影响（runLoop 在入口快照 session 值）。
+func (e *AgentEngine) SetSession(s memory.Session) {
+	e.mu.Lock()
+	e.session = s
+	e.mu.Unlock()
+}
+
+// SetPlanMode 线程安全地更新当前执行模式。TUI Shift+Tab 键调用此方法。
+// 注意：修改对当前正在运行的 runLoop 无影响（runLoop 在入口快照 planMode 值），
+// 仅在下一次 Run/RunStream 调用时生效。
+func (e *AgentEngine) SetPlanMode(mode planning.PlanMode) {
+	e.mu.Lock()
+	e.planMode = mode
+	e.mu.Unlock()
+}
+
+// PromptBuilder 构造 Agent 的 system prompt。
+// 接口定义在 engine 包（使用者侧），由 internal/context 包实现。
+// 引擎通过此接口与 Context Engineering 模块解耦。
+type PromptBuilder interface {
+	Build() string
+}

--- a/internal/engine/planmode.go
+++ b/internal/engine/planmode.go
@@ -1,0 +1,88 @@
+// Package engine — Plan Mode 与 nudge 相关的工具集判定逻辑。
+//
+// Plan Mode 的核心原则：工具层硬约束优先于 prompt 层软约束。
+// 写操作工具直接从传给 LLM 的工具列表中移除（filterReadOnlyTools），
+// 确保模型无论处于何种上下文状态都无法调用它们；prompt 前缀只补充
+// 无法在工具层表达的行为规则（如 bash 只读命令约束）。
+package engine
+
+import (
+	"github.com/harness9/internal/planning"
+	"github.com/harness9/internal/schema"
+)
+
+// planModePromptPrefix 是 Plan Mode 下注入到用户 prompt 前的规划指令前缀。
+// 要求计划条目一一对应可执行动作，避免产出"需求澄清/方案设计"等无法落地的空计划。
+const planModePromptPrefix = "分析以下请求，用 todo_write 输出一份可直接执行的实现计划，然后用纯文字简述计划后停止。\n" +
+	"todo 项要求：每条对应一个具体的实现动作（例如：创建某文件、实现某函数、运行某命令），\n" +
+	"而非高层规划描述（禁止写\"需求澄清\"、\"方案设计\"之类无法直接执行的条目）。\n" +
+	"如需了解当前代码库，可使用 read_file 或 bash（只读命令：ls、cat、find、grep）。\n" +
+	"不要创建文件、执行 build/install 或做任何实际修改。\n\n"
+
+// planModeWhitelist 是 Plan Mode 下允许 LLM 调用的工具名称白名单（read-only map，安全并发读）。
+//
+// 白名单的设计意图：
+//   - read_file / bash：允许探索代码库，但 prompt 层约束 bash 只使用只读命令（ls/cat/find/grep）
+//   - todo_write：Plan Mode 的核心产出——LLM 通过此工具输出结构化实现计划
+//   - use_skill：允许加载 Skills 获取项目规范文档
+//   - write_file / edit_file：不在白名单，从工具列表中硬性移除（工具层硬约束，优于 prompt 层软约束）
+//   - web_search / web_fetch：不在白名单；Plan Mode 专注于本地代码库探索，
+//     网络访问不属于规划阶段所需能力，如需联网研究请使用 Default/AutoEdit 模式
+//   - memory_search / memory_write：不在白名单；Plan Mode 是轻量规划阶段，不触发记忆读写，
+//     避免规划过程产生副作用（如写入错误的记忆条目）；记忆操作在 Default/AutoEdit 模式下可用
+//   - task：不在白名单；Plan Mode 仅生成计划，不触发子代理委派（委派是执行阶段的动作）
+var planModeWhitelist = map[string]bool{
+	"read_file":  true,
+	"bash":       true,
+	"use_skill":  true,
+	"todo_write": true,
+}
+
+// progressToolNames 是被视为"取得实质进展"的工具集合（用于 WithStallNudge 停滞检测）。
+// 调用其一即重置停滞计数：它们改变工作区状态（写入/编辑文件），是 Agent 真正推进任务的信号。
+// 只读探索（read_file/bash grep 等）不计入进展，连续多轮只读即被判定为停滞。
+var progressToolNames = map[string]bool{
+	"write_file": true,
+	"edit_file":  true,
+}
+
+// hasProgressTool 判断本轮工具调用中是否包含进展工具。
+func hasProgressTool(calls []schema.ToolCall) bool {
+	for _, tc := range calls {
+		if progressToolNames[tc.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// appendUserNudge 返回在历史副本末尾追加一条 user nudge 消息的新切片。
+// 不修改入参、不持久化——nudge 仅对当轮发送给 LLM 的临时副本可见。
+func appendUserNudge(history []schema.Message, text string) []schema.Message {
+	withNudge := make([]schema.Message, len(history), len(history)+1)
+	copy(withNudge, history)
+	return append(withNudge, schema.Message{Role: schema.RoleUser, Content: text})
+}
+
+// filterReadOnlyTools 从工具定义列表中过滤出 planModeWhitelist 中的子集，
+// 在 Plan Mode 下替代完整工具列表传递给 LLM。
+// 使用工具层硬约束而非 prompt 层软约束，确保 LLM 无论在何种上下文状态下都无法访问被过滤的工具。
+func filterReadOnlyTools(tools []schema.ToolDefinition) []schema.ToolDefinition {
+	// 预分配容量为全量列表长度：白名单场景下通常保留大多数工具，
+	// 一次分配优于多次 append 扩容。
+	result := make([]schema.ToolDefinition, 0, len(tools))
+	for _, t := range tools {
+		if planModeWhitelist[t.Name] {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// applyPlanModePrefix 在 Plan Mode 下为用户 prompt 注入规划指令前缀。
+func applyPlanModePrefix(mode planning.PlanMode, userPrompt string) string {
+	if mode != planning.PlanModePlan {
+		return userPrompt
+	}
+	return planModePromptPrefix + userPrompt
+}

--- a/internal/engine/retry.go
+++ b/internal/engine/retry.go
@@ -1,0 +1,147 @@
+// Package engine — LLM 生成调用的应用层重试策略。
+//
+// 设计动机：SDK 内置重试只覆盖"首字节到达前"的连接错误，流式响应中途断连
+// 会以 StreamChunkError 形式逃逸到引擎层；一次瞬时抖动不应杀掉整条 agent 轨迹。
+// 重试分两档独立预算：默认预算（业务层瞬时错误）与网络预算（TLS/DNS/连接建立），
+// 后者更宽松，两者互不借用。
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/harness9/internal/logfmt"
+	"github.com/harness9/internal/schema"
+)
+
+// maxGenerateRetryDelay 是生成重试指数退避的上限，避免退避时间吞掉整体预算。
+const maxGenerateRetryDelay = 30 * time.Second
+
+// maxNetworkRetryDelay 是网络传输层错误重试指数退避的上限，比 maxGenerateRetryDelay
+// 更宽松——这类故障（TLS/DNS/连接建立）间歇性更强，值得多等一会儿而不是放弃整个 turn。
+const maxNetworkRetryDelay = 60 * time.Second
+
+// retryBudget 聚合一档重试预算的三要素：最大尝试次数、指数退避基准、退避上限。
+// 默认预算与网络预算各持有一份，互不共享。
+type retryBudget struct {
+	maxAttempts int
+	baseDelay   time.Duration
+	capDelay    time.Duration
+}
+
+// generateWithRetry 在 em.generate 之上叠加有界指数退避重试。
+//
+// 重试策略：
+//   - 成功立即返回；
+//   - context 已取消/超时（ctx.Err()!=nil）不重试，原样返回（会话级终止信号）；
+//   - 其余错误视为可能瞬时，按错误类别选用预算（网络错误用独立宽松预算），
+//     退避后重试，直到耗尽 attempts；
+//   - 退避期间感知 ctx 取消，避免无谓等待。
+func (e *AgentEngine) generateWithRetry(ctx context.Context, em emitter, turn int, history []schema.Message, toolDefs []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+	defaultBudget := retryBudget{
+		maxAttempts: max(e.generateRetries, 1),
+		baseDelay:   orDefault(e.generateRetryBase, time.Second),
+		capDelay:    maxGenerateRetryDelay,
+	}
+	networkBudget := retryBudget{
+		maxAttempts: max(e.networkRetries, 1),
+		baseDelay:   orDefault(e.networkRetryBase, 5*time.Second),
+		capDelay:    maxNetworkRetryDelay,
+	}
+
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+		msg, usage, err := em.generate(ctx, turn, history, toolDefs)
+		if err == nil && msg == nil {
+			// 防御：Provider 契约要求 err==nil 时 msg 非 nil。空响应若直接放行，
+			// runLoop 对其解引用会 panic 导致整个实例崩溃；视为可重试的异常返回。
+			err = fmt.Errorf("provider 返回了空响应（message 为 nil）")
+		}
+		if err == nil {
+			return msg, usage, nil
+		}
+		lastErr = err
+		// context 取消/超时不重试。
+		if ctx.Err() != nil {
+			return nil, nil, err
+		}
+
+		// 网络传输层错误（TLS/DNS/连接建立）间歇性更强，用独立、更宽松的预算，
+		// 不与其他错误类别共享 attempts/base——分类基于本次失败的错误本身，
+		// 不影响非网络错误仍然只用默认预算。
+		budget := defaultBudget
+		if isTransientNetworkError(err) {
+			budget = networkBudget
+		}
+		if attempt >= budget.maxAttempts {
+			break
+		}
+
+		delay := backoffDelay(budget.baseDelay, attempt, budget.capDelay)
+		log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
+			"LLM 生成失败 (turn %d, 尝试 %d/%d)，%s 后重试: %v", turn, attempt, budget.maxAttempts, delay, err)))
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return nil, nil, lastErr
+}
+
+// backoffDelay 计算第 attempt 次失败后的指数退避时长：base << (attempt-1)，以 maxDelay 封顶。
+//
+// 必须封顶移位数：Go 中移位数 ≥ 类型位宽时结果为 0，若不处理，超大 attempt 会使
+// 退避塌缩为 0，把有界指数退避退化为无间隔高频重试（撞击上游限流）。
+// 封顶为 maxDelay 与原语义一致——正常路径下延迟总会先于移位溢出触及上限。
+func backoffDelay(base time.Duration, attempt int, maxDelay time.Duration) time.Duration {
+	shift := attempt - 1
+	if shift < 0 {
+		shift = 0
+	}
+	// 2^32 倍已远超任何合理上限（1ns 基准下也是 ~4398s），直接取上限即可。
+	if shift > 32 {
+		return maxDelay
+	}
+	if d := base << uint(shift); d > maxDelay || d <= 0 {
+		return maxDelay
+	} else {
+		return d
+	}
+}
+
+// orDefault 返回 d 本身（>0 时），否则回退到 fallback，避免调用方零值配置导致 0 延迟。
+func orDefault(d, fallback time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return fallback
+}
+
+// isTransientNetworkError 判断 LLM 生成失败的根因是否为建立到 API 端点连接阶段的
+// 瞬时网络故障（TLS/证书校验、DNS 解析、连接建立），而非业务层错误（如 4xx/5xx）。
+// 这类故障间歇性更强，容错窗口需要比默认重试策略更宽——Terminal-Bench pilot 里
+// 3 个任务在同一条 x509 证书错误上耗尽默认预算后直接放弃整个 turn，详见
+// docs/技术调研/terminal-bench-轨迹分析-v1.md §2 R2。
+//
+// 采用字符串匹配而非 errors.As 类型断言：openai-go/anthropic-sdk-go 对底层
+// net/http 错误的包装不保证保留可断言的具体类型，但错误消息里的关键字符串
+// （x509:/tls:/no such host 等）是稳定、可观测的。
+func isTransientNetworkError(err error) bool {
+	msg := err.Error()
+	for _, marker := range []string{
+		"x509:", "tls:", "no such host", "connection refused",
+		"connection reset", "i/o timeout", "dial tcp",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/retry.go
+++ b/internal/engine/retry.go
@@ -40,7 +40,10 @@ type retryBudget struct {
 //   - 其余错误视为可能瞬时，按错误类别选用预算（网络错误用独立宽松预算），
 //     退避后重试，直到耗尽 attempts；
 //   - 退避期间感知 ctx 取消，避免无谓等待。
-func (e *AgentEngine) generateWithRetry(ctx context.Context, em emitter, turn int, history []schema.Message, toolDefs []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
+//
+// logPrefix 用于重试日志前缀（阻塞模式 "engine"，流式模式 "engine-stream"），
+// 与 runLoop 的其余日志保持同一前缀约定。
+func (e *AgentEngine) generateWithRetry(ctx context.Context, em emitter, turn int, logPrefix string, history []schema.Message, toolDefs []schema.ToolDefinition) (*schema.Message, *schema.Usage, error) {
 	defaultBudget := retryBudget{
 		maxAttempts: max(e.generateRetries, 1),
 		baseDelay:   orDefault(e.generateRetryBase, time.Second),
@@ -84,7 +87,7 @@ func (e *AgentEngine) generateWithRetry(ctx context.Context, em emitter, turn in
 		}
 
 		delay := backoffDelay(budget.baseDelay, attempt, budget.capDelay)
-		log.Print(logfmt.FormatMsg("engine", fmt.Sprintf(
+		log.Print(logfmt.FormatMsg(logPrefix, fmt.Sprintf(
 			"LLM 生成失败 (turn %d, 尝试 %d/%d)，%s 后重试: %v", turn, attempt, budget.maxAttempts, delay, err)))
 		select {
 		case <-ctx.Done():

--- a/internal/engine/tools_exec.go
+++ b/internal/engine/tools_exec.go
@@ -1,0 +1,72 @@
+// Package engine — 同一 Turn 内多个工具调用的并发调度。
+package engine
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/harness9/internal/hooks"
+	"github.com/harness9/internal/logfmt"
+	"github.com/harness9/internal/schema"
+)
+
+// executeTools 并发执行所有工具调用，每个工具带有独立的超时控制。
+//
+// 并发模型（三重保障，见 AGENTS.md §3.4）：
+//   - 预分配 results 切片 + 按 idx 写入，保证结果顺序与 toolCalls 一致；
+//   - sync.WaitGroup 等待全部 goroutine 退出；
+//   - maxConcurrentTools > 0 时以带缓冲 channel 作信号量限制并发上限。
+//
+// 每个工具从 ctx 派生独立子 context（WithTimeout）：单个工具超时不影响
+// 同 Turn 内其他工具的执行；超时结果由 Registry 层转换为 IsError=true，
+// LLM 可据此观察并重试（自愈）。
+// toolStart / toolDone 回调在 per-tool goroutine 中并发调用，emitter 实现方需自行保证安全。
+func (e *AgentEngine) executeTools(ctx context.Context, turn int, toolCalls []schema.ToolCall, logPrefix string, em emitter) []schema.ToolResult {
+	log.Print(logfmt.FormatParallelTools(logPrefix, turn, len(toolCalls), e.maxConcurrentTools))
+
+	results := make([]schema.ToolResult, len(toolCalls))
+	var wg sync.WaitGroup
+
+	// 信号量：仅在配置了并发上限时创建，nil 表示不限制。
+	var sem chan struct{}
+	if e.maxConcurrentTools > 0 {
+		sem = make(chan struct{}, e.maxConcurrentTools)
+	}
+
+	for i, toolCall := range toolCalls {
+		wg.Add(1)
+		go func(idx int, tc schema.ToolCall) {
+			defer wg.Done()
+
+			if sem != nil {
+				sem <- struct{}{}
+				defer func() { <-sem }()
+			}
+
+			// 每工具独立超时：toolTimeout<=0 表示沿用 ctx 原始截止时间（不额外限制）。
+			toolCtx := ctx
+			var cancel context.CancelFunc
+			if e.toolTimeout > 0 {
+				toolCtx, cancel = context.WithTimeout(ctx, e.toolTimeout)
+				defer cancel()
+			}
+
+			// 审批回调注入 context：RunStream 模式下由事件循环驱动人类审批；
+			// 使用会话级 ctx 而非 toolCtx，确保人类决策时间不计入工具超时。
+			if em.approval != nil {
+				toolCtx = hooks.WithApprovalFn(toolCtx, em.approval)
+			}
+
+			em.toolStart(turn, tc)
+
+			start := time.Now()
+			results[idx] = e.registry.Execute(toolCtx, tc)
+			em.toolDone(turn, tc, results[idx], time.Since(start))
+		}(i, toolCall)
+	}
+
+	wg.Wait()
+	return results
+}


### PR DESCRIPTION
## 摘要

将 internal/engine 的 707 行"上帝文件" agent_loop.go 按职责拆分为 6 个单一职责文件，公开 API 与外部行为保持不变：

- **agent_loop.go（707→209 行）**：仅保留引擎结构、NewAgentEngine、emitter 与 runLoop 阶段编排器
- **loop_phases.go**：runLoop 阶段方法化（初始化 / Turn 前置 / 预处理 / 生成 / 注入 / 收尾），每阶段可独立测试
- **options.go / retry.go / history.go / planmode.go / tools_exec.go**：配置选项、双档重试、历史持久化、Plan Mode、并发工具调度各归其位

顺带修复 4 个真实缺陷：

1. 重试退避 \`base << (attempt-1)\` 在 attempt≥64 时移位溢出为 0，退化为无间隔高频重试
2. Provider 返回空响应 (nil, nil, nil) 时 Run 模式直接 panic
3. /compact 写回失败导致整条会话历史永久丢失（新增回滚 + 独立 5s 回滚 ctx）
4. 流式模式日志前缀硬编码 "engine"（含重试日志路径）

评审修复：obsCtx 贯穿 beginTurn/saveTodos/saveHistory，修复 OTEL observer Span 断链（OTEL_ENABLED=true 时 interaction→turn 嵌套静默失效）；prepareTurnInput 收敛单返回值；turnStart 计时口径恢复。

文档：docs/核心功能/* 与 docs/core-features-en/* 双语同步（6 篇 + AGENTS.md）。

## 测试计划

- [x] \`go build ./...\` / \`go vet ./...\` / \`gofmt -l .\` 全部通过
- [x] \`go test -count=1 ./...\` 24 包全绿（含 evals 黄金数据集 22 用例）
- [x] \`go test -race ./internal/engine/ ./internal/observability/\` 无数据竞争
- [x] 新增回归测试含红绿验证：TestRunLoop_ObserverCtxPropagation / TestGenerateRetry_UsesLogPrefix / TestBackoffDelay（移位溢出）