### PR TITLE
feat: 接入 OrcaRouter 网关作为可选 LLM Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,19 @@ OPENAI_BASE_URL=https://api.openai.com/v1
 # LLM_MODEL 指定使用的模型名称，未设置时默认 openai/gpt-4o-mini
 LLM_MODEL=openai/gpt-4o-mini
 
+# ---- OrcaRouter 网关（可选） ----
+# OrcaRouter（https://orcarouter.ai）是 OpenAI 兼容模型路由网关，
+# 一个 API Key 可访问多家上游模型，模型名沿用 provider 前缀（如 openai/gpt-4o-mini）。
+# 通过 LLM_PROVIDER 选择使用哪个端点：
+#   LLM_PROVIDER=orcarouter  强制走 OrcaRouter
+#   LLM_PROVIDER=openai      强制走上方 OPENAI_* 端点
+#   两者都不设置时自动探测：仅配置了 ORCAROUTER_API_KEY（无 OPENAI_API_KEY）→ OrcaRouter，
+#   其余情况沿用 OPENAI_* 端点（既有配置行为零变化）
+# LLM_PROVIDER=orcarouter
+# ORCAROUTER_API_KEY=sk-orca-xxxxxxxx
+# ORCAROUTER_BASE_URL 默认官方网关地址，自建/代理网关时才需要覆盖
+# ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+
 # ---- Anthropic 兼容 API ----
 ANTHROPIC_API_KEY=your-anthropic-api-key
 ANTHROPIC_BASE_URL=https://api.anthropic.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,11 +266,14 @@ harness9/
 │   ├── provider/                    # 大模型接口抽象与具体厂商 SDK 实现
 │   │   ├── interface.go             # LLMProvider 接口定义（Generate + GenerateStream）
 │   │   ├── openai.go                # OpenAI 兼容 API 适配器（支持 OpenRouter / Azure）；WithIncludeReasoning + extractReasoningContent
+│   │   ├── orcarouter.go            # OrcaRouter 网关适配器（NewOrcaRouterProvider + NewFromEnv 统一装配点；ORCAROUTER_* + LLM_PROVIDER 环境变量驱动）
 │   │   ├── anthropic.go             # Anthropic 兼容 API 适配器（Messages API）；WithThinkingBudget（extended thinking）
 │   │   ├── model_limits.go          # 已知模型上下文窗口注册表 + GetModelLimits（剥离前缀，未知回退 256K）
 │   │   ├── tool_call_accumulator.go # OpenAI/Anthropic 共享的流式工具调用累积器
 │   │   ├── anthropic_thinking_test.go # WithThinkingBudget 单元测试（含 clamp 测试）
 │   │   ├── openai_reasoning_test.go # WithIncludeReasoning + extractReasoningContent + auto-detect 测试
+│   │   ├── orcarouter_test.go       # OrcaRouter 构造器与 NewFromEnv 选择规则单元测试
+│   │   ├── orcarouter_live_test.go  # OrcaRouter 真实网关集成测试（未配置 Key 自动跳过，保持 CI 密封）
 │   │   └── providertest/            # 测试基础设施（仅在 _test 编译单元中可见）
 │   │       └── mock.go              # 确定性 mock provider（NewMock / NewMockWithCallback）
 │   ├── schema/                      # 跨组件共享的核心数据类型
@@ -455,7 +458,7 @@ harness9/
 | **memory** | Context Engineering：Session 接口、Manager（SQLite CRUD + WithToolResultsDir + DeleteSession 级联 GC + DB() 访问器）、SQLiteSession（WAL + 事务）、SummarizationCompactor（默认，LLM 摘要压缩 + 增量更新 + 错误回退）、TokenBudgetCompactor（回退，80% 阈值 + 孤立工具对双向修复）、SlidingWindowCompactor（回退方案）、token 估算工具；MemoryExtractor 接口 + WithMemoryExtractor（压缩前提取钩子） | ✅ |
 | **ltm** | Long-Term Memory：Store（`long_term_memories` 表 + standalone FTS5 `memories_fts`，复用 `state.db`，Add 签名去重 / Search FTS5 强化 / SoftDelete signature=NULL / List top-N / PurgeExpired / StaleCandidates）、Precis（MEMORY.md 物化视图，top-30 渲染 + 5KB 截断）、Extractor（LLM 压缩前事实提取，fail-open，实现 MemoryExtractor 接口）、Phase 3 接缝（Provider/Embedder/Consolidator + noopProvider） | ✅ |
 | **context** | DefaultPromptBuilder：System Prompt 结构化组装（基础 prompt + AGENTS.md + Skills 索引 + 规划准则 + offload 检索指引 + 长期记忆精华），WithOffloadEnabled 注入分页检索说明，WithLongTermMemory 接收读取闭包、每轮 Build 时实时重读 MEMORY.md 精华注入（写入即下一轮可见）；**每次 Build() 注入 `当前日期：YYYY-MM-DD`**（`time.Now()` 实时生成，防止 Agent 因训练截止日期偏差产生陈旧搜索词） | ✅ |
-| **provider** | LLM 统一接口 + OpenAI / Anthropic SDK 适配器 + 实际 token 用量提取（Usage 类型）+ 模型 context window 注册表；AnthropicProvider 支持 WithThinkingBudget（extended thinking，≥1024 clamp）；OpenAIProvider 支持 WithIncludeReasoning + OpenRouter 自动检测，流式中通过 extractReasoningContent 提取 reasoning_content / reasoning 字段 | ✅ |
+| **provider** | LLM 统一接口 + OpenAI / Anthropic SDK 适配器 + 实际 token 用量提取（Usage 类型）+ 模型 context window 注册表；AnthropicProvider 支持 WithThinkingBudget（extended thinking，≥1024 clamp）；OpenAIProvider 支持 WithIncludeReasoning + OpenRouter 自动检测，流式中通过 extractReasoningContent 提取 reasoning_content / reasoning 字段；OrcaRouter 网关一等支持（OpenAI 兼容模型路由网关，`NewOrcaRouterProvider` 复用 OpenAI 实现，`NewFromEnv` 依据 `ORCAROUTER_API_KEY` / `LLM_PROVIDER` 在 main / 子代理 / SWE-bench runner 间统一装配，推理内容无需 include_reasoning 标志） | ✅ |
 | **schema** | 跨组件共享的核心数据类型（Message、ToolCall、Usage 等）；StreamChunk 定义 text_delta / thinking_delta / done / error 四种流式增量类型 | ✅ |
 | **tools** | 工具注册表 + 内置工具（bash / read_file（offset/limit 分页）/ write_file / edit_file / plan_write / memory_write（add/update/remove + Precis 重建）/ memory_search（FTS5 检索 + 命中强化）/ web_search（DuckDuckGo，无 API Key）/ web_fetch（go-readability + html-to-markdown，Markdown 输出））+ 路径沙箱（safe_path.go）+ SSRF 防护（web_safety.go） | ✅ |
 | **env** | 零依赖 `.env` 配置加载器（系统变量优先） | ✅ |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ harness9 --help
 harness9 --version
 ```
 
-> For full install options, Anthropic/OpenRouter configuration, AGENTS.md setup, and FAQ, see the [Quick Start Guide](https://zhangshenao.github.io/harness9/docs/quick-start).
+> For full install options, Anthropic/OpenRouter/OrcaRouter configuration, AGENTS.md setup, and FAQ, see the [Quick Start Guide](https://zhangshenao.github.io/harness9/docs/quick-start).
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,7 @@ harness9 --help
 harness9 --version
 ```
 
-> 完整安装选项、Anthropic/OpenRouter 配置、AGENTS.md 设置和常见问题，见[快速启动指南](https://zhangshenao.github.io/harness9/zh/docs/quick-start)。
+> 完整安装选项、Anthropic/OpenRouter/OrcaRouter 配置、AGENTS.md 设置和常见问题，见[快速启动指南](https://zhangshenao.github.io/harness9/zh/docs/quick-start)。
 
 ---
 

--- a/cmd/harness9/main.go
+++ b/cmd/harness9/main.go
@@ -6,9 +6,12 @@
 //
 // 环境变量（可通过 .env 文件或系统环境变量提供）：
 //
-//	OPENAI_API_KEY     LLM Provider API Key（必填）
-//	OPENAI_BASE_URL    自定义 OpenAI 兼容 API 地址（可选）
-//	LLM_MODEL          模型名称（默认：openai/gpt-4o-mini）
+//	OPENAI_API_KEY      OpenAI 兼容端点 API Key
+//	OPENAI_BASE_URL     自定义 OpenAI 兼容 API 地址
+//	ORCAROUTER_API_KEY  OrcaRouter 网关 API Key（可选，OpenAI 兼容网关）
+//	ORCAROUTER_BASE_URL OrcaRouter 网关地址（可选，默认官方地址）
+//	LLM_PROVIDER        显式指定 Provider：openai / orcarouter（可选）
+//	LLM_MODEL           模型名称（默认：openai/gpt-4o-mini）
 package main
 
 import (
@@ -86,9 +89,12 @@ Flags:
   upgrade     升级 harness9 到最新版本
 
 环境变量：
-  LLM_MODEL        模型名称（默认：openai/gpt-4o-mini）
-  OPENAI_API_KEY   OpenAI 兼容 API Key（必填）
-  OPENAI_BASE_URL  自定义 API 地址（可选，用于 OpenRouter / Azure 等）
+  LLM_MODEL           模型名称（默认：openai/gpt-4o-mini）
+  OPENAI_API_KEY      OpenAI 兼容 API Key
+  OPENAI_BASE_URL     自定义 API 地址（可选，用于 OpenRouter / Azure 等）
+  ORCAROUTER_API_KEY  OrcaRouter 网关 API Key（可选）
+  ORCAROUTER_BASE_URL OrcaRouter 网关地址（可选，默认官方地址）
+  LLM_PROVIDER        显式指定 Provider：openai / orcarouter（可选）
 
 示例：
   harness9                  启动（TTY 自动进入 TUI，管道模式退回 CLI REPL）
@@ -142,7 +148,7 @@ Flags:
 	if modelName == "" {
 		modelName = "openai/gpt-4o-mini"
 	}
-	rawLLM, err := provider.NewOpenAIProvider(modelName)
+	rawLLM, err := provider.NewFromEnv(modelName)
 	if err != nil {
 		log.Fatal(logfmt.FormatMsg("main", fmt.Sprintf("创建 Provider 失败: %v", err)))
 	}
@@ -384,7 +390,7 @@ Flags:
 			if model == "" {
 				return llm, modelLimits.ContextTokens, nil
 			}
-			p, err := provider.NewOpenAIProvider(model)
+			p, err := provider.NewFromEnv(model)
 			if err != nil {
 				return nil, 0, err
 			}

--- a/cmd/swebench/main.go
+++ b/cmd/swebench/main.go
@@ -196,8 +196,8 @@ func preflight(cfg Config) error {
 	if cfg.SampleN <= 0 {
 		return fmt.Errorf("--sample 必须 >= 1，当前值：%d", cfg.SampleN)
 	}
-	if os.Getenv("OPENAI_API_KEY") == "" {
-		return fmt.Errorf("OPENAI_API_KEY 未配置")
+	if os.Getenv("OPENAI_API_KEY") == "" && os.Getenv("ORCAROUTER_API_KEY") == "" {
+		return fmt.Errorf("OPENAI_API_KEY 未配置（也可配置 ORCAROUTER_API_KEY 走 OrcaRouter 网关）")
 	}
 	if _, err := os.Stat(cfg.DatasetPath); err != nil {
 		return fmt.Errorf("dataset 文件不可读：%w", err)

--- a/cmd/swebench/runner.go
+++ b/cmd/swebench/runner.go
@@ -120,8 +120,9 @@ func resolveModelName(model string) string {
 
 // newProvider 根据模型名创建 LLM provider。
 // 优先级：cfg.Model > LLM_MODEL 环境变量 > 默认值 openai/gpt-4o-mini。
+// 经 NewFromEnv 装配，与主入口共享 Provider 选择规则（OPENAI_* / OrcaRouter 网关）。
 func newProvider(model string) (provider.LLMProvider, error) {
-	return provider.NewOpenAIProvider(resolveModelName(model))
+	return provider.NewFromEnv(resolveModelName(model))
 }
 
 // runInstance 对单个 SWE-bench instance 执行完整的 clone → sandbox → engine → patch 流程。

--- a/docs/core-features-en/quick_start.md
+++ b/docs/core-features-en/quick_start.md
@@ -55,6 +55,19 @@ export OPENAI_API_KEY="<your-openrouter-key>"
 export LLM_MODEL="openai/gpt-4o"
 ```
 
+### Using OrcaRouter
+
+[OrcaRouter](https://orcarouter.ai) is an OpenAI-compatible model-routing gateway: a single API key grants access to models from many upstream providers (model names keep the provider prefix, e.g. `openai/gpt-4o-mini`, `deepseek/deepseek-chat`):
+
+```bash
+export ORCAROUTER_API_KEY="sk-orca-..."
+export LLM_MODEL="openai/gpt-4o-mini"
+```
+
+The gateway URL defaults to `https://api.orcarouter.ai/v1`; override it with `ORCAROUTER_BASE_URL` for self-hosted or proxied gateways.
+
+When both `OPENAI_API_KEY` and `ORCAROUTER_API_KEY` are present, choose explicitly with `LLM_PROVIDER` (`orcarouter` or `openai`); with only an OrcaRouter key configured, OrcaRouter is selected automatically — no extra setup needed.
+
 ### Using Anthropic
 
 ```bash

--- a/docs/核心功能/quick_start.md
+++ b/docs/核心功能/quick_start.md
@@ -55,6 +55,19 @@ export OPENAI_API_KEY="<your-openrouter-key>"
 export LLM_MODEL="openai/gpt-4o"
 ```
 
+### 使用 OrcaRouter
+
+[OrcaRouter](https://orcarouter.ai) 是 OpenAI 兼容的模型路由网关，一个 API Key 即可访问多家上游模型（模型名沿用 provider 前缀，如 `openai/gpt-4o-mini`、`deepseek/deepseek-chat`）：
+
+```bash
+export ORCAROUTER_API_KEY="sk-orca-..."
+export LLM_MODEL="openai/gpt-4o-mini"
+```
+
+网关地址默认 `https://api.orcarouter.ai/v1`，自建/代理网关时用 `ORCAROUTER_BASE_URL` 覆盖。
+
+当 `OPENAI_API_KEY` 与 `ORCAROUTER_API_KEY` 同时存在时，用 `LLM_PROVIDER` 显式选择：`orcarouter` 或 `openai`；仅配置 OrcaRouter 一个 Key 时自动走 OrcaRouter，无需额外设置。
+
 ### 使用 Anthropic
 
 ```bash

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -94,7 +94,12 @@ func NewOpenAIProvider(model string, opts ...OpenAIOption) (*OpenAIProvider, err
 	if baseURL == "" {
 		return nil, fmt.Errorf("请设置 OPENAI_BASE_URL 环境变量")
 	}
+	return newOpenAICompatProvider(apiKey, baseURL, model, opts...)
+}
 
+// newOpenAICompatProvider 是所有 OpenAI 兼容端点（OPENAI_* 环境变量、OrcaRouter 网关）
+// 的共享构造路径，统一封装认证、端点、超时/重试与 includeReasoning 白名单判断。
+func newOpenAICompatProvider(apiKey, baseURL, model string, opts ...OpenAIOption) (*OpenAIProvider, error) {
 	p := &OpenAIProvider{
 		client: openai.NewClient(
 			option.WithAPIKey(apiKey),

--- a/internal/provider/orcarouter.go
+++ b/internal/provider/orcarouter.go
@@ -1,0 +1,65 @@
+// Package provider — OrcaRouter 网关适配器。
+//
+// OrcaRouter（https://orcarouter.ai）是类似 OpenRouter 的 OpenAI 兼容模型路由网关：
+// 一个 API Key 即可访问多家上游模型（OpenAI / Anthropic / Google / DeepSeek / Qwen 等），
+// 模型名沿用 provider 前缀约定（如 "openai/gpt-4o-mini"），与 GetModelLimits 的
+// 前缀剥离逻辑天然兼容。因此本适配器直接复用 OpenAIProvider（消息转换、流式、
+// 工具调用与重试逻辑完全共享），仅在认证与端点配置上读取 ORCAROUTER_* 专属环境变量。
+package provider
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// DefaultOrcaRouterBaseURL 是 OrcaRouter 官方网关的 OpenAI 兼容端点地址。
+// 与 OpenAI 官方约定一致，Base URL 需带 /v1 后缀（SDK 在其后拼接 /chat/completions）。
+const DefaultOrcaRouterBaseURL = "https://api.orcarouter.ai/v1"
+
+// NewOrcaRouterProvider 创建指向 OrcaRouter 网关的 OpenAI 兼容 Provider。
+//
+// 环境变量：
+//   - ORCAROUTER_API_KEY   必填，网关 API Key（sk-orca- 前缀）
+//   - ORCAROUTER_BASE_URL  可选，默认 DefaultOrcaRouterBaseURL（自建/代理网关时覆盖）
+//
+// 推理内容说明：OrcaRouter 无需 include_reasoning 标志，即会把上游推理内容放进标准的
+// reasoning / reasoning_content delta 字段（由 extractReasoningContent 统一提取并路由为
+// ThinkingDelta），因此不加入 baseURLEnablesReasoning 白名单，保持请求体最小化，
+// 避免严格校验未知参数的上游因多余字段拒绝请求。
+func NewOrcaRouterProvider(model string, opts ...OpenAIOption) (*OpenAIProvider, error) {
+	apiKey := os.Getenv("ORCAROUTER_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("请设置 ORCAROUTER_API_KEY 环境变量")
+	}
+	baseURL := os.Getenv("ORCAROUTER_BASE_URL")
+	if baseURL == "" {
+		baseURL = DefaultOrcaRouterBaseURL
+	}
+	return newOpenAICompatProvider(apiKey, baseURL, model, opts...)
+}
+
+// NewFromEnv 依据环境变量选择并构建 OpenAI 兼容 Provider，是 main 入口、
+// 子代理 ProviderFor 与 SWE-bench runner 的统一装配点。
+//
+// 选择规则（显式优先，自动探测兜底）：
+//   - LLM_PROVIDER=orcarouter 强制走 OrcaRouter；LLM_PROVIDER=openai 强制走 OPENAI_* 端点
+//   - LLM_PROVIDER 未设置时自动探测：仅配置 ORCAROUTER_API_KEY（无 OPENAI_API_KEY）时
+//     走 OrcaRouter，其余情况沿用 OPENAI_* 端点，保证既有用户行为零变化
+//   - 两个 Key 同时配置且未显式指定 LLM_PROVIDER 时按 OPENAI_* 处理，避免静默切换网关
+func NewFromEnv(model string, opts ...OpenAIOption) (LLMProvider, error) {
+	explicit := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_PROVIDER")))
+	switch explicit {
+	case "orcarouter":
+		return NewOrcaRouterProvider(model, opts...)
+	case "openai":
+		return NewOpenAIProvider(model, opts...)
+	case "":
+		if os.Getenv("ORCAROUTER_API_KEY") != "" && os.Getenv("OPENAI_API_KEY") == "" {
+			return NewOrcaRouterProvider(model, opts...)
+		}
+		return NewOpenAIProvider(model, opts...)
+	default:
+		return nil, fmt.Errorf("未知 LLM_PROVIDER %q：仅支持 openai 或 orcarouter", explicit)
+	}
+}

--- a/internal/provider/orcarouter_live_test.go
+++ b/internal/provider/orcarouter_live_test.go
@@ -1,0 +1,197 @@
+// orcarouter_live_test.go — OrcaRouter 真实网关集成测试。
+//
+// 未配置 ORCAROUTER_API_KEY 时自动跳过：go test ./...（含 CI）保持密封零网络调用；
+// 本地验证方式：
+//
+//	ORCAROUTER_API_KEY=sk-orca-xxx go test ./internal/provider/ -run 'TestOrcaRouterLive' -v
+//
+// 默认使用廉价模型 openai/gpt-4o-mini，可用 ORCAROUTER_LIVE_MODEL 覆盖。
+package provider
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/harness9/internal/schema"
+)
+
+// orcaLiveSetup 返回接入真实网关的 Provider；未配置 Key 时跳过测试。
+func orcaLiveSetup(t *testing.T) *OpenAIProvider {
+	t.Helper()
+	if os.Getenv("ORCAROUTER_API_KEY") == "" {
+		t.Skip("未配置 ORCAROUTER_API_KEY，跳过 OrcaRouter 真实网关集成测试")
+	}
+	model := os.Getenv("ORCAROUTER_LIVE_MODEL")
+	if model == "" {
+		model = "openai/gpt-4o-mini"
+	}
+	p, err := NewOrcaRouterProvider(model)
+	if err != nil {
+		t.Fatalf("创建 OrcaRouter Provider 失败: %v", err)
+	}
+	return p
+}
+
+// TestOrcaRouterLiveGenerate 验证阻塞式文本生成与实际 token 用量提取。
+func TestOrcaRouterLiveGenerate(t *testing.T) {
+	p := orcaLiveSetup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	msg, usage, err := p.Generate(ctx, []schema.Message{
+		{Role: schema.RoleUser, Content: "只回复两个字：成功"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Generate 失败: %v", err)
+	}
+	if strings.TrimSpace(msg.Content) == "" {
+		t.Errorf("响应内容为空")
+	}
+	if usage == nil || usage.InputTokens <= 0 || usage.OutputTokens <= 0 {
+		t.Errorf("实际 token 用量未提取：usage=%+v", usage)
+	}
+	t.Logf("响应: %q, usage: in=%d out=%d", msg.Content, usage.InputTokens, usage.OutputTokens)
+}
+
+// TestOrcaRouterLiveGenerateStream 验证流式增量的收集与末尾 Done chunk 的 Usage 携带。
+func TestOrcaRouterLiveGenerateStream(t *testing.T) {
+	p := orcaLiveSetup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	ch, err := p.GenerateStream(ctx, []schema.Message{
+		{Role: schema.RoleUser, Content: "从 1 数到 5，用空格分隔数字，不要其他内容"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("GenerateStream 失败: %v", err)
+	}
+
+	var textBuf strings.Builder
+	var doneMsg *schema.Message
+	var usage *schema.Usage
+	for chunk := range ch {
+		switch chunk.Type {
+		case schema.StreamChunkTextDelta:
+			textBuf.WriteString(chunk.Delta)
+		case schema.StreamChunkDone:
+			doneMsg = chunk.Message
+			usage = chunk.Usage
+		case schema.StreamChunkError:
+			t.Fatalf("流式错误: %s", chunk.Error)
+		}
+	}
+	if textBuf.Len() == 0 {
+		t.Errorf("未收到任何文本增量")
+	}
+	if doneMsg == nil {
+		t.Fatalf("未收到 Done chunk")
+	}
+	if usage == nil || usage.InputTokens <= 0 {
+		t.Errorf("流式实际 token 用量未提取：usage=%+v", usage)
+	}
+	t.Logf("流式文本: %q, usage: in=%d out=%d", textBuf.String(), usage.InputTokens, usage.OutputTokens)
+}
+
+// TestOrcaRouterLiveToolCalling 验证网关的工具调用回路：模型应针对天气问题
+// 发起 get_weather 工具调用而非凭空回答。
+func TestOrcaRouterLiveToolCalling(t *testing.T) {
+	p := orcaLiveSetup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	weatherTool := schema.ToolDefinition{
+		Name:        "get_weather",
+		Description: "查询指定城市的当前天气",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"city": map[string]interface{}{"type": "string", "description": "城市名"},
+			},
+			"required": []string{"city"},
+		},
+	}
+
+	msg, _, err := p.Generate(ctx, []schema.Message{
+		{Role: schema.RoleUser, Content: "请调用 get_weather 工具查询北京的天气"},
+	}, []schema.ToolDefinition{weatherTool})
+	if err != nil {
+		t.Fatalf("Generate 失败: %v", err)
+	}
+	if len(msg.ToolCalls) == 0 {
+		t.Fatalf("模型未发起工具调用，响应内容: %q", msg.Content)
+	}
+	found := false
+	for _, tc := range msg.ToolCalls {
+		if tc.Name == "get_weather" {
+			found = true
+			if !strings.Contains(string(tc.Arguments), "北京") {
+				t.Errorf("工具参数未携带城市名: %s", tc.Arguments)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("未调用 get_weather 工具，实际调用：%+v", msg.ToolCalls)
+	}
+	t.Logf("工具调用: name=%s args=%s", msg.ToolCalls[0].Name, msg.ToolCalls[0].Arguments)
+}
+
+// TestOrcaRouterLiveReasoning 验证推理模型的 reasoning_content 字段被路由为
+// ThinkingDelta。默认模型 deepseek/deepseek-reasoner 可用 ORCAROUTER_LIVE_REASONING_MODEL 覆盖。
+func TestOrcaRouterLiveReasoning(t *testing.T) {
+	if os.Getenv("ORCAROUTER_API_KEY") == "" {
+		t.Skip("未配置 ORCAROUTER_API_KEY，跳过 OrcaRouter 真实网关集成测试")
+	}
+	model := os.Getenv("ORCAROUTER_LIVE_REASONING_MODEL")
+	if model == "" {
+		model = "deepseek/deepseek-reasoner"
+	}
+	p, err := NewOrcaRouterProvider(model)
+	if err != nil {
+		t.Fatalf("创建 Provider 失败: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	ch, err := p.GenerateStream(ctx, []schema.Message{
+		{Role: schema.RoleUser, Content: "9.11 和 9.9 哪个大？简要回答"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("GenerateStream 失败: %v", err)
+	}
+
+	var thinking, text strings.Builder
+	sawDone := false
+	for chunk := range ch {
+		switch chunk.Type {
+		case schema.StreamChunkThinkingDelta:
+			thinking.WriteString(chunk.Delta)
+		case schema.StreamChunkTextDelta:
+			text.WriteString(chunk.Delta)
+		case schema.StreamChunkDone:
+			sawDone = true
+		case schema.StreamChunkError:
+			t.Fatalf("流式错误: %s", chunk.Error)
+		}
+	}
+	if !sawDone {
+		t.Fatalf("未收到 Done chunk")
+	}
+	if text.Len() == 0 {
+		t.Errorf("未收到正文回复")
+	}
+	// 推理内容取决于模型/网关行为：有则记录验证通过，无则显式提示（不判失败，
+	// 避免上游静默调整推理暴露策略导致测试抖动）。
+	if thinking.Len() > 0 {
+		t.Logf("✓ 捕获 ThinkingDelta %d 字节", thinking.Len())
+	} else {
+		t.Logf("⚠ 未捕获 ThinkingDelta（模型 %s 本次未返回推理内容）", model)
+	}
+	t.Logf("正文: %q", text.String())
+}

--- a/internal/provider/orcarouter_test.go
+++ b/internal/provider/orcarouter_test.go
@@ -1,0 +1,190 @@
+// orcarouter_test.go — OrcaRouter 网关适配器单元测试。
+// 覆盖构造器环境变量解析、默认 Base URL、选项透传与 NewFromEnv 的选择规则。
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewOrcaRouterProvider(t *testing.T) {
+	tests := []struct {
+		name               string
+		env                map[string]string
+		model              string
+		opts               []OpenAIOption
+		wantErrContains    string
+		wantModel          string
+		wantIncludeReas    bool
+		wantIncludeReasSet bool
+	}{
+		{
+			name:            "缺少 ORCAROUTER_API_KEY 报错",
+			env:             map[string]string{},
+			wantErrContains: "ORCAROUTER_API_KEY",
+		},
+		{
+			name:               "仅配置 Key 时使用默认网关地址",
+			env:                map[string]string{"ORCAROUTER_API_KEY": "sk-orca-test"},
+			model:              "openai/gpt-4o-mini",
+			wantModel:          "openai/gpt-4o-mini",
+			wantIncludeReas:    false,
+			wantIncludeReasSet: true,
+		},
+		{
+			name: "自定义 ORCAROUTER_BASE_URL 覆盖默认值",
+			env: map[string]string{
+				"ORCAROUTER_API_KEY":  "sk-orca-test",
+				"ORCAROUTER_BASE_URL": "https://my-proxy.example.com/v1",
+			},
+			model:              "deepseek/deepseek-chat",
+			wantModel:          "deepseek/deepseek-chat",
+			wantIncludeReas:    false,
+			wantIncludeReasSet: true,
+		},
+		{
+			name:               "WithIncludeReasoning 选项透传生效",
+			env:                map[string]string{"ORCAROUTER_API_KEY": "sk-orca-test"},
+			model:              "openai/gpt-4o-mini",
+			opts:               []OpenAIOption{WithIncludeReasoning()},
+			wantModel:          "openai/gpt-4o-mini",
+			wantIncludeReas:    true,
+			wantIncludeReasSet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			p, err := NewOrcaRouterProvider(tt.model, tt.opts...)
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("期望报错包含 %q，实际成功", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("错误信息 %q 不包含 %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewOrcaRouterProvider 意外报错: %v", err)
+			}
+			if p.model != tt.wantModel {
+				t.Errorf("model = %q, 期望 %q", p.model, tt.wantModel)
+			}
+			if tt.wantIncludeReasSet && p.includeReasoning != tt.wantIncludeReas {
+				t.Errorf("includeReasoning = %v, 期望 %v", p.includeReasoning, tt.wantIncludeReas)
+			}
+			// 不论 Base URL 是什么，OrcaRouter 都不应自动启用 include_reasoning
+			//（网关原生在标准 reasoning 字段返回推理内容，无需额外标志）。
+			if p.includeReasoning && len(tt.opts) == 0 {
+				t.Errorf("OrcaRouter 默认不应启用 includeReasoning")
+			}
+		})
+	}
+}
+
+// TestBaseURLEnablesReasoningOrcaRouter 锁定白名单行为：
+// OrcaRouter 网关地址不在 include_reasoning 白名单中（与 OpenRouter/Requesty 不同）。
+func TestBaseURLEnablesReasoningOrcaRouter(t *testing.T) {
+	if baseURLEnablesReasoning(DefaultOrcaRouterBaseURL) {
+		t.Errorf("OrcaRouter 默认地址不应启用 include_reasoning（网关原生返回 reasoning 字段）")
+	}
+}
+
+func TestNewFromEnv(t *testing.T) {
+	tests := []struct {
+		name            string
+		env             map[string]string
+		wantErrContains string
+	}{
+		{
+			name: "显式 LLM_PROVIDER=orcarouter 且 Key 就绪",
+			env: map[string]string{
+				"LLM_PROVIDER":       "orcarouter",
+				"ORCAROUTER_API_KEY": "sk-orca-test",
+			},
+		},
+		{
+			name:            "显式 LLM_PROVIDER=orcarouter 但缺少 Key",
+			env:             map[string]string{"LLM_PROVIDER": "orcarouter"},
+			wantErrContains: "ORCAROUTER_API_KEY",
+		},
+		{
+			name: "显式 LLM_PROVIDER=openai 时忽略 OrcaRouter Key（走 OPENAI_* 路径）",
+			env: map[string]string{
+				"LLM_PROVIDER":       "openai",
+				"ORCAROUTER_API_KEY": "sk-orca-test",
+				"OPENAI_API_KEY":     "sk-openai-test",
+				// 故意不设 OPENAI_BASE_URL：openai 路径必须因缺 BASE_URL 报错，以此证明未走 OrcaRouter
+			},
+			wantErrContains: "OPENAI_BASE_URL",
+		},
+		{
+			name: "自动探测：仅有 ORCAROUTER_API_KEY 时走 OrcaRouter",
+			env: map[string]string{
+				"ORCAROUTER_API_KEY": "sk-orca-test",
+			},
+		},
+		{
+			name: "自动探测：两 Key 并存时保持 OPENAI_* 优先（避免静默切换网关）",
+			env: map[string]string{
+				"ORCAROUTER_API_KEY": "sk-orca-test",
+				"OPENAI_API_KEY":     "sk-openai-test",
+				// 缺 OPENAI_BASE_URL 使 openai 路径报错，证明走了 openai 分支
+			},
+			wantErrContains: "OPENAI_BASE_URL",
+		},
+		{
+			name: "自动探测：无任何 OrcaRouter 配置时沿用 OPENAI_* 路径",
+			env: map[string]string{
+				"OPENAI_API_KEY": "sk-openai-test",
+			},
+			wantErrContains: "OPENAI_BASE_URL",
+		},
+		{
+			name:            "未知 LLM_PROVIDER 值报错",
+			env:             map[string]string{"LLM_PROVIDER": "azure"},
+			wantErrContains: "LLM_PROVIDER",
+		},
+		{
+			name: "LLM_PROVIDER 大小写不敏感",
+			env: map[string]string{
+				"LLM_PROVIDER":       "OrcaRouter",
+				"ORCAROUTER_API_KEY": "sk-orca-test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			p, err := NewFromEnv("openai/gpt-4o-mini")
+			if tt.wantErrContains != "" {
+				if err == nil {
+					t.Fatalf("期望报错包含 %q，实际成功", tt.wantErrContains)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("错误信息 %q 不包含 %q", err.Error(), tt.wantErrContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewFromEnv 意外报错: %v", err)
+			}
+			op, ok := p.(*OpenAIProvider)
+			if !ok {
+				t.Fatalf("返回类型 %T 不是 *OpenAIProvider", p)
+			}
+			if op.model != "openai/gpt-4o-mini" {
+				t.Errorf("model = %q, 期望 openai/gpt-4o-mini", op.model)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 摘要

将 [OrcaRouter](https://orcarouter.ai)（OpenAI 兼容模型路由网关，一个 Key 访问多家上游模型）接入为可选 LLM Provider。

- provider 层新增 `orcarouter.go`：`NewOrcaRouterProvider`（`ORCAROUTER_API_KEY` 必填，`ORCAROUTER_BASE_URL` 默认官方网关）+ `NewFromEnv` 统一装配点——`main`、子代理 `ProviderFor`、SWE-bench runner 共用同一选择规则：`LLM_PROVIDER=orcarouter/openai` 显式优先；未设置时自动探测，且两 Key 并存时不静默切换网关，保证既有 `OPENAI_*` 用户行为零变化
- OrcaRouter 无需 `include_reasoning` 标志即返回标准 `reasoning_content` 字段，现有 `extractReasoningContent` 已兼容，推理内容直通 TUI Thinking Delta
- `internal/provider/openai.go` 抽出共享构造路径 `newOpenAICompatProvider`，OrcaRouter 复用全部消息转换/流式/工具调用逻辑
- 文档同步：`.env.example`、quick_start（中英）、README（中英）、AGENTS.md

## 测试计划

- [x] `internal/provider/orcarouter_test.go`：15 个单元用例（构造器 env 解析、默认网关地址、选择规则边界、大小写容忍）
- [x] `go test ./...` 全仓库 23 包通过；gofmt / go vet / autocorrect lint 全绿
- [x] 端到端冒烟：真实二进制 + `.env`（`LLM_PROVIDER=orcarouter`）请求网关，URL 回显确认走 OrcaRouter 路径，引擎装配与错误传播正常
- [x] live 集成测试（`orcarouter_live_test.go`，未配置 Key 自动跳过保持 CI 密封）：文本/流式/工具调用/推理四路径——**待账户充值后执行**（当前 key 余额 $0，付费模型 402、免费模型当日限额，UTC 零点重置）